### PR TITLE
Update CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,48 +1,44 @@
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge
+We as contributors and maintainers of WRF-Hydro pledge to make participation in our software project and community a welcoming and inclusive experience for everyone. This includes acceptance and respectful treatment of everyone regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, political affiliation, veteran status, pregnancy, genetic information, personal appearance, race, religion, or sexual identity and orientation, as well as any other characteristic protected under applicable US federal or state law.
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, political affiliation, veteran status, pregnancy, genetic information, personal appearance, choice of text editor or operating system, race, religion, or sexual identity and orientation, or any other characteristic protected under applicable US federal or state law. 
-
-## Our Standards
-
+## Our Standards 
 Examples of behavior that contributes to creating a positive environment include:
-
 * Using welcoming and inclusive language
 * Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
+* Be respectful when offering constructive criticism
+* Gracefully accepting constructive criticism 
+* Acknowledging the contributions of others 
 * Focusing on what is best for the community
 * Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
+* Using sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting, derogatory comments, and personal or political attacks
+* Harassing others, publicly or privately
 * Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
 * Refusing to use the pronouns that someone requests
-* Intimidating, threatening, or hostile conduct; physical or verbal abuse; vandalism; arson; and sabotage
-* Alarming or threatening comments that might refer to, suggest, or promote a violent, intimidating, or threatening action
-
-## Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+* Alarming, intimidating, threatening, or hostile comments or conduct
+* Badgering someone about their choice of text editor or operating system
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Scope
+This Code of Conduct applies to participants whenever they are conducting any action on behalf of the software project and community whether it be online or face to face. Behavior that is not on behalf of the project may be covered by one of the other UCAR/NCAR Codes of Conduct. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, interacting on a public software repository, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
 
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+## Community Responsibilities
+Everyone in the community is empowered to respond to people who are showing unacceptable behavior. They can talk to them privately or publicly. If this behavior continues they can contact project administrators or do one of the options listed in the “Enforcement & Reporting” section below.
 
-## Enforcement
+## Project Administrator Responsibilities
+Project administrators are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+Project administrators have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, email, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+ 
+Project Administrators who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership and subject to their own institution’s policies and procedures.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at wrfhydro@ucar.edu. Alternatively, this behavior can be reported to individuals on the WRF-Hydro team, who will then have the responsibility to talk about the behavior to the core team. Another alternative for NCAR employees (when all individuals involved are NCAR employees) is to use the reporting methods of NCAR for this behavior (these options include anonymous reporting methods). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately. Retaliation against a person who initiates a complaint or an inquiry about such behaviors is equally prohibited.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+## Enforcement & Reporting
+Instances of unacceptable behavior may be reported by contacting the project team at wrfhydro@ucar.edu. Alternatively, this behavior can be reported to individuals on the WRF-Hydro team, who will then have the responsibility to review and will respond in a way that it deems appropriate to the circumstances, including engaging the UCAR Human Resources and the UCAR Office of Diversity and Inclusion. Another alternative is to use the reporting methods of UCAR/NCAR for this behavior (these options include anonymous reporting methods). The project team will maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately. Retaliation against a person who initiates a complaint or an inquiry about such behaviors is prohibited.
 
 ## Attribution
-
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
 
 [homepage]: http://contributor-covenant.org


### PR DESCRIPTION
A committee made up of members of software-based and online projects across NCAR met to collaborate on a CoC template for software-based projects across UCAR/NCAR. I have included the content as a result of these meetings. A CoC is standard practice on open source and community developed projects. Also, within the last 3 months, NSF has mandated that all NSF projects have a CoC. The president's office has to finalize everything by say end of June.  I expect minimal changes.