### PR TITLE
issue-150: add namelist check for out_dt / dt

### DIFF
--- a/trunk/NDHMS/Data_Rec/module_namelist.F
+++ b/trunk/NDHMS/Data_Rec/module_namelist.F
@@ -185,6 +185,10 @@ CONTAINS
        endif
 #endif
 
+   if ( int(mod(out_dt*60, nlst%dt))  .ne. 0) then
+      call hydro_stop("read_rt_nlst:: out_dt must be a multiple of the NOAH_TIMESTEP")
+   end if
+
 ! ADCHANGE: move these checks to more universal namelist checks...
    if ( io_config_outputs .eq. 4 ) RTOUT_DOMAIN = 0
 


### PR DESCRIPTION
This minor change resolves issue #150 by adding a namelist check to ensure that out_dt in hydro.namelist is a multiple of the land surface model timestep specified in namelist.hrldas.