### PR TITLE
Levelpool bugfixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,7 @@
-# WRF-Hydro v5.0.1
-
-### Bug fixes
+## Bug fixes
 - Gridded routing lake inflows were not preserved in restarts, therefore solution to the level-pool scheme on intial timestep after model restart had slightly different initial conditions. This was fixed by preserving last timestep lake inflows in the restart files.
 - The lake level-pool scheme had a number of internal bugs fixed, which should improve lake level and outflow behavior.
+- Hard-coded values for minutes and seconds in output metadata were removed to allow for correct sub-hourly outputs
 
 # WRF-Hydro v5.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# WRF-Hydro v5.0.1
+
+### Bug fixes
+- Gridded routing lake inflows were not preserved in restarts, therefore solution to the level-pool scheme on intial timestep after model restart had slightly different initial conditions. This was fixed by preserving last timestep lake inflows in the restart files.
+- The lake level-pool scheme had a number of internal bugs fixed, which should improve lake level and outflow behavior.
+
 # WRF-Hydro v5.0.0
 
 ## High-Level Highlights:

--- a/trunk/NDHMS/Routing/module_channel_routing.F
+++ b/trunk/NDHMS/Routing/module_channel_routing.F
@@ -80,7 +80,7 @@ real, intent(IN)    :: wl      ! weir length (m)
 real, intent(IN)    :: oe      ! orifice elevation
 real, intent(IN)    :: oc      ! orifice coeff.
 real, intent(IN)    :: oa      ! orifice area (m^2)
-real, intent(IN)    :: maxh    ! max depth of reservoir before overtop (m)                     
+real, intent(IN)    :: maxh    ! max depth of reservoir before overtop (m)
 integer, intent(IN) :: ln      ! lake number
 
 !!DJG Add lake option switch here...move up to namelist in future versions...
@@ -91,9 +91,10 @@ real    :: Htmp                ! Temporary assign of incoming lake el. (m)
 real :: sap                    ! local surface area values
 real :: discharge              ! storage discharge m^3/s
 real :: tmp1, tmp2
-real :: dh, dh1, dh2, dh3      ! height function and 3 order RK
-real :: It, Itdt_3, Itdt_2_3
+real :: dh, dh1, dh2, dh3      ! Depth in weir, and height function for 3 order RK
+real :: It, Itdt_3, Itdt_2_3   ! inflow hydrographs
 real :: maxWeirDepth           !maximum capacity of weir
+!real :: hdiff_vol, qdiff_vol   ! water balance check variables
 !! ----------------------------  subroutine body: from chow, mad mays. pg. 252
 !! -- determine from inflow hydrograph
 
@@ -102,162 +103,144 @@ real :: maxWeirDepth           !maximum capacity of weir
 !future versions...
 LAKE_OPT = 2
 Htmp = H   !temporary set of incoming lake water elevation...
-
+!hdiff_vol = 0.0
+!qdiff_vol = 0.0
 
 !!DJG IF-block for lake model option  1 - outflow=inflow, 2 - Chow et al level
 !pool, .....
 if (LAKE_OPT.eq.1) then     ! If-block for simple pass through scheme....
-   
-   qo1 = qi1                 ! Set outflow equal to inflow at current time      
+
+   qo1 = qi1                 ! Set outflow equal to inflow at current time
    H = Htmp                  ! Set new lake water elevation to incoming lake el.
-   
+
 else if (LAKE_OPT.eq.2) then   ! If-block for Chow et al level pool scheme
-   
+
    It = qi0
-   Itdt_3   = (qi0 + (qi1 + ql))/3
-   Itdt_2_3 = (qi0 + (qi1 + ql))/3 + Itdt_3
-   maxWeirDepth =  maxh - we   
-   
+   Itdt_3   = qi0 + ((qi1 + ql - qi0) * 0.33)
+   Itdt_2_3 = qi0 + ((qi1 + ql - qi0) * 0.67)
+   maxWeirDepth =  maxh - we
+
+   !assume vertically walled reservoir
+   !remove this when moving to a variable head area volume
+   sap = ar * 1.0E6
+
    !-- determine Q(dh) from elevation-discharge relationship
    !-- and dh1
    dh = H - we
