### PR TITLE
Cache-blocking for three-level nested loop

### DIFF
--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -640,6 +640,8 @@ integer :: i,j,k, ll, count
      integer, allocatable, dimension(:) :: buf
      real, allocatable, dimension(:) :: tmpRESHT
      integer :: new_start_i, new_start_j, new_end_i, new_end_j
+     integer :: cache_block, cache_block_begin_i, cache_block_end_i
+     integer :: cache_idx, num_blocks, cache_idx_k, cache_block_begin_k, cache_block_end_k
 
 #ifdef OUTPUT_CHAN_CONN
 real :: connCalcTimeStart, connCalcTimeEnd
@@ -856,24 +858,34 @@ endif
 
       endif  ! end if block for UDMP_OPT
 
-      new_start_i = 1; new_start_j = 1
+      new_start_i = 0; new_start_j = 1
       new_end_i = rt_domain(did)%ixrt; new_end_j = rt_domain(did)%jxrt
 
-      if(left_id .ge. 0) new_start_i = 2
+      if(left_id .ge. 0) new_start_i = 1
       if(right_id .ge. 0) new_end_i = rt_domain(did)%ixrt - 1
       if(down_id .ge. 0) new_start_j = 2
       if(up_id .ge. 0) new_end_j = rt_domain(did)%jxrt - 1
       
-      do k = 1, rt_domain(did)%LNLINKSL
-         do j = new_start_j, new_end_j
-            do i = new_start_i, new_end_i
-               if(rt_domain(did)%CH_LNKRT(i,j) .eq. rt_domain(did)%LLINKID(k) ) then
-                  rt_domain(did)%CH_LNKRT_SL(i,j) = k   !! mapping
-               endif
+      cache_block = 256
+      num_blocks = ceiling((new_end_i - new_start_i)/real(cache_block))
+      do j = new_start_j, new_end_j
+         do cache_idx = 0, num_blocks - 1
+            cache_block_begin_i = new_start_i + cache_idx * cache_block + 1
+            cache_block_end_i = min(cache_block_begin_i + cache_block - 1, new_end_i)
+            do cache_idx_k = 0, rt_domain(did)%LNLINKSL, cache_block
+               cache_block_begin_k = min(cache_idx_k + 1, rt_domain(did)%LNLINKSL)
+               cache_block_end_k = min(cache_block_begin_k + cache_block - 1, rt_domain(did)%LNLINKSL)
+               do i = cache_block_begin_i, cache_block_end_i
+                  do k = cache_block_begin_k, cache_block_end_k
+                     if(rt_domain(did)%CH_LNKRT(i,j) .eq. rt_domain(did)%LLINKID(k) ) then
+                        rt_domain(did)%CH_LNKRT_SL(i,j) = k   !! mapping
+                     endif
+                  end do
+               end do
             end do
          end do
       end do
-
+   
       call getLocalIndx(rt_domain(did)%gnlinksl,rt_domain(did)%LINKID, rt_domain(did)%LLINKID)
 
       call getToInd(rt_domain(did)%LINKID,rt_domain(did)%to_node,rt_domain(did)%toNodeInd,rt_domain(did)%nToInd,rt_domain(did)%gtoNode)

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -872,7 +872,7 @@ endif
          do cache_idx = 0, num_blocks - 1
             cache_block_begin_i = new_start_i + cache_idx * cache_block + 1
             cache_block_end_i = min(cache_block_begin_i + cache_block - 1, new_end_i)
-            do cache_idx_k = 0, rt_domain(did)%LNLINKSL, cache_block
+            do cache_idx_k = 0, rt_domain(did)%LNLINKSL - 1, cache_block
                cache_block_begin_k = min(cache_idx_k + 1, rt_domain(did)%LNLINKSL)
                cache_block_end_k = min(cache_block_begin_k + cache_block - 1, rt_domain(did)%LNLINKSL)
                do i = cache_block_begin_i, cache_block_end_i


### PR DESCRIPTION
This PR completes the set of optimizations on the initialization phase.
The performance improvements brought by this PR are very evident when the model run on a small number of processes (32-64). The exact performance speedup will be reported later this week.
This PR has been tested again the current version on master for CONUS 24 hours.
The results are identical.