### PR TITLE
commented out an unnecessary warning message

### DIFF
--- a/trunk/NDHMS/Routing/module_UDMAP.F
+++ b/trunk/NDHMS/Routing/module_UDMAP.F
@@ -311,10 +311,15 @@ contains
 
 
         if(LNUMRSL .gt. 0) then 
+
                allocate(LUDRSL(LNUMRSL))
                allocate( basns_area(LNUMRSL) )
         else
-               write(6,*) "Warning: no routing links found."
+! When MPI is performed,for every subdomain in each process, all the links 
+! are listed and if there is no link in the subdomain then it is calling 
+! cleanBuf (memory cleaning purposes), this used to print a warning 
+! that is not necessary for the user to see it, therefore it is been commented out here
+!               write(6,*) "Warning: no routing links found."
                call cleanBuf()
                return
         endif


### PR DESCRIPTION
This pull request is with respect to the issue #86 in the wrf_hydro_nwm repo. This was a confusing warning with no additional information provided at the WARNING message. The Warning is being discussed with Wei and we commented it out, since it is not really a warning and more like checking for Wei (under MPI). FYI, I have closed that issue in the wrf_hydro_nwm repo by mistake. 