### PR TITLE
SMCMAX exceed check fix

### DIFF
--- a/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
+++ b/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
@@ -1154,7 +1154,7 @@ endif
 !end 
 
 !ADCHANGE: Change to accept very small diff since was being triggered by vals that print identical
-IF ( (RT_DOMAIN(did)%SMCRT(IXXRT,JYYRT,KRT)-RT_DOMAIN(did)%SMCMAXRT(IXXRT,JYYRT,KRT)) .GT. 0.000001 ) THEN
+IF ( (RT_DOMAIN(did)%SMCRT(IXXRT,JYYRT,KRT)-RT_DOMAIN(did)%SMCMAXRT(IXXRT,JYYRT,KRT)) .GT. 0.00001 ) THEN
 #ifdef HYDRO_D
 #ifndef NCEP_WCOSS
                       print *, "SMCMAX exceeded upon aggregation...", &


### PR DESCRIPTION
Reduce smc smcmax check threshold from 10-6 to 10-5 due to some conflicts still triggering at the lower threshold. Need to properly resolve source of small diffs at some point. These seem to result from a small subset of parameter combinations (i.e., during calibration).