### PR TITLE
Output metadata fix + updates

### DIFF
--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -4373,7 +4373,7 @@ subroutine output_chanObs_NWM(domainId)
       if(nlst_rt(domainId)%channel_option .eq. 3) then 
          iret = nf90_put_att(ftn,featureVarId,'long_name','User Specified Forecast Points')
          call nwmCheck(diagFlag,iret,'ERROR: Uanble to place long_name attribute into feature_id variable')
-         iret = nf90_put_att(ftn,featureVarId,'comment','Forecast Points Specified in Geogrid file')
+         iret = nf90_put_att(ftn,featureVarId,'comment','Forecast Points Specified in Fulldom file')
          call nwmCheck(diagFlag,iret,'ERROR: Unable to place comment attribute into feature_id variable')
       else
          iret = nf90_put_att(ftn,featureVarId,'long_name',trim(fileMeta%featureIdLName))

--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -15,7 +15,8 @@ module module_NWM_io_dict
 implicit none
 
 ! Declare parameter values for module.
-integer, parameter :: numChVars=10
+character (len=512) :: codeVersion = "WRF-Hydro v5.0.0-dev"
+integer, parameter :: numChVars = 10
 integer, parameter :: numLdasVars = 95
 integer, parameter :: numRtDomainVars = 5
 integer, parameter :: numLakeVars = 2
@@ -40,7 +41,7 @@ type chrtMeta
    ! Variable names
    character (len=64), dimension(numChVars) :: varNames
    integer :: numVars = numChVars
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
+   character (len=512) :: outVersion = codeVersion
    ! Output variable attributes
    real, dimension(numChVars) :: scaleFactor ! scale_factor values used for each
                                                   ! variable to converte from real to
@@ -108,7 +109,7 @@ type ldasMeta
    integer :: numVars = numLdasVars
    integer :: numSnowLayers = 3
    integer :: numSoilLayers = 4
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
+   character (len=512) :: outVersion = codeVersion
    ! Output variable attributes
    real, dimension(numLdasVars) :: scaleFactor ! scale_factor values used for each
                                                   ! variable to converte from
@@ -175,7 +176,7 @@ type rtDomainMeta
    character (len=64), dimension(numRtDomainVars) :: varNames
    integer :: numVars = numRtDomainVars
    integer :: numSoilLayers = 4
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
+   character (len=512) :: outVersion = codeVersion
    ! Output variable attributes
    real, dimension(numRtDomainVars) :: scaleFactor ! scale_factor values used for each
                                                   ! variable to converte from
@@ -240,7 +241,7 @@ type lakeMeta
    ! Variable names
    character (len=64), dimension(numLakeVars) :: varNames
    integer :: numVars = numLakeVars
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
+   character (len=512) :: outVersion = codeVersion
    ! Output variable attributes
    real, dimension(numLakeVars) :: scaleFactor ! scale_factor values used for each
                                                ! variable to converte from
@@ -306,7 +307,7 @@ type chrtGrdMeta
    ! Variable names
    character (len=64), dimension(numChGrdVars) :: varNames
    integer :: numVars = numChGrdVars
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
+   character (len=512) :: outVersion = codeVersion
    ! Output variable attributes
    real, dimension(numChGrdVars) :: scaleFactor ! scale_factor values for each
                                                 ! variable to convert from 
@@ -374,7 +375,7 @@ type lsmMeta
    integer :: numVars = numLsmVars
    integer :: numSnowLayers = 3
    integer :: numSoilLayers = 4
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
+   character (len=512) :: outVersion = codeVersion
    ! Output variable attributes
    real, dimension(numLsmVars) :: scaleFactor ! scale_factor values used for each
                                                   ! variable to converte from
@@ -441,7 +442,7 @@ type chObsMeta
    ! Variable names
    character (len=64), dimension(numChObsVars) :: varNames
    integer :: numVars = numChObsVars
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
+   character (len=512) :: outVersion = codeVersion
    ! Output variable attributes
    real, dimension(numChObsVars) :: scaleFactor ! scale_factor values used for
                                                  ! each variable to convert 
@@ -508,7 +509,7 @@ type gwMeta
    ! Variable names
    character (len=64), dimension(numGwVars) :: varNames
    integer :: numVars = numGwVars
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
+   character (len=512) :: outVersion = codeVersion
    ! Output variable attributes
    real, dimension(numGwVars) :: scaleFactor ! scale_factor values used for each
                                                ! variable to converte from
@@ -742,7 +743,7 @@ subroutine initLdasDict(ldasOutDict,procId,diagFlag)
    ldasOutDict%modelNdvInt = -2147483647
 
    ! First establish global attributes.
