### PR TITLE
Replicate SM checks to happen after hydro2dtbl read for consistency.

### DIFF
--- a/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
+++ b/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
@@ -1750,6 +1750,15 @@ end subroutine HYDRO_ini
        ! input from HYDRO.TBL.nc file
        print*, "reading from hydrotbl_f(HYDRO.TBL.nc)  file ...."
        call hdtbl_in_nc(did)
+       !ADCHANGE: For consistency, mirror urban and param value checks used in table read
+       where (rt_domain(did)%VEGTYP == rt_domain(did)%isurban) 
+          rt_domain(did)%SMCMAX1 = 0.45
+          rt_domain(did)%SMCREF1 = 0.42
+          rt_domain(did)%SMCWLT1 = 0.40
+       endwhere
+       where (rt_domain(did)%SMCMAX1 .gt. 1.0) rt_domain(did)%SMCMAX1 = 1.0
+       rt_domain(did)%SMCREF1 = max(min(rt_domain(did)%SMCREF1, rt_domain(did)%SMCMAX1 - 0.01), 0.0)
+       rt_domain(did)%SMCWLT1 = max(min(rt_domain(did)%SMCWLT1, rt_domain(did)%SMCREF1 - 0.01), 0.0)
     endif
 
        rt_domain(did)%soiltyp = soltyp


### PR DESCRIPTION
Addresses Issue #127 in wrf_hydro_nwm ("Soil properties checks if reading from HYDRO_2D_TBL"). Ran the following checks using Croton on hydro-c1 PGI:
1) Confirmed checks applied as expected.
2) Confirmed TBL and NC file runs give identical solutions.
3) Confirmed same answers if urban soil properties specified in hydro2dtbl input file or hydro2dtbl is internally-generated from TBL.
4)  Answer changes from master code simulation if urban cells present and urban properties NOT specified in hydro2dtbl. This is expected behavior per Issue #127.

Also confirmed behavior on Cheyenne Intel using NWM CONUS domain. Expected differences in urban cells. Passed perfect restart with NWM CONUS.

NOTE: Per Issue #127 exchange, this is a consistency fix between LSM and hydro for hard-coding of urban soil properties. Both will be relaxed in future versions.
