### PR TITLE
Surface resistance and retention depth modifications

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # Development
-- *Backwards Incompatibility*. The previously hard coded soil shape function exponent parameter in Noah-MP was added to the MPTABLE.TBL parameter table as `RSURF_EXP` and spatial soil parameter file as `rsurfexp`.  Users specifying a spatial soil parameter file (in namelist.hrldas -> noahlsm_offline -> spatial_file)  will need to update this file. The file can be updated, for example, by the following NCO command where the existing file is named "soil_properties.nc": `ncap2 -O -s "rsurfexp=slope*0.0+5.0" soil_properties.nc soil_properties.nc` (#62)
+- *Backwards Incompatibility*. The previously hard coded soil shape function exponent parameter in Noah-MP was added to the MPTABLE.TBL parameter table as `RSURF_EXP` and spatial soil parameter file as `rsurfexp`.  Users specifying a spatial soil parameter file (in namelist.hrldas -> noahlsm_offline -> spatial_filename)  will need to update this file. The file can be updated, for example, by the following NCO command where the existing file is named "soil_properties.nc": `ncap2 -O -s "rsurfexp=slope*0.0+5.0" soil_properties.nc soil_properties.nc` (#62)
 
 # WRF-Hydro v5.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Development
+- *Backwards Incompatibility*. The previously hard coded soil shape function exponent parameter in Noah-MP was added to the MPTABLE.TBL parameter table as `RSURF_EXP` and spatial soil parameter file as `rsurfexp`.  Users specifying a spatial soil parameter file (in namelist.hrldas -> noahlsm_offline -> spatial_file)  will need to update this file. The file can be updated, for example, by the following NCO command where the existing file is named "soil_properties.nc": `ncap2 -O -s "rsurfexp=slope*0.0+5.0" soil_properties.nc soil_properties.nc` (#62)
+
 # WRF-Hydro v5.0.0
 
 ## High-Level Highlights:

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -148,6 +148,7 @@ module module_NoahMP_hrldas_driver
   REAL, ALLOCATABLE, DIMENSION(:,:)       ::  mp_2D      ! Slope of Ball-Berry rs-P relationship
   REAL, ALLOCATABLE, DIMENSION(:,:)       ::  hvt_2D     ! Canopy Height
   REAL, ALLOCATABLE, DIMENSION(:,:)       ::  mfsno_2D   ! Snow cover m parameter
+  REAL, ALLOCATABLE, DIMENSION(:,:)       ::  rsurfexp_2D! exponent in the shape parameter for soil resistance option 1
 #endif
 
 ! INOUT (with generic LSM equivalent) (as defined in WRF)
@@ -829,6 +830,7 @@ module module_NoahMP_hrldas_driver
   ALLOCATE ( mp_2D      (XSTART:XEND,YSTART:YEND) )            ! Slope of Ball-Berry rs-P relationship
   ALLOCATE ( hvt_2D     (XSTART:XEND,YSTART:YEND) )            ! Canopy Height
   ALLOCATE ( mfsno_2D   (XSTART:XEND,YSTART:YEND) )            ! Snow cover m parameter
+  ALLOCATE ( rsurfexp_2D(XSTART:XEND,YSTART:YEND) )            ! exponent in the shape parameter for soil resistance option 1
 #endif
 
 ! INOUT (with generic LSM equivalent) (as defined in WRF)
@@ -1171,7 +1173,7 @@ module module_NoahMP_hrldas_driver
     CALL READ_3D_SOIL(SPATIAL_FILENAME, XSTART, XEND, YSTART, YEND, &
                       NSOIL,BEXP_3D,SMCDRY_3D,SMCWLT_3D,SMCREF_3D,SMCMAX_3D,  &
 		      DKSAT_3D,DWSAT_3D,PSISAT_3D,QUARTZ_3D,REFDK_2D,REFKDT_2D,&
-		      SLOPE_2D,CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D)
+		      SLOPE_2D,CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,RSURFEXP_2D)
 #endif
   
 !------------------------------------------------------------------------
@@ -1740,7 +1742,7 @@ end subroutine land_driver_ini
                  BEXP_3D,SMCDRY_3D,SMCWLT_3D,SMCREF_3D,SMCMAX_3D,             &
 		 DKSAT_3D,DWSAT_3D,PSISAT_3D,QUARTZ_3D,                       &
 		 REFDK_2D,REFKDT_2D,SLOPE_2D,                                 &
-		 CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,                    &
+		 CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,RSURFEXP_2D,        &
 #endif
 #ifdef WRF_HYDRO
                  sfcheadrt,INFXSRT,soldrain,                          &    !O

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -766,7 +766,7 @@ contains
   subroutine read_3d_soil(spatial_filename,xstart, xend,ystart, yend,           &
                           nsoil,bexp_3d,smcdry_3d,smcwlt_3d,smcref_3d,smcmax_3d,  &
 		          dksat_3d,dwsat_3d,psisat_3d,quartz_3d,refdk_2d,refkdt_2d,slope_2d,&
-			  cwpvt_2d,vcmx25_2d,mp_2d,hvt_2d,mfsno_2d)
+			  cwpvt_2d,vcmx25_2d,mp_2d,hvt_2d,mfsno_2d,rsurfexp_2d)
     implicit none
     character(len=*),          intent(in)  :: spatial_filename
     integer,                   intent(in)  :: xstart, xend, ystart, yend
@@ -788,6 +788,7 @@ contains
     real,    dimension(xstart:xend,ystart:yend), intent(out)       :: mp_2d
     real,    dimension(xstart:xend,ystart:yend), intent(out)       :: hvt_2d
     real,    dimension(xstart:xend,ystart:yend), intent(out)       :: mfsno_2d    
+    real,    dimension(xstart:xend,ystart:yend), intent(out)       :: rsurfexp_2d
 
     character(len=24)  :: name
     character(len=256) :: units
@@ -1006,6 +1007,16 @@ contains
     endif
 
     iret = nf90_get_var(ncid, varid, mfsno_2d, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
+!    
+    name = "rsurfexp"
+    iret = nf90_inq_varid(ncid,  trim(name),  varid)
+    if (iret /= 0) then
+      print*, 'ncid = ', ncid
+      write(*,*) "FATAL ERROR: In read_3d_soil():  Problem finding variable '"//trim(name)//"' in NetCDF file: " // trim(spatial_filename)
+      stop
+    endif
+
+    iret = nf90_get_var(ncid, varid, rsurfexp_2d, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
     
     ! Close the NetCDF file
     ierr = nf90_close(ncid)

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
@@ -62,7 +62,7 @@ CONTAINS
                  BEXP_3D,SMCDRY_3D,SMCWLT_3D,SMCREF_3D,SMCMAX_3D,             &
 		 DKSAT_3D,DWSAT_3D,PSISAT_3D,QUARTZ_3D,                       &
 		 REFDK_2D,REFKDT_2D,SLOPE_2D,                                 &
-		 CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,                    &
+		 CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,RSURFEXP_2D,        &
 #endif
 #ifdef WRF_HYDRO
                sfcheadrt,INFXSRT,soldrain,                                  &
@@ -157,6 +157,7 @@ CONTAINS
     REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  MP_2D     ! Slope of Ball-Berry rs-P relationship
     REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  HVT_2D    ! Canopy Height
     REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  MFSNO_2D  ! Snow cover m parameter
+    REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  RSURFEXP_2D ! exponent in the shape parameter for soil resistance option 1
 #endif
 
 ! INOUT (with generic LSM equivalent)
@@ -643,6 +644,7 @@ CONTAINS
        parameters%mp     = MP_2D(I,J)             ! Slope of Ball-Berry rs-P relationship
        parameters%hvt    = HVT_2D(I,J)            ! Canopy Height
        parameters%mfsno  = MFSNO_2D(I,J)          ! Snow cover m parameter
+       parameters%rsurf_exp = RSURFEXP_2D(I,J)    ! exponent in the shape parameter for soil resistance option 1
 #endif
        CALL TRANSFER_MP_PARAMETERS(VEGTYP,SOILTYP,SLOPETYP,SOILCOLOR,parameters)
        
@@ -1121,6 +1123,7 @@ SUBROUTINE TRANSFER_MP_PARAMETERS(VEGTYPE,SOILTYPE,SLOPETYPE,SOILCOLOR,parameter
     parameters%MFSNO  =  MFSNO_TABLE(VEGTYPE)       !snowmelt m parameter ()
     parameters%HVT    =    HVT_TABLE(VEGTYPE)       !top of canopy (m)
     parameters%MP     =     MP_TABLE(VEGTYPE)       !slope of conductance-to-photosynthesis relationship
+   parameters%RSURF_EXP  =   RSURF_EXP_TABLE
 #endif
 
 ! ----------------------------------------------------------------------

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -285,6 +285,7 @@ MODULE MODULE_SF_NOAHMPLSM
      REAL :: BATS_VIS_DIR !cosz factor for direct visible snow albedo Yang97 eqn. 15
      REAL :: BATS_NIR_DIR !cosz factor for direct NIR snow albedo Yang97 eqn. 16
      REAL :: RSURF_SNOW   !surface resistance for snow(s/m)
+     REAL :: RSURF_EXP    !exponent in the shape parameter for soil resistance option 1
 
 !------------------------------------------------------------------------------------------!
 ! From the SOILPARM.TBL tables, as functions of soil category.
@@ -1820,7 +1821,7 @@ contains
          ! RSURF based on Sakaguchi and Zeng, 2009
          ! taking the "residual water content" to be the wilting point, 
          ! and correcting the exponent on the D term (typo in SZ09 ?)
-         L_RSURF = (-ZSOIL(1)) * ( exp ( (1.0 - MIN(1.0,SH2O(1)/parameters%SMCMAX(1))) ** 5 ) - 1.0 ) / ( 2.71828 - 1.0 ) 
+         L_RSURF = (-ZSOIL(1)) * ( exp ( (1.0 - MIN(1.0,SH2O(1)/parameters%SMCMAX(1))) ** parameters%RSURF_EXP ) - 1.0 ) / ( 2.71828 - 1.0 ) 
          D_RSURF = 2.2E-5 * parameters%SMCMAX(1) * parameters%SMCMAX(1) * ( 1.0 - parameters%SMCWLT(1) / parameters%SMCMAX(1) ) ** (2.0+3.0/parameters%BEXP(1))
          RSURF = L_RSURF / D_RSURF
        ELSEIF(OPT_RSF == 2) THEN
@@ -8445,6 +8446,7 @@ MODULE NOAHMP_TABLES
     REAL :: BATS_VIS_DIR_TABLE  !cosz factor for direct visible snow albedo Yang97 eqn. 15
     REAL :: BATS_NIR_DIR_TABLE  !cosz factor for direct NIR snow albedo Yang97 eqn. 16
     REAL :: RSURF_SNOW_TABLE    !surface resistance for snow(s/m)
+    REAL :: RSURF_EXP_TABLE    !exponent in the shape parameter for soil resistance option 1
 
 CONTAINS
 
@@ -8820,12 +8822,12 @@ CONTAINS
     REAL :: CO2,O2,TIMEAN,FSATMX,Z0SNO,SSI, &
             SWEMX,TAU0,GRAIN_GROWTH,EXTRA_GROWTH,DIRT_SOOT,&
 	    BATS_COSZ,BATS_VIS_NEW,BATS_NIR_NEW,BATS_VIS_AGE,BATS_NIR_AGE,BATS_VIS_DIR,BATS_NIR_DIR,&
-	    RSURF_SNOW
+	    RSURF_SNOW,RSURF_EXP
 
     NAMELIST / noahmp_global_parameters / CO2,O2,TIMEAN,FSATMX,Z0SNO,SSI, &
             SWEMX,TAU0,GRAIN_GROWTH,EXTRA_GROWTH,DIRT_SOOT,&
 	    BATS_COSZ,BATS_VIS_NEW,BATS_NIR_NEW,BATS_VIS_AGE,BATS_NIR_AGE,BATS_VIS_DIR,BATS_NIR_DIR,&
-	    RSURF_SNOW
+	    RSURF_SNOW,RSURF_EXP
 
 
     ! Initialize our variables to bad values, so that if the namelist read fails, we come to a screeching halt as soon as we try to use anything.
@@ -8848,6 +8850,7 @@ BATS_NIR_AGE_TABLE   = -1.E36
 BATS_VIS_DIR_TABLE   = -1.E36
 BATS_NIR_DIR_TABLE   = -1.E36
 RSURF_SNOW_TABLE     = -1.E36
+ RSURF_EXP_TABLE     = -1.E36
 
 #ifndef NCEP_WCOSS
     open(15, file="MPTABLE.TBL", status='old', form='formatted', action='read', iostat=ierr)
@@ -8881,6 +8884,7 @@ BATS_NIR_AGE_TABLE   = BATS_NIR_AGE
 BATS_VIS_DIR_TABLE   = BATS_VIS_DIR
 BATS_NIR_DIR_TABLE   = BATS_NIR_DIR
 RSURF_SNOW_TABLE     = RSURF_SNOW
+ RSURF_EXP_TABLE     = RSURF_EXP
 
   end subroutine read_mp_global_parameters
 

--- a/trunk/NDHMS/Land_models/NoahMP/run/MPTABLE.TBL
+++ b/trunk/NDHMS/Land_models/NoahMP/run/MPTABLE.TBL
@@ -330,5 +330,6 @@
   BATS_VIS_DIR  = 0.4   !cosz factor for direct visible snow albedo Yang97 eqn. 15
   BATS_NIR_DIR  = 0.4   !cosz factor for direct NIR snow albedo Yang97 eqn. 16
   RSURF_SNOW = 50.0     !surface resistence for snow [s/m]
+  RSURF_EXP = 5.0       !exponent in the shape parameter for soil resistance option 1
 
 /

--- a/trunk/NDHMS/Routing/Noah_distr_routing.F
+++ b/trunk/NDHMS/Routing/Noah_distr_routing.F
@@ -894,8 +894,10 @@
 !	     RETDEPRT(I,J) = RETDEPRT(I,J) * 100.0    !DJG TEMP HARDWIRE!!!!
 !	     RETDEPRT(I,J) = 10.0    !DJG TEMP HARDWIRE!!!!
 
-! AD hardwire to force channel retention depth to be 5mm.
-             RETDEPRT(I,J) = 5.0
+!ADCHANGE: This RETDEPRT setting for channel cells has been moved to LandRT_ini where
+!RETDEPRT is initially calculated. Keeps it out of this frequent routine call and 
+!time loop. 
+!             RETDEPRT(I,J) = 5.0
 
              IF (SFCHEADSUBRT(I,J).GT.RETDEPRT(I,J)) THEN
 !!               QINFLO(CH_NET(I,J)=QINFLO(CH_NET(I,J)+SFCHEAD(I,J) - RETDEPRT(I,J)

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -1015,8 +1015,10 @@ if(nlst_rt(did)%channel_only       .eq. 0 .and. &
    rt_domain(did)%RETDEPRT = rt_domain(did)%RETDEPRT * rt_domain(did)%RETDEPRTFAC
    rt_domain(did)%OVROUGHRT = rt_domain(did)%OVROUGHRT * rt_domain(did)%OVROUGHRTFAC
    
-   ! AD new limit for RETDEPRT at 1mm, assuming larger values of RETDEPRTFAC possible
-   rt_domain(did)%RETDEPRT = min(rt_domain(did)%RETDEPRT, 1.0)  
+   !ADCHANGE: Moved this channel cell setting from OV_RTNG so it is outside
+   !of overland routine (frequently called) and time loop.
+   !Force channel retention depth to be 5mm.
+   where (rt_domain(did)%CH_NETRT .ge. 0) rt_domain(did)%RETDEPRT = 5.0
  
    ! calculate the slope for boundary        
 #ifdef MPP_LAND


### PR DESCRIPTION
Includes the following commits migrated from wrf_hydro_nwm repo:
- Add soil shape function exponent to MPTABLE (for spatially constant) and SPATIAL_SOIL file (for spatially varying); produces some expected machine-precision-level differences when reading from MPTABLE (barlage)
- Relax retdeprt 1mm hard limit in code. (aubreyd)
- Move channel retdep limit setting to outside of ov_rtng time loop. Now happens during initialization. (aubreyd)

There will be expected machine-precision-level answer changes due to rsurfexp parameter read from external file vs. internal. Larger changes due to retdeprt limit change where retdeprt exceeds 1mm. New surface resistance parameter added to MPTABLE.TBL (included in PR) so requires TBL update to run. Compile and run tested on Cheyenne Intel 16.0.3. These changes have been vetted as part of v2.0 calibration prep.