### PR TITLE
Improve the scale factor for greater accuracy to to-channel fluxes (e…

### DIFF
--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -732,7 +732,7 @@ subroutine initChrtDict(chrtOutDict,diagFlag,procId)
                                  "latitude longitude","latitude longitude",&
                                  "latitude longitude","latitude longitude",&
                                  "latitude longitude","latitude longitude"]
-   chrtOutDict%scaleFactor(:) = [0.01,0.01,0.1,0.01,0.01,0.001,0.001,0.001,&
+   chrtOutDict%scaleFactor(:) = [0.01,0.01,0.1,0.01,0.01,0.00001,0.00001,0.001,&
                                  0.01,0.01]
    chrtOutDict%addOffset(:) = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,&
                                0.0]


### PR DESCRIPTION
…xcludes the volume from the bottom of the column used in chan-only+bucket

The imporvement results in slightly worse compression to the tune of about 2MB per chrtout file when compressed as in the operational work flow. 