### PR TITLE
issue-152: remove hard-coded values for min and sec in output metadata

### DIFF
--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -503,13 +503,15 @@ subroutine output_chrt_NWM(domainId)
    validTime = trim(nlst_rt(domainId)%olddate(1:4)//'-'//&
                     nlst_rt(domainId)%olddate(6:7)//'-'//&
                     nlst_rt(domainId)%olddate(9:10)//'_'//&
-                    nlst_rt(domainId)%olddate(12:13)//&
-                    &':00:00')
+                    nlst_rt(domainId)%olddate(12:13)//':'//&
+                    nlst_rt(domainId)%olddate(15:16)//':'//&
+                    nlst_rt(domainId)%olddate(18:19))   
    initTime = trim(nlst_rt(domainId)%startdate(1:4)//'-'//&
                   nlst_rt(domainId)%startdate(6:7)//'-'//&
                   nlst_rt(domainId)%startdate(9:10)//'_'//&
-                  nlst_rt(domainId)%startdate(12:13)//&
-                  &':00:00') 
+                  nlst_rt(domainId)%startdate(12:13)//':'//&
+                  nlst_rt(domainId)%startdate(15:16)//':'//&
+                  nlst_rt(domainId)%startdate(18:19)) 
    ! Replace default values in the dictionary.
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)
@@ -1130,13 +1132,15 @@ subroutine output_NoahMP_NWM(outDir,iGrid,output_timestep,itime,startdate,date,i
    validTime = trim(nlst_rt(1)%olddate(1:4)//'-'//&
                     nlst_rt(1)%olddate(6:7)//'-'//&
                     nlst_rt(1)%olddate(9:10)//'_'//&
-                    nlst_rt(1)%olddate(12:13)//&
-                    &':00:00')
+                    nlst_rt(1)%olddate(12:13)//':'//&
+                    nlst_rt(1)%olddate(15:16)//':'//&
+                    nlst_rt(1)%olddate(18:19))
    initTime = trim(nlst_rt(1)%startdate(1:4)//'-'//&
                   nlst_rt(1)%startdate(6:7)//'-'//&
                   nlst_rt(1)%startdate(9:10)//'_'//&
-                  nlst_rt(1)%startdate(12:13)//&
-                  &':00:00') 
+                  nlst_rt(1)%startdate(12:13)//':'//&
+                  nlst_rt(1)%startdate(15:16)//':'//&
+                  nlst_rt(1)%startdate(18:19))
 
    ! Replace default values in the dictionary.
    fileMeta%initTime = trim(initTime)
