### PR TITLE
Metadata fix

### DIFF
--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -1528,14 +1528,9 @@ endif
 ! the t0OutputFlag is 1 in the hydro.namelist
 ! the ldas_output requires one variables ITIME 
 ! which is the LSM timestep, we declare it here
-! since it does not exist at this point 
-#ifdef WRF_HYDRO
-  ITIME = 1
-#else
+! since it does not exist at this point
   ITIME = 0
-#endif
-!#ifdef HYDRO_REALTIME
-   if(t0OutputFlag .eq. 1) call ldas_output(ITIME)
+  if(t0OutputFlag .eq. 1) call ldas_output(ITIME)
 !#else
 !  if (restart_filename_requested == " ") then
 !     if(t0OutputFlag .eq. 1) call ldas_output()

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -312,7 +312,8 @@ module module_NoahMP_hrldas_driver
 ! Timing:
 !------------------------------------------------------------------------
 
-  INTEGER :: NTIME          ! timesteps
+  INTEGER :: NTIME          ! total timesteps
+  INTEGER :: ITIME          ! LSM time step
   integer :: clock_count_1 = 0
   integer :: clock_count_2 = 0
   integer :: clock_rate    = 0
@@ -1521,9 +1522,20 @@ endif
 #ifdef MPP_LAND
    if(my_id .eq. io_id) &
        print*, "t0OutputFlag: ", t0OutputFlag  
-#endif        
+#endif     
+
+! ldas_output subroutine will be called when 
+! the t0OutputFlag is 1 in the hydro.namelist
+! the ldas_output requires one variables ITIME 
+! which is the LSM timestep, we declare it here
+! since it does not exist at this point 
+#ifdef WRF_HYDRO
+  ITIME = 1
+#else
+  ITIME = 0
+#endif
 !#ifdef HYDRO_REALTIME
-   if(t0OutputFlag .eq. 1) call ldas_output(0)
+   if(t0OutputFlag .eq. 1) call ldas_output(ITIME)
 !#else
 !  if (restart_filename_requested == " ") then
 !     if(t0OutputFlag .eq. 1) call ldas_output()
@@ -1843,8 +1855,7 @@ end subroutine land_driver_exe
 
 !!===============================================================================
 subroutine  ldas_output(itime)
-integer, intent(in)  :: itime ! time step of the LSM, had to explicitly declare it since 
-                              ! it did not exist in the land_driver_ini 
+integer, intent(in)  :: itime ! time step of the LSM  
 
 !#ifdef WRF_HYDRO
 !if ( (io_config_outputs .eq. 0) ) then

--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -123,7 +123,7 @@ type ldasMeta
                                                   ! real to
                                                   ! integer.
    real, dimension(numLdasVars)             :: addOffset   ! add_offset values for each variable.
-   character (len=64), dimension(numLdasVars) :: longName  ! Long names for each variable.
+   character (len=128), dimension(numLdasVars) :: longName  ! Long names for each variable.
    character (len=64), dimension(numLdasVars) :: units ! Units for each variable.
    integer, dimension(numLdasVars) :: numLev ! Number of levels for each variable.
    integer*8, dimension(numLdasVars) :: validMinComp ! Valid min (after conversion to integer)
@@ -1029,7 +1029,7 @@ subroutine initLdasDict(ldasOutDict,procId,diagFlag)
                                "WOOD","STBLCP","FASTCP","NEE","GPP","NPP","PSN",&
                                "APAR","ACCET","CANWAT","SOILICE","SOILSAT_TOP",&
                                "SOILSAT","SNOWT_AVG"]
