### PR TITLE
Gridded lake restart fixes

### DIFF
--- a/trunk/NDHMS/Routing/module_HYDRO_io.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_io.F
@@ -5905,6 +5905,7 @@ end subroutine mpp_output_chrt
          if(rt_domain(did)%nlakes .gt. 0) then
             iret = nf_def_var(ncid,"resht",NF_FLOAT,1,(/dimid_lakes/),varid)
             iret = nf_def_var(ncid,"qlakeo",NF_FLOAT,1,(/dimid_lakes/),varid)
+            iret = nf_def_var(ncid,"qlakei",NF_FLOAT,1,(/dimid_lakes/),varid)
          endif
 
          if( nlst_rt(did)%channel_only       .eq. 0 .and. &
@@ -6111,7 +6112,13 @@ if(nlst_rt(did)%SUBRTSWCRT  .eq. 1 .or. &
            ,rt_domain(did)%lake_index  &
 #endif
            )
-      
+
+      call w_rst_crt_nc1_lake(ncid,rt_domain(did)%nlakes,rt_domain(did)%qlakei,"qlakei" &
+#ifdef MPP_LAND
+           ,rt_domain(did)%lake_index  &
+#endif
+           )
+ 
       if( nlst_rt(did)%channel_only       .eq. 0 .and. &
           nlst_rt(did)%channelBucket_only .eq. 0         ) &
           call w_rst_rt_nc2(ncid,rt_domain(did)%ixrt,rt_domain(did)%jxrt,rt_domain(did)%LAKE_INFLORT,"lake_inflort")
@@ -6212,6 +6219,7 @@ end if  ! end if(nlst_rt(did)%SUBRTSWCRT  .eq. 1 .or. &
                    write(iunit,ERR=101) rt_domain(did)%cvol
                    write(iunit,ERR=101) rt_domain(did)%resht
                    write(iunit,ERR=101) rt_domain(did)%qlakeo
+                   write(iunit,ERR=101) rt_domain(did)%qlakei
                    write(iunit,ERR=101) rt_domain(did)%LAKE_INFLORT
                 end if
                 if(nlst_rt(did)%GWBASESWCRT.EQ.1) then
@@ -6305,6 +6313,7 @@ end if  ! end if(nlst_rt(did)%SUBRTSWCRT  .eq. 1 .or. &
                    read(iunit,ERR=101) rt_domain(did)%cvol
                    read(iunit,ERR=101) rt_domain(did)%resht
                    read(iunit,ERR=101) rt_domain(did)%qlakeo
+                   read(iunit,ERR=101) rt_domain(did)%qlakei
                    read(iunit,ERR=101) rt_domain(did)%LAKE_INFLORT
                 end if
                 if(nlst_rt(did)%GWBASESWCRT.EQ.1) then
@@ -6815,6 +6824,7 @@ if(nlst_rt(did)%SUBRTSWCRT  .eq. 1 .or. &
       if(rt_domain(did)%NLAKES .gt. 0) then
          call read_rst_crt_nc(ncid,rt_domain(did)%RESHT,rt_domain(did)%NLAKES,"resht")
          call read_rst_crt_nc(ncid,rt_domain(did)%QLAKEO,rt_domain(did)%NLAKES,"qlakeo")
+         call read_rst_crt_nc(ncid,rt_domain(did)%QLAKEI,rt_domain(did)%NLAKES,"qlakei")
       endif
    
       if( nlst_rt(did)%channel_only       .eq. 0 .and. &

--- a/trunk/NDHMS/Routing/module_channel_routing.F
+++ b/trunk/NDHMS/Routing/module_channel_routing.F
@@ -1309,7 +1309,7 @@ gwOption:   if(gwBaseSwCRT == 3) then
          call updateLake_grid(QLLAKE, nlakes,lake_index)
          call updateLake_grid(RESHT,  nlakes,lake_index)
          call updateLake_grid(QLAKEO, nlakes,lake_index)
-         call updateLake_grid(QLLAKE, nlakes,lake_index)
+         call updateLake_grid(QLAKEI, nlakes,lake_index)
          call updateLake_grid(QLAKEIP,nlakes,lake_index)
     endif
 #endif


### PR DESCRIPTION
Fix for perfect restart issue in gridded routing configuration with lakes active. Now tracking lake inflow from previous timestep in restarts so that the levelpool routine has same starting conditions as through run. New qlakei variable added to hydro restarts, so will not bit-for-bit match previous restarts. No apparent issues running new code with old restarts.

Also confirmed the following:
1) No answer changes in NWM CONUS, Croton reach-based (no lakes), and Croton gridded w/o lakes configurations.
2) Expected answer changes in Croton gridded w/ lakes configuration.
3) Perfect restarts in Croton gridded w/ lakes configuration.
4) Blessed by Yates!
