### PR TITLE
Metadata fix

### DIFF
--- a/trunk/NDHMS/Data_Rec/namelist.inc
+++ b/trunk/NDHMS/Data_Rec/namelist.inc
@@ -58,6 +58,7 @@
           integer ::output_gw                   ! Netcdf grid of GW
           integer ::outlake                   ! Netcdf grid of lake
           integer :: rtFlag
+          integer ::khour
 
 !#ifdef WRF_HYDRO_NUDGING
        character(len=256) :: nudgingParamFile

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -574,6 +574,7 @@ module module_NoahMP_hrldas_driver
 
      if(.not. RT_DOMAIN(did)%initialized) then  
         nlst_rt(did)%dt = real(noah_timestep)
+        nlst_rt(did)%khour = khour ! Adding kHOUR to be used in the NWM output routines.
         nlst_rt(did)%olddate(1:19) = olddate(1:19)
         nlst_rt(did)%startdate(1:19) = olddate(1:19)
         nlst_rt(did)%nsoil = kk
@@ -1412,6 +1413,10 @@ module module_NoahMP_hrldas_driver
 #ifdef HYDRO_D
   print*, "NTIME = ", NTIME , "KHOUR=",KHOUR,"dtbl = ", dtbl
 #endif
+
+  ! assinging the KHOUR to be used in the NWM output routing for global metadata
+  nlst_rt(did)%khour = khour
+
   call system_clock(count=clock_count_1)   ! Start a timer
 
 

--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -514,6 +514,10 @@ subroutine output_chrt_NWM(domainId)
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)
  
+   ! calculate the minimum and maximum time
+   fileMeta%timeValidMin = minSinceEpoch1 + nlst_rt(1)%out_dt 
+   fileMeta%timeValidMax = minSinceEpoch1 + nlst_rt(1)%khour * 60
+
    ! Compose output file name.
    write(output_flnm, '(A12,".CHRTOUT_DOMAIN",I1)')nlst_rt(domainId)%olddate(1:4)//&
          nlst_rt(domainId)%olddate(6:7)//nlst_rt(domainId)%olddate(9:10)//&