-   ldasOutDict%longName(:) = [character(len=64) :: "Dominant vegetation category",&
+   ldasOutDict%longName(:) = [character(len=128) :: "Dominant vegetation category",&
                               "Dominant soil category",&
                               "Green Vegetation Fraction",&
                               "Leaf area index",&
@@ -1091,7 +1091,7 @@ subroutine initLdasDict(ldasOutDict,procId,diagFlag)
                               "soil temperature",&
                               "liquid volumetric soil moisture",&
                               "snow temperature",&
-                              "volumetric soil moisture",&
+                              "volumetric soil moisture, the dimensionless ratio of water volume (m3) to soil volume (m3)",&
                               "Snow depth",&
                               "Snow water equivalent",&
                               "Snowfall rate",&
@@ -1135,11 +1135,11 @@ subroutine initLdasDict(ldasOutDict,procId,diagFlag)
                             "K","K","K","K","K","K","K","K",&
                             "kg/kg","kg/kg","Pa","fraction",&
                             "m","mm","mm","K","m3 m-3","K","m3 m-3",&
-                            "m","kg m-2","mm s-1","count","-","mm","mm",&
+                            "m","kg m-2","mm s-1","count","1","mm","mm",&
                             "-","-","m s-1","m s-1","m s-1","m s-1","m s-1","m s-1",&
                             "g m-2","g m-2","g m-2","g m-2","g m-2","g m-2","g m-2s-1 CO2",&
                             "g m-2s-1 C","g m-2s-1 C","umol CO2 m-2 s-1","W m-2",&
-                            "mm","mm","fraction","fraction","fraction","K"]
+                            "mm","mm","1","1","1","K"]
    ldasOutDict%scaleFactor(:) = [1.0,1.0,0.01,0.1,0.1,0.1,0.01,0.1,0.000001,0.01,&
                                  0.1,0.1,0.1,0.1,0.1,0.000001,0.000001,0.01,&
                                  0.000001,0.01,0.001,0.01,0.01,0.00001,0.01,&
@@ -1612,7 +1612,7 @@ subroutine initLakeDict(lakeOutDict,diagFlag,procId)
 
    ! Establish elevation variable attributes
    lakeOutDict%elevLName = "Water Surface Elevation"
-   lakeOutDict%elevUnits = "meters"
+   lakeOutDict%elevUnits = "m" ! meters
 
    ! Establish feature_id attributes
    lakeOutDict%featureIdLName = "Lake ComID"


### PR DESCRIPTION
To remove the hardcoded `ldas_output(0)` to something more explanatory, I added the ITIME variable to the initialization routine where ITIME is 0 or 1 depending on HYDRO being on and off. 

The following changes have been made to the module_NWM_io_dict.F:
* Changing the unit for the lake elevation from “meters” to “m”, the impact would be in the *LAKEOUT* files where is changes from 
``` 
float water_sfc_elev(feature_id) ;
water_sfc_elev:long_name = "Water Surface Elevation" ;
water_sfc_elev:units = "meters";
```
To
```
float water_sfc_elev(feature_id) ;
water_sfc_elev:long_name = "Water Surface Elevation" ;
water_sfc_elev:units = "m" ;
```
* Changing the unit for FSNO from “-“ to “1”, the impact would be in the *LDASOUT* files where is changing from 
```  
float FSNO(time, y, x) ;
FSNO:long_name = "Snow-cover fraction on the ground" ;
FSNO:units = "-" ;
```
To
```
float FSNO(time, y, x) ;
FSNO:long_name = "Snow-cover fraction on the ground" ;
FSNO:units = "1" ;
```
* Changing the unit from “fraction” to “1” for the SOILSAT_TOP, the impact would be in the *LDASOUT* files where is changing from 
```
float SOILSAT_TOP(time, y, x) ;
SOILSAT_TOP:long_name = "fraction of soil saturation, top 2 layers" ;
SOILSAT_TOP:units = "fraction" ;
```
To
```
float SOILSAT_TOP(time, y, x) ;
SOILSAT_TOP:long_name = "fraction of soil saturation, top 2 layers" ;
SOILSAT_TOP:units = "1" ;
```

* The same changes applied to SOILSAT_TOP is been made to SOILSAT and SOILICE, so one would expect the same change for those variables:
```
float SOILSAT(time, y, x) ;
SOILSAT:long_name = "fraction of soil saturation, column integrated" ;
SOILSAT:units = "1" ;

float SOILICE(time, y, x) ;
SOILICE:long_name = "fraction of soil moisture that is ice" ;
SOILICE:units = "1" ;
```

* Changing the long name for the SOIL_M, the impact would be in the *LDASOUT* files where is changing from 
 ```
float SOIL_M(time, y, soil_layers_stag, x) ;
SOIL_M:long_name = "volumetric soil moisture" ;
SOIL_M:units = "m3 m-3" ;
```
To
```
float SOIL_M(time, y, soil_layers_stag, x) ;
SOIL_M:long_name = "volumetric soil moisture, the dimensionless ratio of water volume (m3) to soil volume (m3)" ;
SOIL_M:units = "m3 m-3" ;
```



