### PR TITLE
WCOSS channel-fluxes:

### DIFF
--- a/trunk/NDHMS/template/WCOSS/namelists/v2.0/analysis_assim_long_range/hydro.namelist
+++ b/trunk/NDHMS/template/WCOSS/namelists/v2.0/analysis_assim_long_range/hydro.namelist
@@ -79,7 +79,7 @@ t0OutputFlag = 1
 ! 0=None (default), 1=channel influxes (qSfcLatRunoff, qBucket)
 ! 2=channel+bucket fluxes    (qSfcLatRunoff, qBucket, qBtmVertRunoff_toBucket)
 ! 3=channel accumulations    (accSfcLatRunoff, accBucket) *** NOT TESTED ***
-output_channelBucket_influx = 2
+output_channelBucket_influx = 0
 
 ! Output netcdf file control
 CHRTOUT_DOMAIN = 1           ! Netcdf point timeseries output at all channel points (1d)

--- a/trunk/NDHMS/template/WCOSS/namelists/v2.0/hi_analysis_assim/hydro.namelist
+++ b/trunk/NDHMS/template/WCOSS/namelists/v2.0/hi_analysis_assim/hydro.namelist
@@ -79,7 +79,7 @@ t0OutputFlag = 1
 ! 0=None (default), 1=channel influxes (qSfcLatRunoff, qBucket)
 ! 2=channel+bucket fluxes    (qSfcLatRunoff, qBucket, qBtmVertRunoff_toBucket)
 ! 3=channel accumulations    (accSfcLatRunoff, accBucket) *** NOT TESTED ***
-output_channelBucket_influx = 0
+output_channelBucket_influx = 2
 
 ! Output netcdf file control
 CHRTOUT_DOMAIN = 1           ! Netcdf point timeseries output at all channel points (1d)

--- a/trunk/NDHMS/template/WCOSS/namelists/v2.0/hi_short_range/hydro.namelist
+++ b/trunk/NDHMS/template/WCOSS/namelists/v2.0/hi_short_range/hydro.namelist
@@ -79,7 +79,7 @@ t0OutputFlag = 1
 ! 0=None (default), 1=channel influxes (qSfcLatRunoff, qBucket)
 ! 2=channel+bucket fluxes    (qSfcLatRunoff, qBucket, qBtmVertRunoff_toBucket)
 ! 3=channel accumulations    (accSfcLatRunoff, accBucket) *** NOT TESTED ***
-output_channelBucket_influx = 0
+output_channelBucket_influx = 2
 
 ! Output netcdf file control
 CHRTOUT_DOMAIN = 1           ! Netcdf point timeseries output at all channel points (1d)

--- a/trunk/NDHMS/template/WCOSS/namelists/v2.0_reforecasts/analysis_assim_long_range/hydro.namelist
+++ b/trunk/NDHMS/template/WCOSS/namelists/v2.0_reforecasts/analysis_assim_long_range/hydro.namelist
@@ -79,7 +79,7 @@ t0OutputFlag = 1
 ! 0=None (default), 1=channel influxes (qSfcLatRunoff, qBucket)
 ! 2=channel+bucket fluxes    (qSfcLatRunoff, qBucket, qBtmVertRunoff_toBucket)
 ! 3=channel accumulations    (accSfcLatRunoff, accBucket) *** NOT TESTED ***
-output_channelBucket_influx = 2
+output_channelBucket_influx = 0
 
 ! Output netcdf file control
 CHRTOUT_DOMAIN = 1           ! Netcdf point timeseries output at all channel points (1d)


### PR DESCRIPTION
* real-time: Remove channel-fluxes from long range analysis
* reforecast: Remove channel-fluxes from long range analysis
* real-time:  add channel-fluxes to hi analysis
* real-time:  add channel-fluxes to hi short range