### PR TITLE
Unit fix for soil column bottom runoff for CHRTOUT/Channel-only fluxes

### DIFF
--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -732,7 +732,7 @@ subroutine initChrtDict(chrtOutDict,diagFlag,procId)
                               "Accumulated runoff from gw bucket"]
    chrtOutDict%units(:) = [character(len=64) :: "m3 s-1","m3 s-1","m3 s-1","ms-1",&
                                                 "meter","m3 s-1","m3 s-1",&
-                                                "m3","m3","m3"]
+                                                "m3 s-1","m3","m3"]
    chrtOutDict%coordNames(:) = [character(len=64) :: "latitude longitude","latitude longitude",&
                                  "latitude longitude","latitude longitude",&
                                  "latitude longitude","latitude longitude",&


### PR DESCRIPTION
I think one of these was not fixed. @logankarsten to verify.