### PR TITLE
Remove references to private repository from repo docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -38,12 +38,6 @@ document title, page number and quote the line or section for suggesting changes
 documentation.
 
 ## Code contributions
-Much of the WRF-Hydro development occurs on the public
-[NCAR/wrf_hydro_nwm_public](https://github.com/NCAR/wrf_hydro_nwm_public) repository. However, some
-internal development must occur on a private repository maintained by NCAR and NOAA. Due to this
-dual-repository system, a strict procedure must be followed when making contributions to the WRF-
-Hydro model code.
-
 All code development contributions will be made via [forks](https://help.github.com/articles/about-forks/)
 and [pull requests](https://help.github.com/articles/about-pull-requests/). If you are
 unfamiliar with GitHub, forks, or pull requests, see [collaborating with issues and pull

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 #  WRF-Hydro <img src=".github/images/wrf_hydro_symbol_logo_2017_09.png" width=100 align="left" />
 
-|Single node|
-|----------|
-|[![Build Status](https://travis-ci.com/NCAR/wrf_hydro_nwm.svg?token=QgVvMwYPGMz47yDxuega&branch=master)](https://travis-ci.com/NCAR/wrf_hydro_nwm)|
+-[![Build Status](https://travis-ci.org/NCAR/wrf_hydro_nwm_public.svg?branch=master)](https://travis-ci.org/NCAR/wrf_hydro_nwm_public)
+-[![Release](https://img.shields.io/github/release/NCAR/wrf_hydro_nwm_public.svg)](https://github.com/NCAR/wrf_hydro_nwm_public/releases/latest)
+-[![DOI](.github/badges/doi.svg)](https://ezid.cdlib.org/id/doi:10.5065/D6J38RBJ)
 
 ## Description
 This is the code repository for [WRF-Hydro](https://ral.ucar.edu/projects/wrf_hydro).


### PR DESCRIPTION
This change resolves issue #85 by removing references to the private WRF-Hydro / NWM repository from our repository documentation (README.md and CONTRIBUTING.md).  