### PR TITLE
CHRTOUT output routine fix for io_form_outputs=0 and SOILM check tolerance error fix

### DIFF
--- a/trunk/NDHMS/Data_Rec/module_namelist.F
+++ b/trunk/NDHMS/Data_Rec/module_namelist.F
@@ -187,7 +187,6 @@ CONTAINS
 
 ! ADCHANGE: move these checks to more universal namelist checks...
 if ( io_config_outputs .eq. 4 ) RTOUT_DOMAIN = 0
-if ( (io_config_outputs .gt. 0) .and. (CHRTOUT_DOMAIN .eq.1) .and. (channel_option .ne. 3) ) CHRTOUT_DOMAIN = 1
 
    if(output_channelBucket_influx .ne. 0) then
       if(nlst%dt .ne. out_dt*60) &
@@ -571,7 +570,7 @@ subroutine rt_nlst_check(nlst)
    if( (nlst%output_channelBucket_influx .lt. 0 ) .or. (nlst%output_channelBucket_influx .gt. 3) ) then
       call hydro_stop('hydro.namelist ERROR: Invalid output_channelBucket_influx specified')
    endif   
-   if( (nlst%CHRTOUT_DOMAIN .lt. 0 ) .or. (nlst%CHRTOUT_DOMAIN .gt. 2) ) then
+   if( (nlst%CHRTOUT_DOMAIN .lt. 0 ) .or. (nlst%CHRTOUT_DOMAIN .gt. 1) ) then
       call hydro_stop('hydro.namelist ERROR: Invalid CHRTOUT_DOMAIN specified')
    endif   
    if( (nlst%CHANOBS_DOMAIN .lt. 0 ) .or. (nlst%CHANOBS_DOMAIN .gt. 1) ) then