@@ -691,6 +695,10 @@ subroutine output_chrt_NWM(domainId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place standard_name attribute into time variable')
       iret = nf90_put_att(ftn,timeId,'units',trim(fileMeta%timeUnits))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into time variable')
+      iret = nf90_put_att(ftn,timeId,'valid_min',fileMeta%timeValidMin)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_min attribute into time variable')
+      iret = nf90_put_att(ftn,timeId,'valid_max',fileMeta%timeValidMax)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_max attribute into time variable')
       iret = nf90_def_var(ftn,"reference_time",nf90_int,dimId(3),refTimeId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create reference_time variable')
       iret = nf90_put_att(ftn,refTimeId,'long_name',trim(fileMeta%rTimeLName))
@@ -1124,10 +1132,15 @@ subroutine output_NoahMP_NWM(outDir,iGrid,output_timestep,startdate,date,ixPar,j
                   nlst_rt(1)%startdate(9:10)//'_'//&
                   nlst_rt(1)%startdate(12:13)//&
                   &':00:00') 
+
    ! Replace default values in the dictionary.
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)
  
+   ! calculate the minimum and maximum time
+   fileMeta%timeValidMin = minSinceEpoch1 + nlst_rt(1)%out_dt 
+   fileMeta%timeValidMax = minSinceEpoch1 + nlst_rt(1)%khour * 60
+   
    ! Depending on the NWM forecast config, we will be outputting different
    ! varibles. DO NOT MODIFY THESE ARRAYS WITHOUT CONSULTING NCAR OR
    ! OWP!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1257,6 +1270,10 @@ subroutine output_NoahMP_NWM(outDir,iGrid,output_timestep,startdate,date,ixPar,j
          call nwmCheck(diagFlag,iret,'ERROR: Unable to place standard_name attribute into time variable')
          iret = nf90_put_att(ftnNoahMP,timeId,'units',trim(fileMeta%timeUnits))
          call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into time variable')
+         iret = nf90_put_att(ftn,timeId,'valid_min',fileMeta%timeValidMin)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_min attribute into time variable')
+         iret = nf90_put_att(ftn,timeId,'valid_max',fileMeta%timeValidMax)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_max attribute into time variable')
          iret = nf90_def_var(ftnNoahMP,"reference_time",nf90_int,dimId(6),refTimeId)
          call nwmCheck(diagFlag,iret,'ERROR: Unable to create reference_time variable')
          iret = nf90_put_att(ftnNoahMP,refTimeId,'long_name',trim(fileMeta%rTimeLName))
@@ -1766,6 +1783,10 @@ subroutine output_rt_NWM(domainId,iGrid)
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)
 
+   ! calculate the minimum and maximum time
+   fileMeta%timeValidMin = minSinceEpoch1 + nlst_rt(1)%out_dt 
+   fileMeta%timeValidMax = minSinceEpoch1 + nlst_rt(1)%khour * 60
+
    ! Create output filename
    write(output_flnm, '(A12,".RTOUT_DOMAIN",I1)') nlst_rt(domainId)%olddate(1:4)//&
                        nlst_rt(domainId)%olddate(6:7)//&
@@ -1817,6 +1838,10 @@ subroutine output_rt_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place standard_name attribute into time variable')
       iret = nf90_put_att(ftn,timeId,'units',trim(fileMeta%timeUnits))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into time variable')
+      iret = nf90_put_att(ftn,timeId,'valid_min',fileMeta%timeValidMin)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_min attribute into time variable')
+      iret = nf90_put_att(ftn,timeId,'valid_max',fileMeta%timeValidMax)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_max attribute into time variable')
       iret = nf90_def_var(ftn,"reference_time",nf90_int,dimId(4),refTimeId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create reference_time variable')
       iret = nf90_put_att(ftn,refTimeId,'long_name',trim(fileMeta%rTimeLName))
@@ -2405,6 +2430,10 @@ subroutine output_lakes_NWM(domainId,iGrid)
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)
 
+   ! calculate the minimum and maximum time
+   fileMeta%timeValidMin = minSinceEpoch1 + nlst_rt(1)%out_dt 
+   fileMeta%timeValidMax = minSinceEpoch1 + nlst_rt(1)%khour * 60
+
    ! Compose output file name.
    write(output_flnm, '(A12,".LAKEOUT_DOMAIN",I1)')nlst_rt(domainId)%olddate(1:4)//&
          nlst_rt(domainId)%olddate(6:7)//nlst_rt(domainId)%olddate(9:10)//&
@@ -2502,6 +2531,10 @@ subroutine output_lakes_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place standard_name attribute into time variable')
       iret = nf90_put_att(ftn,timeId,'units',trim(fileMeta%timeUnits))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into time variable')
+      iret = nf90_put_att(ftn,timeId,'valid_min',fileMeta%timeValidMin)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_min attribute into time variable')
+      iret = nf90_put_att(ftn,timeId,'valid_max',fileMeta%timeValidMax)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_max attribute into time variable')
       iret = nf90_def_var(ftn,"reference_time",nf90_int,dimId(3),refTimeId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create reference_time variable')
       iret = nf90_put_att(ftn,refTimeId,'long_name',trim(fileMeta%rTimeLName))
@@ -2948,6 +2981,10 @@ subroutine output_chrtout_grd_NWM(domainId,iGrid)
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)
 
+   ! calculate the minimum and maximum time
+   fileMeta%timeValidMin = minSinceEpoch1 + nlst_rt(1)%out_dt 
+   fileMeta%timeValidMax = minSinceEpoch1 + nlst_rt(1)%khour * 60
+
    ! Create output filename
    write(output_flnm, '(A12,".CHRTOUT_GRID",I1)') nlst_rt(domainId)%olddate(1:4)//&
                        nlst_rt(domainId)%olddate(6:7)//&
@@ -3000,6 +3037,10 @@ subroutine output_chrtout_grd_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place standard_name attribute into time variable')
       iret = nf90_put_att(ftn,timeId,'units',trim(fileMeta%timeUnits))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into time variable')
+      iret = nf90_put_att(ftn,timeId,'valid_min',fileMeta%timeValidMin)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_min attribute into time variable')
+      iret = nf90_put_att(ftn,timeId,'valid_max',fileMeta%timeValidMax)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_max attribute into time variable')
       iret = nf90_def_var(ftn,"reference_time",nf90_int,dimId(4),refTimeId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create reference_time variable')
       iret = nf90_put_att(ftn,refTimeId,'long_name',trim(fileMeta%rTimeLName))
@@ -3388,6 +3429,10 @@ subroutine output_lsmOut_NWM(domainId)
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)
 
+   ! calculate the minimum and maximum time
+   fileMeta%timeValidMin = minSinceEpoch1 + nlst_rt(1)%out_dt
+   fileMeta%timeValidMax = minSinceEpoch1 + nlst_rt(1)%khour * 60
+
    ! For now, will always default to outputting all available
    ! variables since the nature of this output file is
    ! diagnostic in nature.
@@ -3452,6 +3497,10 @@ subroutine output_lsmOut_NWM(domainId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place standard_name attribute into time variable')
       iret = nf90_put_att(ftn,timeId,'units',trim(fileMeta%timeUnits))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into time variable')
+      iret = nf90_put_att(ftn,timeId,'valid_min',fileMeta%timeValidMin)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_min attribute into time variable')
+      iret = nf90_put_att(ftn,timeId,'valid_max',fileMeta%timeValidMax)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_max attribute into time variable')
       iret = nf90_def_var(ftn,"reference_time",nf90_int,dimId(4),refTimeId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create reference_time variable')
       iret = nf90_put_att(ftn,refTimeId,'long_name',trim(fileMeta%rTimeLName))
@@ -4166,6 +4215,10 @@ subroutine output_chanObs_NWM(domainId)
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)
 
+   ! calculate the minimum and maximum time 
+   fileMeta%timeValidMin = minSinceEpoch1 + nlst_rt(1)%out_dt
+   fileMeta%timeValidMax = minSinceEpoch1 + nlst_rt(1)%khour * 60
+
    ! Compose output file name.
    write(output_flnm,'(A12,".CHANOBS_DOMAIN",I1)')nlst_rt(domainId)%olddate(1:4)//&
          nlst_rt(domainId)%olddate(6:7)//nlst_rt(domainId)%olddate(9:10)//&
@@ -4415,6 +4468,10 @@ subroutine output_chanObs_NWM(domainId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place standard_name attribute into time variable')
       iret = nf90_put_att(ftn,timeId,'units',trim(fileMeta%timeUnits))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into time variable')
+      iret = nf90_put_att(ftn,timeId,'valid_min',fileMeta%timeValidMin)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_min attribute into time variable')
+      iret = nf90_put_att(ftn,timeId,'valid_max',fileMeta%timeValidMax)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_max attribute into time variable')
       iret = nf90_def_var(ftn,"reference_time",nf90_int,dimId(3),refTimeId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create reference_time variable')
       iret = nf90_put_att(ftn,refTimeId,'long_name',trim(fileMeta%rTimeLName))
@@ -4937,6 +4994,10 @@ subroutine output_gw_NWM(domainId,iGrid)
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)
 
+   ! calculate the minimum and maximum time
+   fileMeta%timeValidMin = minSinceEpoch1 + nlst_rt(1)%out_dt 
+   fileMeta%timeValidMax = minSinceEpoch1 + nlst_rt(1)%khour * 60
+
    ! Compose output file name.
    write(output_flnm,'(A12,".GWOUT_DOMAIN",I1)')nlst_rt(domainId)%olddate(1:4)//&
          nlst_rt(domainId)%olddate(6:7)//nlst_rt(domainId)%olddate(9:10)//&
@@ -4999,6 +5060,10 @@ subroutine output_gw_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place standard_name attribute into time variable')
       iret = nf90_put_att(ftn,timeId,'units',trim(fileMeta%timeUnits))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into time variable')
+      iret = nf90_put_att(ftn,timeId,'valid_min',fileMeta%timeValidMin)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_min attribute into time variable')
+      iret = nf90_put_att(ftn,timeId,'valid_max',fileMeta%timeValidMax)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_max attribute into time variable')
       iret = nf90_def_var(ftn,"reference_time",nf90_int,dimId(3),refTimeId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create reference_time variable')
       iret = nf90_put_att(ftn,refTimeId,'long_name',trim(fileMeta%rTimeLName))

--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -69,6 +69,8 @@ type chrtMeta
    character (len=64) :: timeLName ! long_name - usually valid output time
    character (len=64) :: timeUnits ! Usually seconds since 1/1/1970
    character (len=64) :: timeStName ! standard_name - usually time
+   integer :: timeValidMin ! the minimum time each configuration can have, time of the first output file
+   integer :: timeValidMax ! the maximum time each configuration can have, time of the last output file
    ! Reference time attributes
    character (len=64) :: rTimeLName ! long_name - usually model initialization time
    character (len=64) :: rTimeStName ! standard_name - usually forecast_reference_time
@@ -144,6 +146,9 @@ type ldasMeta
    character (len=64) :: timeLName ! long_name - usually valid output time
    character (len=64) :: timeUnits ! Usually seconds since 1/1/1970
    character (len=64) :: timeStName ! standard_name - usually time
+   integer :: timeValidMin ! the minimum time each configuration can have, time of the first output file
+   integer :: timeValidMax ! the maximum time each configuration can have, time of the last output file
+
    ! Reference time attributes
    character (len=64) :: rTimeLName ! long_name - usually model initialization time
    character (len=64) :: rTimeStName ! standard_name - usually forecast_reference_time
@@ -211,6 +216,8 @@ type rtDomainMeta
    character (len=64) :: timeLName ! long_name - usually valid output time
    character (len=64) :: timeUnits ! Usually seconds since 1/1/1970
    character (len=64) :: timeStName ! standard_name - usually time
+   integer :: timeValidMin ! the minimum time each configuration can have, time of the first output file
+   integer :: timeValidMax ! the maximum time each configuration can have, time of the last output file
    ! Reference time attributes
    character (len=64) :: rTimeLName ! long_name - usually model initialization time
    character (len=64) :: rTimeStName ! standard_name - usually forecast_reference_time
@@ -279,6 +286,8 @@ type lakeMeta
    character (len=64) :: timeLName ! long_name - usually valid output time
    character (len=64) :: timeUnits ! Usually seconds since 1/1/1970
    character (len=64) :: timeStName ! standard_name - usually time
+   integer :: timeValidMin ! the minimum time each configuration can have, time of the first output file
+   integer :: timeValidMax ! the maximum time each configuration can have, time of the last output file
    ! Reference time attributes
    character (len=64) :: rTimeLName ! long_name - usually model initialization time
    character (len=64) :: rTimeStName ! standard_name - usually forecast_reference_time
@@ -349,6 +358,8 @@ type chrtGrdMeta
    character (len=64) :: timeLName ! long_name - usually valid output time
    character (len=64) :: timeUnits ! Usually seconds since 1/1/1970
    character (len=64) :: timeStName ! standard_name - usually time
+   integer :: timeValidMin ! the minimum time each configuration can have, time of the first output file
+   integer :: timeValidMax ! the maximum time each configuration can have, time of the last output file
    ! Reference time attributes
    character (len=64) :: rTimeLName ! long_name - usually model initialization time
    character (len=64) :: rTimeStName ! standard_name - usually forecast_reference_time
@@ -422,6 +433,8 @@ type lsmMeta
    character (len=64) :: timeLName ! long_name - usually valid output time
    character (len=64) :: timeUnits ! Usually seconds since 1/1/1970
    character (len=64) :: timeStName ! standard_name - usually time
+   integer :: timeValidMin ! the minimum time each configuration can have, time of the first output file
+   integer :: timeValidMax ! the maximum time each configuration can have, time of the last output file
    ! Reference time attributes
    character (len=64) :: rTimeLName ! long_name - usually model initialization time
    character (len=64) :: rTimeStName ! standard_name - usually forecast_reference_time
@@ -489,6 +502,8 @@ type chObsMeta
    character (len=64) :: timeLName ! long_name - usually valid output time
    character (len=64) :: timeUnits ! Usually seconds since 1/1/1970
    character (len=64) :: timeStName ! standard_name - usually time
+   integer :: timeValidMin ! the minimum time each configuration can have, time of the first output file
+   integer :: timeValidMax ! the maximum time each configuration can have, time of the last output file
    ! Reference time attributes
    character (len=64) :: rTimeLName ! long_name - usually model initialization time
    character (len=64) :: rTimeStName ! standard_name - usually forecast_reference_time
@@ -561,6 +576,8 @@ type gwMeta
    character (len=64) :: timeLName ! long_name - usually valid output time
    character (len=64) :: timeUnits ! Usually seconds since 1/1/1970
    character (len=64) :: timeStName ! standard_name - usually time
+   integer :: timeValidMin ! the minimum time each configuration can have, time of the first output file
+   integer :: timeValidMax ! the maximum time each configuration can have, time of the last output file
    ! Reference time attributes
    character (len=64) :: rTimeLName ! long_name - usually model initialization time
    character (len=64) :: rTimeStName ! standard_name - usually forecast_reference_time


### PR DESCRIPTION
I have added the min_valid and max_valid as attributes to the output files from NWM output routines. To do so, I added KHOUR to the nlst_rt, since the simulation duration was not accessible in other routines. 

Potential problem: I noticed that in the NWM output routine, the simulation time is calculated based on the out_dt for all the routines, even for output_NoahMP_NWM and output_lsmOut_NWM subroutines. Should not we be using the dt (NOAHMP time step) for these ones? For the NWM configuration might not be important since the time step for outputting is the same between the LSM and Hydro, but we will have issues if not. If someone could confirm my suspicious, then I will fix them accordingly. 