-   if (dh .gt. maxWeirDepth) then 
-      dh = maxWeirDepth 
+   if (dh .gt. maxWeirDepth) then
+      dh = maxWeirDepth
    endif
-   
+
    if (dh .gt. 0.0 ) then              !! orifice and overtop discharge
-      tmp1 = oc * oa * sqrt(2 * 9.81 * ( H - oe ) )
-      tmp2 = wc * wl * (dh ** 2./3.)
+      tmp1 = oc * oa * sqrt(2. * 9.81 * ( H - oe ) )
+      tmp2 = wc * wl * (dh ** (3./2.))
       discharge = tmp1 + tmp2
-      
-      if (H .gt. 0.0) then
-         sap = (ar * 1.0E6 ) * (1 + (H - we) / H)
-      else
-         sap  = 0.0
-      endif
-      
    else if ( H .gt. oe ) then     !! only orifice flow,not full
-      discharge = oc * oa * sqrt(2 * 9.81 * ( H - oe ) )
-      sap = ar * 1.0E6
+      discharge = oc * oa * sqrt(2. * 9.81 * ( H - oe ) )
    else
       discharge = 0.0
-      sap = ar * 1.0E6
    endif
-   
-   if (sap .gt. 0) then 
+
+   if (sap .gt. 0) then
       dh1 = ((It - discharge)/sap)*dt
    else
       dh1 = 0.0
    endif
-   
+
    !-- determine Q(H + dh1/3) from elevation-discharge relationship
    !-- dh2
    dh = (H+dh1/3) - we
-   if (dh .gt. maxWeirDepth) then 
-      dh = maxWeirDepth 
+   if (dh .gt. maxWeirDepth) then
+      dh = maxWeirDepth
    endif
-   
+
    if (dh .gt. 0.0 ) then              !! orifice and overtop discharge
-      tmp1 = oc * oa * sqrt(2 * 9.81 * ( H - oe ) )
-      tmp2 = wc * wl * (dh ** 2./3.) 
+      tmp1 = oc * oa * sqrt(2. * 9.81 * ( (H+dh1/3.) - oe ) )
+      tmp2 = wc * wl * (dh ** (3./2.))
       discharge = tmp1 + tmp2
-      
-      if (H .gt. 0.0) then 
-         sap = (ar * 1.0E6 ) * (1 + (H - we) / H)
-      else
-         sap  = 0.0
-      endif
-      
-   else if ( H .gt. oe ) then     !! only orifice flow,not full
-      discharge = oc * oa * sqrt(2 * 9.81 * ( H - oe ) )
-      sap = ar * 1.0E6
+   else if ( (H+dh1/3) .gt. oe ) then     !! only orifice flow,not full
+      discharge = oc * oa * sqrt(2. * 9.81 * ( (H+dh1/3.) - oe ) )
    else
       discharge = 0.0
-      sap = ar * 1.0E6
    endif
-   
-   if (sap .gt. 0.0) then 
+
+   if (sap .gt. 0.0) then
       dh2 = ((Itdt_3 - discharge)/sap)*dt
    else
       dh2 = 0.0
    endif
-   
+
    !-- determine Q(H + 2/3 dh2) from elevation-discharge relationship
    !-- dh3
    dh = (H + (0.667*dh2)) - we
-   if (dh .gt. maxWeirDepth) then 
-      dh = maxWeirDepth 
+   if (dh .gt. maxWeirDepth) then
+      dh = maxWeirDepth
    endif
-   
+
    if (dh .gt. 0.0 ) then              !! orifice and overtop discharge
-      tmp1 = oc * oa * sqrt(2 * 9.81 * ( H - oe ) )
-      tmp2 = wc * wl * (dh ** 2./3.) 
+      tmp1 = oc * oa * sqrt(2. * 9.81 * ( (H+dh2*0.667) - oe ) )
+      tmp2 = wc * wl * (dh ** (3./2.))
       discharge = tmp1 + tmp2