--- a/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
+++ b/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
@@ -372,34 +372,35 @@ if(nlst_rt(did)%SUBRTSWCRT         .gt. 0 .or. &
       endif
    else
       ! Call traditional output routines
-             if(nlst_rt(did)%CHRTOUT_DOMAIN  .eq. 1)  then
-#ifdef MPP_LAND
-                 call mpp_output_chrt( &
-                      rt_domain(did)%gnlinks,rt_domain(did)%gnlinksl,rt_domain(did)%map_l2g, &
-#else
-                 call output_chrt(  &
-#endif
-                   nlst_rt(did)%igrid, nlst_rt(did)%split_output_count, &
-                   RT_DOMAIN(did)%NLINKS,RT_DOMAIN(did)%ORDER, &
-                   nlst_rt(did)%sincedate,nlst_rt(did)%olddate,RT_DOMAIN(did)%CHLON,&
-                   RT_DOMAIN(did)%CHLAT,                                      &
-                   RT_DOMAIN(did)%HLINK, RT_DOMAIN(did)%ZELEV,                &
-                   !RT_DOMAIN(did)%QLINK,nlst_rt(did)%DT,Kt,                   &
-                   str_out, nlst_rt(did)%DT,Kt,                   &
-                   RT_DOMAIN(did)%STRMFRXSTPTS,nlst_rt(did)%order_to_write,   &
-                   RT_DOMAIN(did)%NLINKSL,nlst_rt(did)%channel_option,        &
-                   rt_domain(did)%gages, rt_domain(did)%gageMiss,             &
-                   nlst_rt(did)%dt                                            &
-#ifdef WRF_HYDRO_NUDGING
-                   , RT_DOMAIN(did)%nudge                                     &
-#endif
-                   , RT_DOMAIN(did)%accSfcLatRunoff, RT_DOMAIN(did)%accBucket &
-                   , RT_DOMAIN(did)%qSfcLatRunoff,   RT_DOMAIN(did)%qBucket   &
-                   , RT_DOMAIN(did)%qin_gwsubbas                              &
-                   , nlst_rt(did)%UDMP_OPT                                    &
-                   )
-              else
-                if(nlst_rt(did)%CHRTOUT_DOMAIN  .eq. 2)  then
+!ADCHANGE: We suspect this routine is broken so default is now output_chrtout2
+!             if(nlst_rt(did)%CHRTOUT_DOMAIN  .eq. 1)  then
+!#ifdef MPP_LAND
+!                 call mpp_output_chrt( &
+!                      rt_domain(did)%gnlinks,rt_domain(did)%gnlinksl,rt_domain(did)%map_l2g, &
+!#else
+!                 call output_chrt(  &
+!#endif
+!                   nlst_rt(did)%igrid, nlst_rt(did)%split_output_count, &
+!                   RT_DOMAIN(did)%NLINKS,RT_DOMAIN(did)%ORDER, &
+!                   nlst_rt(did)%sincedate,nlst_rt(did)%olddate,RT_DOMAIN(did)%CHLON,&
+!                   RT_DOMAIN(did)%CHLAT,                                      &
+!                   RT_DOMAIN(did)%HLINK, RT_DOMAIN(did)%ZELEV,                &
+!                   !RT_DOMAIN(did)%QLINK,nlst_rt(did)%DT,Kt,                   &
+!                   str_out, nlst_rt(did)%DT,Kt,                   &
+!                   RT_DOMAIN(did)%STRMFRXSTPTS,nlst_rt(did)%order_to_write,   &
+!                   RT_DOMAIN(did)%NLINKSL,nlst_rt(did)%channel_option,        &
+!                   rt_domain(did)%gages, rt_domain(did)%gageMiss,             &
+!                   nlst_rt(did)%dt                                            &
+!#ifdef WRF_HYDRO_NUDGING
+!                   , RT_DOMAIN(did)%nudge                                     &
+!#endif
+!                   , RT_DOMAIN(did)%accSfcLatRunoff, RT_DOMAIN(did)%accBucket &
+!                   , RT_DOMAIN(did)%qSfcLatRunoff,   RT_DOMAIN(did)%qBucket   &
+!                   , RT_DOMAIN(did)%qin_gwsubbas                              &
+!                   , nlst_rt(did)%UDMP_OPT                                    &
+!                   )
+!              else
+                if(nlst_rt(did)%CHRTOUT_DOMAIN  .gt. 0)  then
 #ifdef MPP_LAND
                      call mpp_output_chrt2(&
                           rt_domain(did)%gnlinks,rt_domain(did)%gnlinksl,rt_domain(did)%map_l2g, &
@@ -427,7 +428,7 @@ if(nlst_rt(did)%SUBRTSWCRT         .gt. 0 .or. &
                      )
                  endif
 
-              endif
+!              endif
    endif ! End of checking for io_form_outputs flag value      
       
 #ifdef MPP_LAND

--- a/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
+++ b/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
@@ -1153,9 +1153,9 @@ endif
                    endif
 
 !end 
-                    IF (RT_DOMAIN(did)%SMCRT(IXXRT,JYYRT,KRT) .GT. &
-                        RT_DOMAIN(did)%SMCMAXRT(IXXRT,JYYRT,KRT)) THEN
 
+!ADCHANGE: Change to accept very small diff since was being triggered by vals that print identical
+IF ( (RT_DOMAIN(did)%SMCRT(IXXRT,JYYRT,KRT)-RT_DOMAIN(did)%SMCMAXRT(IXXRT,JYYRT,KRT)) .GT. 0.000001 ) THEN
 #ifdef HYDRO_D
 #ifndef NCEP_WCOSS
                       print *, "SMCMAX exceeded upon aggregation...", &

--- a/trunk/NDHMS/template/HYDRO/hydro.namelist
+++ b/trunk/NDHMS/template/HYDRO/hydro.namelist
@@ -61,8 +61,9 @@ SPLIT_OUTPUT_COUNT = 1
 ! Note: lower value of stream order produces more output.
 order_to_write = 4
 
-! Flag to turn on/off new I/O routines: 1 = with scale/offset/compression,
-! 2 = with scale/offset/NO compression, 3 = compression only, 4 = no scale/offset/compression (default)
+! Flag to turn on/off new I/O routines: 0 = deprecated output routines (use when running with Noah LSM),
+! 1 = with scale/offset/compression, ! 2 = with scale/offset/NO compression, 
+! 3 = compression only, 4 = no scale/offset/compression (default)
 io_form_outputs = 1
 
 ! Realtime run configuration option:


### PR DESCRIPTION
Two small housekeeping fixes (should not affect answers):
1) Switched the output option CHRTOUT_DOMAIN=1 when io_config_outputs=0 to call output_chrt2 since output_chrt is broken (and deprecated twice over). Only needed for Noah runs.
2) Very small (<10^-8) SMC>SMCMAX diffs causing fatal error in aggregation in some calib runs. Changed to very small tolerance check.