-   ldasOutDict%title = "OUTPUT FROM WRF-Hydro v5.0.0-dev"
+   ldasOutDict%title = "OUTPUT FROM " // codeVersion
    ldasOutDict%initTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    ldasOutDict%validTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    ldasOutDict%conventions = "CF-1.6"
@@ -1943,7 +1944,7 @@ subroutine initLsmOutDict(lsmOutDict,procId,diagFlag)
    lsmOutDict%modelNdvInt = -2147483647
 
    ! First establish global attributes.
-   lsmOutDict%title = "OUTPUT FROM WRF-Hydro v5.0.0-dev"
+   lsmOutDict%title = "OUTPUT FROM " // codeVersion
    lsmOutDict%initTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    lsmOutDict%validTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    lsmOutDict%conventions = "CF-1.6"

--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -40,7 +40,7 @@ type chrtMeta
    ! Variable names
    character (len=64), dimension(numChVars) :: varNames
    integer :: numVars = numChVars
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
    ! Output variable attributes
    real, dimension(numChVars) :: scaleFactor ! scale_factor values used for each
                                                   ! variable to converte from real to
@@ -108,7 +108,7 @@ type ldasMeta
    integer :: numVars = numLdasVars
    integer :: numSnowLayers = 3
    integer :: numSoilLayers = 4
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
    ! Output variable attributes
    real, dimension(numLdasVars) :: scaleFactor ! scale_factor values used for each
                                                   ! variable to converte from
@@ -175,7 +175,7 @@ type rtDomainMeta
    character (len=64), dimension(numRtDomainVars) :: varNames
    integer :: numVars = numRtDomainVars
    integer :: numSoilLayers = 4
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
    ! Output variable attributes
    real, dimension(numRtDomainVars) :: scaleFactor ! scale_factor values used for each
                                                   ! variable to converte from
@@ -240,7 +240,7 @@ type lakeMeta
    ! Variable names
    character (len=64), dimension(numLakeVars) :: varNames
    integer :: numVars = numLakeVars
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
    ! Output variable attributes
    real, dimension(numLakeVars) :: scaleFactor ! scale_factor values used for each
                                                ! variable to converte from
@@ -306,7 +306,7 @@ type chrtGrdMeta
    ! Variable names
    character (len=64), dimension(numChGrdVars) :: varNames
    integer :: numVars = numChGrdVars
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
    ! Output variable attributes
    real, dimension(numChGrdVars) :: scaleFactor ! scale_factor values for each
                                                 ! variable to convert from 
@@ -374,7 +374,7 @@ type lsmMeta
    integer :: numVars = numLsmVars
    integer :: numSnowLayers = 3
    integer :: numSoilLayers = 4
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
    ! Output variable attributes
    real, dimension(numLsmVars) :: scaleFactor ! scale_factor values used for each
                                                   ! variable to converte from
@@ -441,7 +441,7 @@ type chObsMeta
    ! Variable names
    character (len=64), dimension(numChObsVars) :: varNames
    integer :: numVars = numChObsVars
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
    ! Output variable attributes
    real, dimension(numChObsVars) :: scaleFactor ! scale_factor values used for
                                                  ! each variable to convert 
@@ -508,7 +508,7 @@ type gwMeta
    ! Variable names
    character (len=64), dimension(numGwVars) :: varNames
    integer :: numVars = numGwVars
-   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0-dev"
    ! Output variable attributes
    real, dimension(numGwVars) :: scaleFactor ! scale_factor values used for each
                                                ! variable to converte from
@@ -742,7 +742,7 @@ subroutine initLdasDict(ldasOutDict,procId,diagFlag)
    ldasOutDict%modelNdvInt = -2147483647
 
    ! First establish global attributes.
-   ldasOutDict%title = "OUTPUT FROM WRF-Hydro v5.0.0"
+   ldasOutDict%title = "OUTPUT FROM WRF-Hydro v5.0.0-dev"
    ldasOutDict%initTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    ldasOutDict%validTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    ldasOutDict%conventions = "CF-1.6"
@@ -1943,7 +1943,7 @@ subroutine initLsmOutDict(lsmOutDict,procId,diagFlag)
    lsmOutDict%modelNdvInt = -2147483647
 
    ! First establish global attributes.
-   lsmOutDict%title = "OUTPUT FROM WRF-Hydro v5.0.0"
+   lsmOutDict%title = "OUTPUT FROM WRF-Hydro v5.0.0-dev"
    lsmOutDict%initTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    lsmOutDict%validTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    lsmOutDict%conventions = "CF-1.6"

--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -40,7 +40,7 @@ type chrtMeta
    ! Variable names
    character (len=64), dimension(numChVars) :: varNames
    integer :: numVars = numChVars