@@ -1782,13 +1786,15 @@ subroutine output_rt_NWM(domainId,iGrid)
    validTime = trim(nlst_rt(domainId)%olddate(1:4)//'-'//&
                     nlst_rt(domainId)%olddate(6:7)//'-'//&
                     nlst_rt(domainId)%olddate(9:10)//'_'//&
-                    nlst_rt(domainId)%olddate(12:13)//&
-                    &':00:00')
+                    nlst_rt(domainId)%olddate(12:13)//':'//&
+                    nlst_rt(domainId)%olddate(15:16)//':'//&
+                    nlst_rt(domainId)%olddate(18:19))
    initTime = trim(nlst_rt(domainId)%startdate(1:4)//'-'//&
                   nlst_rt(domainId)%startdate(6:7)//'-'//&
                   nlst_rt(domainId)%startdate(9:10)//'_'//&
-                  nlst_rt(domainId)%startdate(12:13)//&
-                  &':00:00')
+                  nlst_rt(domainId)%startdate(12:13)//':'//&
+                  nlst_rt(domainId)%startdate(15:16)//':'//&
+                  nlst_rt(domainId)%startdate(18:19))
    ! Replace default values in the dictionary.
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)
@@ -2434,13 +2440,15 @@ subroutine output_lakes_NWM(domainId,iGrid)
    validTime = trim(nlst_rt(domainId)%olddate(1:4)//'-'//&
                     nlst_rt(domainId)%olddate(6:7)//'-'//&
                     nlst_rt(domainId)%olddate(9:10)//'_'//&
-                    nlst_rt(domainId)%olddate(12:13)//&
-                    &':00:00')
+                    nlst_rt(domainId)%olddate(12:13)//':'//&
+                    nlst_rt(domainId)%olddate(15:16)//':'//&
+                    nlst_rt(domainId)%olddate(18:19))
    initTime = trim(nlst_rt(domainId)%startdate(1:4)//'-'//&
                   nlst_rt(domainId)%startdate(6:7)//'-'//&
                   nlst_rt(domainId)%startdate(9:10)//'_'//&
-                  nlst_rt(domainId)%startdate(12:13)//&
-                  &':00:00')
+                  nlst_rt(domainId)%startdate(12:13)//':'//&
+                  nlst_rt(domainId)%startdate(15:16)//':'//&
+                  nlst_rt(domainId)%startdate(18:19))
    ! Replace default values in the dictionary.
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)
@@ -2990,13 +2998,15 @@ subroutine output_chrtout_grd_NWM(domainId,iGrid)
    validTime = trim(nlst_rt(domainId)%olddate(1:4)//'-'//&
                     nlst_rt(domainId)%olddate(6:7)//'-'//&
                     nlst_rt(domainId)%olddate(9:10)//'_'//&
-                    nlst_rt(domainId)%olddate(12:13)//&
-                    &':00:00')
+                    nlst_rt(domainId)%olddate(12:13)//':'//&
+                    nlst_rt(domainId)%olddate(15:16)//':'//&
+                    nlst_rt(domainId)%olddate(18:19))
    initTime = trim(nlst_rt(domainId)%startdate(1:4)//'-'//&
                   nlst_rt(domainId)%startdate(6:7)//'-'//&
                   nlst_rt(domainId)%startdate(9:10)//'_'//&
-                  nlst_rt(domainId)%startdate(12:13)//&
-                  &':00:00')
+                  nlst_rt(domainId)%startdate(12:13)//':'//&
+                  nlst_rt(domainId)%startdate(15:16)//':'//&
+                  nlst_rt(domainId)%startdate(18:19))
    ! Replace default values in the dictionary.
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)
@@ -3443,13 +3453,15 @@ subroutine output_lsmOut_NWM(domainId)
    validTime = trim(nlst_rt(1)%olddate(1:4)//'-'//&
                     nlst_rt(1)%olddate(6:7)//'-'//&
                     nlst_rt(1)%olddate(9:10)//'_'//&
-                    nlst_rt(1)%olddate(12:13)//&
-                    &':00:00')
+                    nlst_rt(1)%olddate(12:13)//':'//&
+                    nlst_rt(1)%olddate(15:16)//':'//&
+                    nlst_rt(1)%olddate(18:19))
    initTime = trim(nlst_rt(1)%startdate(1:4)//'-'//&
                   nlst_rt(1)%startdate(6:7)//'-'//&
                   nlst_rt(1)%startdate(9:10)//'_'//&
-                  nlst_rt(1)%startdate(12:13)//&
-                  &':00:00')
+                  nlst_rt(1)%startdate(12:13)//':'//&
+                  nlst_rt(1)%startdate(15:16)//':'//&
+                  nlst_rt(1)%startdate(18:19))
    ! Replace default values in the dictionary.
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)
@@ -4234,13 +4246,15 @@ subroutine output_chanObs_NWM(domainId)
    validTime = trim(nlst_rt(domainId)%olddate(1:4)//'-'//&
                     nlst_rt(domainId)%olddate(6:7)//'-'//&
                     nlst_rt(domainId)%olddate(9:10)//'_'//&
-                    nlst_rt(domainId)%olddate(12:13)//&
-                    &':00:00')
+                    nlst_rt(domainId)%olddate(12:13)//':'//&
+                    nlst_rt(domainId)%olddate(15:16)//':'//&
+                    nlst_rt(domainId)%olddate(18:19))
    initTime = trim(nlst_rt(domainId)%startdate(1:4)//'-'//&
                   nlst_rt(domainId)%startdate(6:7)//'-'//&
                   nlst_rt(domainId)%startdate(9:10)//'_'//&
-                  nlst_rt(domainId)%startdate(12:13)//&
-                  &':00:00') 
+                  nlst_rt(domainId)%startdate(12:13)//':'//&
+                  nlst_rt(domainId)%startdate(15:16)//':'//&
+                  nlst_rt(domainId)%startdate(18:19))
    ! Replace default values in the dictionary.
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)
@@ -5018,13 +5032,15 @@ subroutine output_gw_NWM(domainId,iGrid)
    validTime = trim(nlst_rt(domainId)%olddate(1:4)//'-'//&
                     nlst_rt(domainId)%olddate(6:7)//'-'//&
                     nlst_rt(domainId)%olddate(9:10)//'_'//&
-                    nlst_rt(domainId)%olddate(12:13)//&
-                    &':00:00')
+                    nlst_rt(domainId)%olddate(12:13)//':'//&
+                    nlst_rt(domainId)%olddate(15:16)//':'//&
+                    nlst_rt(domainId)%olddate(18:19))
    initTime = trim(nlst_rt(domainId)%startdate(1:4)//'-'//&
                   nlst_rt(domainId)%startdate(6:7)//'-'//&
                   nlst_rt(domainId)%startdate(9:10)//'_'//&
-                  nlst_rt(domainId)%startdate(12:13)//&
-                  &':00:00')
+                  nlst_rt(domainId)%startdate(12:13)//':'//&
+                  nlst_rt(domainId)%startdate(15:16)//':'//&
+                  nlst_rt(domainId)%startdate(18:19))
    ! Replace default values in the dictionary.
    fileMeta%initTime = trim(initTime)
    fileMeta%validTime = trim(validTime)


### PR DESCRIPTION
This PR resolves issue #152 by assigning the minutes and seconds values for init and valid time file output metadata from the appropriate time variables rather than hard-coded 00 values for both.

I've confirmed that the code compiles and produces appropriate file metadata for sub-hourly output intervals (as long as the LSM time step is adapted accordingly - issue #151). Since file output for testing is hourly, we shouldn't see any changes there.