### PR TITLE
Minor edits to repo docs + add code of conduct

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,8 +44,8 @@ internal development must occur on a private repository maintained by NCAR and N
 dual-repository system, a strict procedure must be followed when making contributions to the WRF-
 Hydro model code.
 
-All code development contributions will be made via [forks](https://help.github.com/articles/about-
-forks/) and [Pull Requests](https://help.github.com/articles/about-pull-requests/). If you are
+All code development contributions will be made via [forks](https://help.github.com/articles/about-forks/)
+and [Pull Requests](https://help.github.com/articles/about-pull-requests/). If you are
 unfamiliar with GitHub, forks, or pull requests, see [collaborating with issues and pull
 requests](https://help.github.com/categories/collaborating-with-issues-and-pull-requests/) for a
 thorough guide to collaborating on GitHub.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,7 +45,7 @@ dual-repository system, a strict procedure must be followed when making contribu
 Hydro model code.
 
 All code development contributions will be made via [forks](https://help.github.com/articles/about-forks/)
-and [Pull Requests](https://help.github.com/articles/about-pull-requests/). If you are
+and [pull requests](https://help.github.com/articles/about-pull-requests/). If you are
 unfamiliar with GitHub, forks, or pull requests, see [collaborating with issues and pull
 requests](https://help.github.com/categories/collaborating-with-issues-and-pull-requests/) for a
 thorough guide to collaborating on GitHub.
@@ -59,7 +59,7 @@ Please see our Fortran [code style guidelines](CODESTYLE.md)
 * All contributions must be made in an open, and public way via the GitHub repository. There will
   be no embargo period for code contributions.
 * All contributions must be able to be merged without conflict. It is the responsibility of the
-  contributor to resolve any merge conflicts **prior** to submitting a Pull Request.
+  contributor to resolve any merge conflicts **prior** to submitting a pull request.
 * All contributions must pass relevant automated testing procedures. These tests are executed
   automatically when you submit your pull request.
 * Be respectful when giving and receiving feedback on contributions or issues.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, politcal affiliation, veteran status, pregnancy, genetic information, personal appearance, choice of text editor or operating system, race, religion, or sexual identity and orientation, or any other characteristic protected under applicable US federal or state law. 
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+* Refusing to use the pronouns that someone requests
+* Intimidating, threatening, or hostile conduct; physical or verbal abuse; vandalism; arson; and sabotage
+* Alarming or threatening comments that might refer to, suggest, or promote a violent, intimidating, or threatening action
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at wrfhydro@ucar.edu. Alternatively, this behavior can be reported to individuals on the WRF-Hydro team, who will then have the responsibility to talk about the behavior to the core team. Another alternative for NCAR employees (when all individuals involved are NCAR employees) is to use the reporting methods of NCAR for this behavior (these options include anonymous reporting methods). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately. Retaliation against a person who initiates a complaint or an inquiry about such behaviors is equally prohibited.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, politcal affiliation, veteran status, pregnancy, genetic information, personal appearance, choice of text editor or operating system, race, religion, or sexual identity and orientation, or any other characteristic protected under applicable US federal or state law. 
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, political affiliation, veteran status, pregnancy, genetic information, personal appearance, choice of text editor or operating system, race, religion, or sexual identity and orientation, or any other characteristic protected under applicable US federal or state law. 
 
 ## Our Standards
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For news and updates regarding the WRF-Hydro project please subscribe to our [em
 
 For user support and general inquiries please use our [contact form](https://ral.ucar.edu/projects/wrf_hydro/contact).
 
-If you have found a bug or would like to propose changes to the model code please submit an issue [here on GitHub](https://github.com/NCAR/wrf_hydro_community/issues).
+If you have found a bug or would like to propose changes to the model code please submit an issue [here on GitHub](https://github.com/NCAR/wrf_hydro_nwm_public/issues).
 
 ## Contributions
 For more information on how to contribute to this project please refer to our [contributing guidelines](.github/CONTRIBUTING.md).


### PR DESCRIPTION
This PR includes:
* Adds a code of conduct to the repo based upon a [community standard template](https://www.contributor-covenant.org/version/1/4/code-of-conduct) and what CTSM [has put together](https://github.com/ESCOMP/ctsm/blob/master/CODE_OF_CONDUCT.md) 
* Fixes to broken links in README and CONTRIBUTING
* Corrects minor typos

Would love thoughts on any additional changes we should make to the code of conduct text.  