-   character (len=512) :: outVersion = "WRF-Hydro 5.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
    ! Output variable attributes
    real, dimension(numChVars) :: scaleFactor ! scale_factor values used for each
                                                   ! variable to converte from real to
@@ -108,7 +108,7 @@ type ldasMeta
    integer :: numVars = numLdasVars
    integer :: numSnowLayers = 3
    integer :: numSoilLayers = 4
-   character (len=512) :: outVersion = "WRF-Hydro 5.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
    ! Output variable attributes
    real, dimension(numLdasVars) :: scaleFactor ! scale_factor values used for each
                                                   ! variable to converte from
@@ -175,7 +175,7 @@ type rtDomainMeta
    character (len=64), dimension(numRtDomainVars) :: varNames
    integer :: numVars = numRtDomainVars
    integer :: numSoilLayers = 4
-   character (len=512) :: outVersion = "WRF-Hydro 5.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
    ! Output variable attributes
    real, dimension(numRtDomainVars) :: scaleFactor ! scale_factor values used for each
                                                   ! variable to converte from
@@ -240,7 +240,7 @@ type lakeMeta
    ! Variable names
    character (len=64), dimension(numLakeVars) :: varNames
    integer :: numVars = numLakeVars
-   character (len=512) :: outVersion = "WRF-Hydro 5.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
    ! Output variable attributes
    real, dimension(numLakeVars) :: scaleFactor ! scale_factor values used for each
                                                ! variable to converte from
@@ -306,7 +306,7 @@ type chrtGrdMeta
    ! Variable names
    character (len=64), dimension(numChGrdVars) :: varNames
    integer :: numVars = numChGrdVars
-   character (len=512) :: outVersion = "WRF-Hydro 5.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
    ! Output variable attributes
    real, dimension(numChGrdVars) :: scaleFactor ! scale_factor values for each
                                                 ! variable to convert from 
@@ -374,7 +374,7 @@ type lsmMeta
    integer :: numVars = numLsmVars
    integer :: numSnowLayers = 3
    integer :: numSoilLayers = 4
-   character (len=512) :: outVersion = "WRF-Hydro 5.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
    ! Output variable attributes
    real, dimension(numLsmVars) :: scaleFactor ! scale_factor values used for each
                                                   ! variable to converte from
@@ -441,7 +441,7 @@ type chObsMeta
    ! Variable names
    character (len=64), dimension(numChObsVars) :: varNames
    integer :: numVars = numChObsVars
-   character (len=512) :: outVersion = "WRF-Hydro 5.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
    ! Output variable attributes
    real, dimension(numChObsVars) :: scaleFactor ! scale_factor values used for
                                                  ! each variable to convert 
@@ -508,7 +508,7 @@ type gwMeta
    ! Variable names
    character (len=64), dimension(numGwVars) :: varNames
    integer :: numVars = numGwVars
-   character (len=512) :: outVersion = "WRF-Hydro 5.0"
+   character (len=512) :: outVersion = "WRF-Hydro v5.0.0"
    ! Output variable attributes
    real, dimension(numGwVars) :: scaleFactor ! scale_factor values used for each
                                                ! variable to converte from
@@ -742,7 +742,7 @@ subroutine initLdasDict(ldasOutDict,procId,diagFlag)
    ldasOutDict%modelNdvInt = -2147483647
 
    ! First establish global attributes.
-   ldasOutDict%title = "OUTPUT FROM HRLDAS v20150506"
+   ldasOutDict%title = "OUTPUT FROM WRF-Hydro v5.0.0"
    ldasOutDict%initTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    ldasOutDict%validTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    ldasOutDict%conventions = "CF-1.6"
@@ -1943,7 +1943,7 @@ subroutine initLsmOutDict(lsmOutDict,procId,diagFlag)
    lsmOutDict%modelNdvInt = -2147483647
 
    ! First establish global attributes.
-   lsmOutDict%title = "OUTPUT FROM WRF-Hydro v4.0"
+   lsmOutDict%title = "OUTPUT FROM WRF-Hydro v5.0.0"
    lsmOutDict%initTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    lsmOutDict%validTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    lsmOutDict%conventions = "CF-1.6"


### PR DESCRIPTION
Two minor changes here to output file metadata:
1. Change geogrid -> fulldom to address issue #152 on private repo
2. Change model version in output files to WRF-Hydro v5.0.0 for the upcoming release.  

Notes:
* As mentioned in issue #186 on private repo we should implement a better system for updating the code version (currently it's hard coded in 10 places).  These updates do not address this and if someone else has time before the release that'd be awesome (feel free to close this in that case).
* I changed HRLDAS v20150506 -> WRF-Hydro v5.0.0 in the output metadata for LSMOUT files.  Open to other ideas | opinions here.
  