### PR TITLE
Update hydro output timestep in template/WCOSS namelists

### DIFF
--- a/trunk/NDHMS/template/WCOSS/namelists/v2.0/hi_analysis_assim/hydro.namelist
+++ b/trunk/NDHMS/template/WCOSS/namelists/v2.0/hi_analysis_assim/hydro.namelist
@@ -50,7 +50,7 @@ GW_RESTART = 1
 !!!! -------------------- MODEL OUTPUT CONTROL -------------------- !!!!
 
 ! Specify the output file write frequency...(minutes)
-out_dt = 15
+out_dt = 60
 
 ! Specify the number of output times to be contained within each output history file...(integer)
 !   SET = 1 WHEN RUNNING CHANNEL ROUTING ONLY/CALIBRATION SIMS!!!

--- a/trunk/NDHMS/template/WCOSS/namelists/v2.0/hi_short_range/hydro.namelist
+++ b/trunk/NDHMS/template/WCOSS/namelists/v2.0/hi_short_range/hydro.namelist
@@ -50,7 +50,7 @@ GW_RESTART = 1
 !!!! -------------------- MODEL OUTPUT CONTROL -------------------- !!!!
 
 ! Specify the output file write frequency...(minutes)
-out_dt = 15
+out_dt = 60
 
 ! Specify the number of output times to be contained within each output history file...(integer)
 !   SET = 1 WHEN RUNNING CHANNEL ROUTING ONLY/CALIBRATION SIMS!!!


### PR DESCRIPTION
This is just an update to the WCOSS/template/v2.0 namelists for Hawaii to reflect the change back to hourly hydro outputs.  The testing namelists for Hawaii were already set to hourly outputs for both hydro and the LSM.  

Note:  There are no code or testing changes here (only template files logged in the repository).