-      
-      if (H .gt. 0.0) then
-         sap = (ar * 1.0E6 ) * (1 + (H - we) / H)
-      else
-         sap = 0.0
-      endif
-      
-   else if ( H .gt. oe ) then     !! only orifice flow,not full
-      discharge = oc * oa * sqrt(2 * 9.81 * ( H - oe ) )
-      sap = ar * 1.0E6
+   else if ( (H+dh2*0.667) .gt. oe ) then     !! only orifice flow,not full
+      discharge = oc * oa * sqrt(2. * 9.81 * ( (H+dh2*0.667) - oe ) )
    else
       discharge = 0.0
-      sap = ar * 1.0E6
    endif
-   
-   if (sap .gt. 0.0) then 
+
+   if (sap .gt. 0.0) then
       dh3 = ((Itdt_2_3 - discharge)/sap)*dt
    else
       dh3 = 0.0
    endif
-    
+
    !-- determine dh and H
    dh = (dh1/4.) + (0.75*dh3)
    H = H + dh
-   
+
    !-- compute final discharge
    dh = H - we
-   if (dh .gt. maxWeirDepth) then 
-      dh = maxWeirDepth 
+   if (dh .gt. maxWeirDepth) then
+      dh = maxWeirDepth
    endif
    if (dh .gt. 0.0 ) then              !! orifice and overtop discharge
-      tmp1 = oc * oa * sqrt(2 * 9.81 * ( H - oe ) )
-      tmp2 = wc * wl * (dh ** 2./3.)
+      tmp1 = oc * oa * sqrt(2. * 9.81 * ( H - oe ) )
+      tmp2 = wc * wl * (dh ** (3./2.))
       discharge = tmp1 + tmp2
-      
-      if (H .gt. 0.0) then 
-         sap = (ar * 1.0E6 ) * (1 + (H - we) / H)
-      else
-         sap = 0.0
-      endif
-      
    else if ( H .gt. oe ) then     !! only orifice flow,not full
-      discharge = oc * oa * sqrt(2 * 9.81 * ( H - oe ) )
-      sap = ar * 1.0E6
+      discharge = oc * oa * sqrt(2. * 9.81 * ( H - oe ) )
    else
       discharge = 0.0
-      sap = ar * 1.0E6
    endif
-   
+
    if(H .ge. maxh) then  ! overtop condition
       discharge = qi1
       H = maxh
    endif
-   
+
    qo1  = discharge  ! return the flow rate from reservoir
-   
+
+!#ifdef HYDRO_D
+!#ifndef NCEP_WCOSS
+!   ! Water balance check
+!   qdiff_vol = (qi1+ql-qo1)*dt !m3
+!   hdiff_vol = (H-Htmp)*sap    !m3
+!22 format(f8.4,2x,f8.4,2x,f8.4,2x,f8.4,2x,f8.4,2x,f6.0,2x,f20.1,2x,f20.1)
+!   open (unit=67, &
+!     file='lake_massbalance_out.txt', status='unknown',position='append')
+!   write(67,22) Htmp, H, qi1, ql, qo1, dt, qdiff_vol, hdiff_vol
+!   close(67)
+!#endif
+!#endif
+
 23 format('botof H dh orf wr Q',f8.4,2x,f8.4,2x,f8.3,2x,f8.3,2x,f8.2)
 24 format('ofonl H dh sap Q ',f8.4,2x,f8.4,2x,f8.0,2x,f8.2)
-   
-   
+
+
 else   ! ELSE for LAKE_OPT....
 endif  ! ENDIF for LAKE_OPT....
 
 return
- 
+
 ! ----------------------------------------------------------------
 end subroutine LEVELPOOL
 ! ----------------------------------------------------------------


### PR DESCRIPTION
Bulk update of levelpool routine bug fixes from master, including: fixes to exponent typos (thanks, Medhi!), corrections for uniform lake area (thanks, Medhi!), and updates to the Runge-Kutta solution (thanks, Yates!).

Notes:
1) Answer changes in channel and lake vars expected when lakes are active.
2) No answer changes expected when lakes are not active.
3) These changes were previously reviewed and approved in master PR 161: https://github.com/NCAR/wrf_hydro_nwm_public/pull/161
