### PR TITLE
Update .gitignore to ignore Run directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ trunk/NDHMS/macros
 trunk/NDHMS/HRLDAS/user_build_options
 *exe
 /.project
-trunk/NDHMS/Run/*.exe
+trunk/NDHMS/Run
 trunk/NDHMS/Makefile.comm
 trunk/NDHMS/Land_models/NoahMP/user_build_options
 trunk/NDHMS/Land_models/Noah/user_build_options


### PR DESCRIPTION
The Run directory is a compilation artifact and should not be version controlled