### PR TITLE
v5.1.0: NWM v2.0 Metadata Changes.

### DIFF
--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -839,8 +839,8 @@ subroutine output_chrt_NWM(domainId)
             ! Extract valid range into a 1D array for placement. 
             varRange(1) = fileMeta%validMinComp(iTmp)
             varRange(2) = fileMeta%validMaxComp(iTmp)
-            varRangeReal(1) = fileMeta%validMinReal(iTmp)
-            varRangeReal(2) = fileMeta%validMaxReal(iTmp)
+            varRangeReal(1) = real(fileMeta%validMinReal(iTmp))
+            varRangeReal(2) = real(fileMeta%validMaxReal(iTmp))
 
             ! Establish a compression level for the variables. For now we are using a
             ! compression level of 2. In addition, we are choosing to turn the shuffle
@@ -1287,8 +1287,12 @@ subroutine output_NoahMP_NWM(outDir,iGrid,output_timestep,itime,startdate,date,i
          call nwmCheck(diagFlag,iret,'ERROR: Unable to define snow_layers dimension')
          iret = nf90_def_dim(ftnNoahMP,'reference_time',1,dimId(6))
          call nwmCheck(diagFlag,iret,'ERROR: Unable to define reference_time dimension')
-         iret = nf90_def_dim(ftnNoahMP,'vis_nir',fileMeta%numSpectrumBands,dimId(7))
-         call nwmCheck(diagFlag,iret,'ERROR: Unable to define vis_nir dimension')
+         ! Only create vis_nir if we are outputting the two snow albedo variables. 
+         ! Otherwise these are unecessary dimensions.
+         if ((fileMeta%outFlag(96) .eq. 1) .or. (fileMeta%outFlag(96) .eq. 1)) then
+            iret = nf90_def_dim(ftnNoahMP,'vis_nir',fileMeta%numSpectrumBands,dimId(7))
+            call nwmCheck(diagFlag,iret,'ERROR: Unable to define vis_nir dimension')
+         endif
 
          ! Create and populate reference_time and time variables.
          iret = nf90_def_var(ftnNoahMP,"time",nf90_int,dimId(1),timeId)
@@ -1392,8 +1396,8 @@ subroutine output_NoahMP_NWM(outDir,iGrid,output_timestep,itime,startdate,date,i
                ! Extract valid range into a 1D array for placement.
                varRange(1) = fileMeta%validMinComp(iTmp)
                varRange(2) = fileMeta%validMaxComp(iTmp)
-               varRangeReal(1) = fileMeta%validMinReal(iTmp)
-               varRangeReal(2) = fileMeta%validMaxReal(iTmp)
+               varRangeReal(1) = real(fileMeta%validMinReal(iTmp))
+               varRangeReal(2) = real(fileMeta%validMaxReal(iTmp))
 
                ! Establish a compression level for the variables. For now we are using a
                ! compression level of 2. In addition, we are choosing to turn the shuffle
@@ -1868,8 +1872,12 @@ subroutine output_rt_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to define y dimension')
       iret = nf90_def_dim(ftn,'reference_time',1,dimId(4))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to define reference_time dimension') 
-      iret = nf90_def_dim(ftn,'soil_layers_stag',fileMeta%numSoilLayers,dimId(5))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to define soil_layers_stag dimension')
+      ! Only create soil layers stag dimension if we are outputting to the soil moisture grid. 
+      ! Otherwise this creates unused dimensions. 
+      if (fileMeta%outFlag(5) .eq. 1) then
+         iret = nf90_def_dim(ftn,'soil_layers_stag',fileMeta%numSoilLayers,dimId(5))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to define soil_layers_stag dimension')
+      endif
 
       ! Create and populate reference_time and time variables.
       iret = nf90_def_var(ftn,"time",nf90_int,dimId(1),timeId)
@@ -1967,8 +1975,8 @@ subroutine output_rt_NWM(domainId,iGrid)
             ! Extract valid range into a 1D array for placement.
             varRange(1) = fileMeta%validMinComp(iTmp)
             varRange(2) = fileMeta%validMaxComp(iTmp)
-            varRangeReal(1) = fileMeta%validMinReal(iTmp)
-            varRangeReal(2) = fileMeta%validMaxReal(iTmp)
+            varRangeReal(1) = real(fileMeta%validMinReal(iTmp))
+            varRangeReal(2) = real(fileMeta%validMaxReal(iTmp))
 
             ! Establish a compression level for the variables. For now we are using a
             ! compression level of 2. In addition, we are choosing to turn the shuffle
@@ -2698,8 +2706,8 @@ subroutine output_lakes_NWM(domainId,iGrid)
             ! Extract valid range into a 1D array for placement. 
             varRange(1) = fileMeta%validMinComp(iTmp)
             varRange(2) = fileMeta%validMaxComp(iTmp)
-            varRangeReal(1) = fileMeta%validMinReal(iTmp)
-            varRangeReal(2) = fileMeta%validMaxReal(iTmp)
+            varRangeReal(1) = real(fileMeta%validMinReal(iTmp))
+            varRangeReal(2) = real(fileMeta%validMaxReal(iTmp))
 
             ! Establish a compression level for the variables. For now we are using a
             ! compression level of 2. In addition, we are choosing to turn the shuffle
@@ -3199,8 +3207,8 @@ subroutine output_chrtout_grd_NWM(domainId,iGrid)
             ! Extract valid range into a 1D array for placement.
             varRange(1) = fileMeta%validMinComp(iTmp)
             varRange(2) = fileMeta%validMaxComp(iTmp)
-            varRangeReal(1) = fileMeta%validMinReal(iTmp)
-            varRangeReal(2) = fileMeta%validMaxReal(iTmp)
+            varRangeReal(1) = real(fileMeta%validMinReal(iTmp))
+            varRangeReal(2) = real(fileMeta%validMaxReal(iTmp))
 
             ! Establish a compression level for the variables. For now we are
             ! using a
@@ -4683,8 +4691,8 @@ subroutine output_chanObs_NWM(domainId)
             ! Extract valid range into a 1D array for placement. 
             varRange(1) = fileMeta%validMinComp(iTmp)
             varRange(2) = fileMeta%validMaxComp(iTmp)
-            varRangeReal(1) = fileMeta%validMinReal(iTmp)
-            varRangeReal(2) = fileMeta%validMaxReal(iTmp)
+            varRangeReal(1) = real(fileMeta%validMinReal(iTmp))
+            varRangeReal(2) = real(fileMeta%validMaxReal(iTmp))
 
             ! Establish a compression level for the variables. For now we are
             ! using a
@@ -5202,8 +5210,8 @@ subroutine output_gw_NWM(domainId,iGrid)
             ! Extract valid range into a 1D array for placement. 
             varRange(1) = fileMeta%validMinComp(iTmp)
             varRange(2) = fileMeta%validMaxComp(iTmp)
-            varRangeReal(1) = fileMeta%validMinReal(iTmp)
-            varRangeReal(2) = fileMeta%validMaxReal(iTmp)
+            varRangeReal(1) = real(fileMeta%validMinReal(iTmp))
+            varRangeReal(2) = real(fileMeta%validMaxReal(iTmp))
 
             ! Establish a compression level for the variables. For now we are using a
             ! compression level of 2. In addition, we are choosing to turn the shuffle

--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -839,8 +839,8 @@ subroutine output_chrt_NWM(domainId)
             ! Extract valid range into a 1D array for placement. 
             varRange(1) = fileMeta%validMinComp(iTmp)
             varRange(2) = fileMeta%validMaxComp(iTmp)
-            varRangeReal(1) = real(fileMeta%validMinReal(iTmp))
-            varRangeReal(2) = real(fileMeta%validMaxReal(iTmp))
+            varRangeReal(1) = real(fileMeta%validMinDbl(iTmp))
+            varRangeReal(2) = real(fileMeta%validMaxDbl(iTmp))
 
             ! Establish a compression level for the variables. For now we are using a
             ! compression level of 2. In addition, we are choosing to turn the shuffle
@@ -1396,8 +1396,8 @@ subroutine output_NoahMP_NWM(outDir,iGrid,output_timestep,itime,startdate,date,i
                ! Extract valid range into a 1D array for placement.
                varRange(1) = fileMeta%validMinComp(iTmp)
                varRange(2) = fileMeta%validMaxComp(iTmp)
-               varRangeReal(1) = real(fileMeta%validMinReal(iTmp))
-               varRangeReal(2) = real(fileMeta%validMaxReal(iTmp))
+               varRangeReal(1) = real(fileMeta%validMinDbl(iTmp))
+               varRangeReal(2) = real(fileMeta%validMaxDbl(iTmp))
 
                ! Establish a compression level for the variables. For now we are using a
                ! compression level of 2. In addition, we are choosing to turn the shuffle
@@ -1975,8 +1975,8 @@ subroutine output_rt_NWM(domainId,iGrid)
             ! Extract valid range into a 1D array for placement.
             varRange(1) = fileMeta%validMinComp(iTmp)
             varRange(2) = fileMeta%validMaxComp(iTmp)
-            varRangeReal(1) = real(fileMeta%validMinReal(iTmp))
-            varRangeReal(2) = real(fileMeta%validMaxReal(iTmp))
+            varRangeReal(1) = real(fileMeta%validMinDbl(iTmp))
+            varRangeReal(2) = real(fileMeta%validMaxDbl(iTmp))
 
             ! Establish a compression level for the variables. For now we are using a
             ! compression level of 2. In addition, we are choosing to turn the shuffle
@@ -2142,10 +2142,10 @@ subroutine output_rt_NWM(domainId,iGrid)
 
                   ! Run a quick gross check on values to ensure they aren't outside our
                   ! defined limits.
-                  !if(varRealTmp .lt. fileMeta%validMinReal(iTmp2)) then
+                  !if(varRealTmp .lt. fileMeta%validMinDbl(iTmp2)) then
                   !   varRealTmp = fileMeta%fillReal(iTmp2)
                   !endif
-                  !if(varRealTmp .gt. fileMeta%validMaxReal(iTmp2)) then
+                  !if(varRealTmp .gt. fileMeta%validMaxDbl(iTmp2)) then
                   !   varRealTmp = fileMeta%fillReal(iTmp2)
                   !endif
                   if(varRealTmp .ne. varRealTmp) then
@@ -2706,8 +2706,8 @@ subroutine output_lakes_NWM(domainId,iGrid)
             ! Extract valid range into a 1D array for placement. 
             varRange(1) = fileMeta%validMinComp(iTmp)
             varRange(2) = fileMeta%validMaxComp(iTmp)
-            varRangeReal(1) = real(fileMeta%validMinReal(iTmp))
-            varRangeReal(2) = real(fileMeta%validMaxReal(iTmp))
+            varRangeReal(1) = real(fileMeta%validMinDbl(iTmp))
+            varRangeReal(2) = real(fileMeta%validMaxDbl(iTmp))
 
             ! Establish a compression level for the variables. For now we are using a
             ! compression level of 2. In addition, we are choosing to turn the shuffle
@@ -3207,8 +3207,8 @@ subroutine output_chrtout_grd_NWM(domainId,iGrid)
             ! Extract valid range into a 1D array for placement.
             varRange(1) = fileMeta%validMinComp(iTmp)
             varRange(2) = fileMeta%validMaxComp(iTmp)
-            varRangeReal(1) = real(fileMeta%validMinReal(iTmp))
-            varRangeReal(2) = real(fileMeta%validMaxReal(iTmp))
+            varRangeReal(1) = real(fileMeta%validMinDbl(iTmp))
+            varRangeReal(2) = real(fileMeta%validMaxDbl(iTmp))
 
             ! Establish a compression level for the variables. For now we are
             ! using a
@@ -3647,8 +3647,8 @@ subroutine output_lsmOut_NWM(domainId)
             call nwmCheck(diagFlag,iret,"ERROR: Unable to create variable: "//trim(fileMeta%varNames(iTmp)))
 
             ! Extract valid range into a 1D array for placement.
-            varRange(1) = fileMeta%validMinReal(iTmp)
-            varRange(2) = fileMeta%validMaxReal(iTmp)
+            varRange(1) = fileMeta%validMinDbl(iTmp)
+            varRange(2) = fileMeta%validMaxDbl(iTmp)
 
             ! Establish a compression level for the variables. For now we are using a
             ! compression level of 2. In addition, we are choosing to turn the shuffle
@@ -4691,8 +4691,8 @@ subroutine output_chanObs_NWM(domainId)
             ! Extract valid range into a 1D array for placement. 
             varRange(1) = fileMeta%validMinComp(iTmp)
             varRange(2) = fileMeta%validMaxComp(iTmp)
-            varRangeReal(1) = real(fileMeta%validMinReal(iTmp))
-            varRangeReal(2) = real(fileMeta%validMaxReal(iTmp))
+            varRangeReal(1) = real(fileMeta%validMinDbl(iTmp))
+            varRangeReal(2) = real(fileMeta%validMaxDbl(iTmp))
 
             ! Establish a compression level for the variables. For now we are
             ! using a
@@ -5210,8 +5210,8 @@ subroutine output_gw_NWM(domainId,iGrid)
             ! Extract valid range into a 1D array for placement. 
             varRange(1) = fileMeta%validMinComp(iTmp)
             varRange(2) = fileMeta%validMaxComp(iTmp)
-            varRangeReal(1) = real(fileMeta%validMinReal(iTmp))
-            varRangeReal(2) = real(fileMeta%validMaxReal(iTmp))
+            varRangeReal(1) = real(fileMeta%validMinDbl(iTmp))
+            varRangeReal(2) = real(fileMeta%validMaxDbl(iTmp))
 
             ! Establish a compression level for the variables. For now we are using a
             ! compression level of 2. In addition, we are choosing to turn the shuffle

--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -36,6 +36,8 @@ public :: lsmMeta ! Public metadata for LSMOUT output.
 public :: chObsMeta ! Public CHANOBS metadata for NWM output.
 public :: gwMeta ! Public groundwater metadata.
 
+real*8 :: one_real = 1.0d0
+
 ! Establish types for each output type
 type chrtMeta
    ! Variable names
@@ -629,7 +631,6 @@ subroutine initChrtDict(chrtOutDict,diagFlag,procId)
    ! Local variables
    integer :: ftnMeta,iret
    integer :: projVarId
-   real :: one_real = 1.0d0
  
    chrtOutDict%modelNdv = -9.E15
    ! CHRTOUT FILES
@@ -786,7 +787,6 @@ subroutine initLdasDict(ldasOutDict,procId,diagFlag)
    character(len=512) :: tmpAttName
    integer :: xtypeTmp
    integer :: tmpLen
-   real :: one_real = 1.0d0
 
    ! LDASOUT FILES
 
@@ -1254,7 +1254,6 @@ subroutine initRtDomainDict(rtDomainDict,procId,diagFlag)
    character(len=512) :: tmpAttName
    integer :: xtypeTmp
    integer :: tmpLen
-   real :: one_real = 1.0d0
    ! RT_DOMAIN files
 
    rtDomainDict%modelNdv = -9.E15
@@ -1577,7 +1576,6 @@ subroutine initLakeDict(lakeOutDict,procId,diagFlag)
    ! Local variables
    integer :: ftnMeta,iret
    integer :: projVarId
-   real :: one_real = 1.0d0
 
    lakeOutDict%modelNdv = -9.E15
    ! LAKE FILES
@@ -1703,7 +1701,6 @@ subroutine initChrtGrdDict(chrtGrdDict,procId,diagFlag)
    character(len=512) :: tmpAttName
    integer :: xtypeTmp
    integer :: tmpLen
-   real :: one_real = 1.0d0
    !CHRTOUT_GRID files
 
    chrtGrdDict%modelNdv = -9.E15
@@ -2027,7 +2024,6 @@ subroutine initLsmOutDict(lsmOutDict,procId,diagFlag)
    character(len=512) :: tmpAttName
    integer :: xtypeTmp
    integer :: tmpLen
-   real :: one_real = 1.0d0
    !LSMOUT files
 
    lsmOutDict%modelNdv = 9.9692099683868690E36
@@ -2324,7 +2320,6 @@ subroutine initChanObsDict(chObsDict,diagFlag,procId)
    ! Local variables
    integer :: ftnMeta, iret
    integer :: projVarId
-   real :: one_real = 1.0d0
 
    chObsDict%modelNdv = -9.E15
    !CHANOBS FILES
@@ -2440,7 +2435,6 @@ subroutine initGwDict(gwOutDict)
 
    type(gwMeta), intent(inout) :: gwOutDict
 
-   real :: one_real = 1.0d0
 
    gwOutDict%modelNdv = -9.E15
 

--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -122,7 +122,7 @@ type ldasMeta
    real, dimension(numLdasVars) :: scaleFactor ! scale_factor values used for each
                                                   ! variable to converte from
                                                   ! real to
-                                                  ! integer.
+                                                  ! integer
    real, dimension(numLdasVars)             :: addOffset   ! add_offset values for each variable.
    character (len=128), dimension(numLdasVars) :: longName  ! Long names for each variable.
    character (len=64), dimension(numLdasVars) :: units ! Units for each variable.
@@ -335,7 +335,7 @@ type chrtGrdMeta
    ! Output variable attributes
    real, dimension(numChGrdVars) :: scaleFactor ! scale_factor values for each
                                                 ! variable to convert from 
-                                                ! real to integer.
+                                                ! real to integer
    real, dimension(numChGrdVars) :: addOffset ! add_offset values for each variable.
    character (len=64), dimension(numChGrdVars) :: longName ! longname for each variable
    character (len=64), dimension(numChGrdVars) :: units ! Units for each variable.
@@ -409,7 +409,7 @@ type lsmMeta
    real, dimension(numLsmVars) :: scaleFactor ! scale_factor values used for each
                                                   ! variable to converte from
                                                   ! real to
-                                                  ! integer.
+                                                  ! integer
    real, dimension(numLsmVars)             :: addOffset   ! add_offset values for each variable.
    character (len=64), dimension(numLsmVars) :: longName  ! Long names for each variable.
    character (len=64), dimension(numLsmVars) :: units ! Units for each variable.
@@ -629,6 +629,7 @@ subroutine initChrtDict(chrtOutDict,diagFlag,procId)
    ! Local variables
    integer :: ftnMeta,iret
    integer :: projVarId
+   real :: one_real = 1.0d0
  
    chrtOutDict%modelNdv = -9.E15
    ! CHRTOUT FILES
@@ -754,16 +755,16 @@ subroutine initChrtDict(chrtOutDict,diagFlag,procId)
    do i=1,numChVars
       chrtOutDict%fillComp(i) = &
            nint((chrtOutDict%fillReal(i)     + chrtOutDict%addOffset(i)), 8) * &
-           nint(1.0 / chrtOutDict%scaleFactor(i), 8)
+           nint(one_real / chrtOutDict%scaleFactor(i), 8)
       chrtOutDict%missingComp(i) = &
            nint((chrtOutDict%missingReal(i)  + chrtOutDict%addOffset(i)), 8) * &
-           nint(1.0 / chrtOutDict%scaleFactor(i), 8)
+           nint(one_real / chrtOutDict%scaleFactor(i), 8)
       chrtOutDict%validMinComp(i) = &
            nint((chrtOutDict%validMinReal(i) + chrtOutDict%addOffset(i)) * &
-                nint(1.0 / chrtOutDict%scaleFactor(i), 8), 8)
+                nint(one_real / chrtOutDict%scaleFactor(i), 8), 8)
       chrtOutDict%validMaxComp(i) = &
            nint((chrtOutDict%validMaxReal(i) + chrtOutDict%addOffset(i)) * &
-                nint(1.0 / chrtOutDict%scaleFactor(i), 8), 8)
+                nint(one_real / chrtOutDict%scaleFactor(i), 8), 8)
    end do
 end subroutine initChrtDict
 
@@ -785,6 +786,7 @@ subroutine initLdasDict(ldasOutDict,procId,diagFlag)
    character(len=512) :: tmpAttName
    integer :: xtypeTmp
    integer :: tmpLen
+   real :: one_real = 1.0d0
 
    ! LDASOUT FILES
 
@@ -1219,16 +1221,16 @@ subroutine initLdasDict(ldasOutDict,procId,diagFlag)
    do i=1,numLdasVars
       ldasOutDict%fillComp(i) = &
            nint((ldasOutDict%fillReal(i)     + ldasOutDict%addOffset(i)), 8) * &
-           nint(1.0 / ldasOutDict%scaleFactor(i), 8)
+           nint(one_real / ldasOutDict%scaleFactor(i), 8)
       ldasOutDict%missingComp(i) = &
            nint((ldasOutDict%missingReal(i)  + ldasOutDict%addOffset(i)), 8) * &
-           nint(1.0 / ldasOutDict%scaleFactor(i), 8)
+           nint(one_real / ldasOutDict%scaleFactor(i), 8)
       ldasOutDict%validMinComp(i) = &
            nint((ldasOutDict%validMinReal(i) + ldasOutDict%addOffset(i)) * &
-                nint(1.0 / ldasOutDict%scaleFactor(i), 8), 8)
+                nint(one_real / ldasOutDict%scaleFactor(i), 8), 8)
       ldasOutDict%validMaxComp(i) = &
            nint((ldasOutDict%validMaxReal(i) + ldasOutDict%addOffset(i)) * &
-                nint(1.0 / ldasOutDict%scaleFactor(i), 8), 8)
+                nint(one_real / ldasOutDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initLdasDict
@@ -1252,6 +1254,7 @@ subroutine initRtDomainDict(rtDomainDict,procId,diagFlag)
    character(len=512) :: tmpAttName
    integer :: xtypeTmp
    integer :: tmpLen
+   real :: one_real = 1.0d0
    ! RT_DOMAIN files
 
    rtDomainDict%modelNdv = -9.E15
@@ -1548,16 +1551,16 @@ subroutine initRtDomainDict(rtDomainDict,procId,diagFlag)
    do i=1,numRtDomainVars
       rtDomainDict%fillComp(i) = &
            nint((rtDomainDict%fillReal(i)     + rtDomainDict%addOffset(i)), 8) * &
-           nint(1.0 / rtDomainDict%scaleFactor(i), 8)
+           nint(one_real / rtDomainDict%scaleFactor(i), 8)
       rtDomainDict%missingComp(i) = &
            nint((rtDomainDict%missingReal(i)  + rtDomainDict%addOffset(i)), 8) * &
-           nint(1.0 / rtDomainDict%scaleFactor(i), 8)
+           nint(one_real / rtDomainDict%scaleFactor(i), 8)
       rtDomainDict%validMinComp(i) = &
            nint((rtDomainDict%validMinReal(i) + rtDomainDict%addOffset(i)) * &
-                nint(1.0 / rtDomainDict%scaleFactor(i), 8), 8)
+                nint(one_real / rtDomainDict%scaleFactor(i), 8), 8)
       rtDomainDict%validMaxComp(i) = &
            nint((rtDomainDict%validMaxReal(i) + rtDomainDict%addOffset(i)) * &
-                nint(1.0 / rtDomainDict%scaleFactor(i), 8), 8)
+                nint(one_real / rtDomainDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initRtDomainDict
@@ -1574,6 +1577,7 @@ subroutine initLakeDict(lakeOutDict,procId,diagFlag)
    ! Local variables
    integer :: ftnMeta,iret
    integer :: projVarId
+   real :: one_real = 1.0d0
 
    lakeOutDict%modelNdv = -9.E15
    ! LAKE FILES
@@ -1666,16 +1670,16 @@ subroutine initLakeDict(lakeOutDict,procId,diagFlag)
    do i=1,numLakeVars
       lakeOutDict%fillComp(i) = &
            nint((lakeOutDict%fillReal(i)     + lakeOutDict%addOffset(i)), 8) * &
-           nint(1.0 / lakeOutDict%scaleFactor(i), 8)
+           nint(one_real / lakeOutDict%scaleFactor(i), 8)
       lakeOutDict%missingComp(i) = &
            nint((lakeOutDict%missingReal(i)  + lakeOutDict%addOffset(i)), 8) * &
-           nint(1.0 / lakeOutDict%scaleFactor(i), 8)
+           nint(one_real / lakeOutDict%scaleFactor(i), 8)
       lakeOutDict%validMinComp(i) = &
            nint((lakeOutDict%validMinReal(i) + lakeOutDict%addOffset(i)) * &
-                nint(1.0 / lakeOutDict%scaleFactor(i), 8), 8)
+                nint(one_real / lakeOutDict%scaleFactor(i), 8), 8)
       lakeOutDict%validMaxComp(i) = &
            nint((lakeOutDict%validMaxReal(i) + lakeOutDict%addOffset(i)) * &
-                nint(1.0 / lakeOutDict%scaleFactor(i), 8), 8)
+                nint(one_real / lakeOutDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initLakeDict
@@ -1699,6 +1703,7 @@ subroutine initChrtGrdDict(chrtGrdDict,procId,diagFlag)
    character(len=512) :: tmpAttName
    integer :: xtypeTmp
    integer :: tmpLen
+   real :: one_real = 1.0d0
    !CHRTOUT_GRID files
 
    chrtGrdDict%modelNdv = -9.E15
@@ -1990,16 +1995,16 @@ subroutine initChrtGrdDict(chrtGrdDict,procId,diagFlag)
    do i=1,numChGrdVars
       chrtGrdDict%fillComp(i) = &
            nint((chrtGrdDict%fillReal(i)     + chrtGrdDict%addOffset(i)), 8) * &
-           nint(1.0 / chrtGrdDict%scaleFactor(i), 8)
+           nint(one_real / chrtGrdDict%scaleFactor(i), 8)
       chrtGrdDict%missingComp(i) = &
            nint((chrtGrdDict%missingReal(i)  + chrtGrdDict%addOffset(i)), 8) * &
-           nint(1.0 / chrtGrdDict%scaleFactor(i), 8)
+           nint(one_real / chrtGrdDict%scaleFactor(i), 8)
       chrtGrdDict%validMinComp(i) = &
            nint((chrtGrdDict%validMinReal(i) + chrtGrdDict%addOffset(i)) * &
-                nint(1.0 / chrtGrdDict%scaleFactor(i), 8), 8)
+                nint(one_real / chrtGrdDict%scaleFactor(i), 8), 8)
       chrtGrdDict%validMaxComp(i) = &
            nint((chrtGrdDict%validMaxReal(i) + chrtGrdDict%addOffset(i)) * &
-                nint(1.0 / chrtGrdDict%scaleFactor(i), 8), 8)
+                nint(one_real / chrtGrdDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initChrtGrdDict
@@ -2022,6 +2027,7 @@ subroutine initLsmOutDict(lsmOutDict,procId,diagFlag)
    character(len=512) :: tmpAttName
    integer :: xtypeTmp
    integer :: tmpLen
+   real :: one_real = 1.0d0
    !LSMOUT files
 
    lsmOutDict%modelNdv = 9.9692099683868690E36
@@ -2292,16 +2298,16 @@ subroutine initLsmOutDict(lsmOutDict,procId,diagFlag)
    do i=1,numLsmVars
       lsmOutDict%fillComp(i) = &
            nint((lsmOutDict%fillReal(i)     + lsmOutDict%addOffset(i)), 8) * &
-           nint(1.0 / lsmOutDict%scaleFactor(i), 8)
+           nint(one_real / lsmOutDict%scaleFactor(i), 8)
       lsmOutDict%missingComp(i) = &
            nint((lsmOutDict%missingReal(i)  + lsmOutDict%addOffset(i)), 8) * &
-           nint(1.0 / lsmOutDict%scaleFactor(i), 8)
+           nint(one_real / lsmOutDict%scaleFactor(i), 8)
       lsmOutDict%validMinComp(i) = &
            nint((lsmOutDict%validMinReal(i) + lsmOutDict%addOffset(i)) * &
-                nint(1.0 / lsmOutDict%scaleFactor(i), 8), 8)
+                nint(one_real / lsmOutDict%scaleFactor(i), 8), 8)
       lsmOutDict%validMaxComp(i) = &
            nint((lsmOutDict%validMaxReal(i) + lsmOutDict%addOffset(i)) * &
-                nint(1.0 / lsmOutDict%scaleFactor(i), 8), 8)
+                nint(one_real / lsmOutDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initLsmOutDict
@@ -2318,6 +2324,7 @@ subroutine initChanObsDict(chObsDict,diagFlag,procId)
    ! Local variables
    integer :: ftnMeta, iret
    integer :: projVarId
+   real :: one_real = 1.0d0
 
    chObsDict%modelNdv = -9.E15
    !CHANOBS FILES
@@ -2414,16 +2421,16 @@ subroutine initChanObsDict(chObsDict,diagFlag,procId)
    do i=1,numChObsVars
       chObsDict%fillComp(i) = &
            nint((chObsDict%fillReal(i)     + chObsDict%addOffset(i)), 8) * &
-           nint(1.0 / chObsDict%scaleFactor(i), 8)
+           nint(one_real / chObsDict%scaleFactor(i), 8)
       chObsDict%missingComp(i) = &
            nint((chObsDict%missingReal(i)  + chObsDict%addOffset(i)), 8) * &
-           nint(1.0 / chObsDict%scaleFactor(i), 8)
+           nint(one_real / chObsDict%scaleFactor(i), 8)
       chObsDict%validMinComp(i) = &
            nint((chObsDict%validMinReal(i) + chObsDict%addOffset(i)) * &
-                nint(1.0 / chObsDict%scaleFactor(i), 8), 8)
+                nint(one_real / chObsDict%scaleFactor(i), 8), 8)
       chObsDict%validMaxComp(i) = &
            nint((chObsDict%validMaxReal(i) + chObsDict%addOffset(i)) * &
-                nint(1.0 / chObsDict%scaleFactor(i), 8), 8)
+                nint(one_real / chObsDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initChanObsDict
@@ -2432,6 +2439,8 @@ subroutine initGwDict(gwOutDict)
    implicit none
 
    type(gwMeta), intent(inout) :: gwOutDict
+
+   real :: one_real = 1.0d0
 
    gwOutDict%modelNdv = -9.E15
 
@@ -2489,16 +2498,16 @@ subroutine initGwDict(gwOutDict)
    do i=1,numGwVars
       gwOutDict%fillComp(i) = &
            nint((gwOutDict%fillReal(i)     + gwOutDict%addOffset(i)), 8) * &
-           nint(1.0 / gwOutDict%scaleFactor(i), 8)
+           nint(one_real / gwOutDict%scaleFactor(i), 8)
       gwOutDict%missingComp(i) = &
            nint((gwOutDict%missingReal(i)  + gwOutDict%addOffset(i)), 8) * &
-           nint(1.0 / gwOutDict%scaleFactor(i), 8)
+           nint(one_real / gwOutDict%scaleFactor(i), 8)
       gwOutDict%validMinComp(i) = &
            nint((gwOutDict%validMinReal(i) + gwOutDict%addOffset(i)) * &
-                nint(1.0 / gwOutDict%scaleFactor(i), 8), 8)
+                nint(one_real / gwOutDict%scaleFactor(i), 8), 8)
       gwOutDict%validMaxComp(i) = &
            nint((gwOutDict%validMaxReal(i) + gwOutDict%addOffset(i)) * &
-                nint(1.0 / gwOutDict%scaleFactor(i), 8), 8)
+                nint(one_real / gwOutDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initGwDict

--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -36,7 +36,7 @@ public :: lsmMeta ! Public metadata for LSMOUT output.
 public :: chObsMeta ! Public CHANOBS metadata for NWM output.
 public :: gwMeta ! Public groundwater metadata.
 
-real*8 :: one_real = 1.0d0
+real*8 :: one_dbl = 1.0d0
 
 ! Establish types for each output type
 type chrtMeta
@@ -55,8 +55,8 @@ type chrtMeta
    character (len=64), dimension(numChVars) :: coordNames ! Coordinate names for each variable. 
    integer*8, dimension(numChVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numChVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real*8, dimension(numChVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real*8, dimension(numChVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numChVars) :: validMinDbl ! Valid minimum (before conversion to integer)
+   real*8, dimension(numChVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
    integer*8, dimension(numChVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numChVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numChVars) :: fillReal ! Fill value (before conversion to integer)
@@ -131,8 +131,8 @@ type ldasMeta
    integer, dimension(numLdasVars) :: numLev ! Number of levels for each variable.
    integer*8, dimension(numLdasVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numLdasVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real*8, dimension(numLdasVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real*8, dimension(numLdasVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numLdasVars) :: validMinDbl ! Valid minimum (before conversion to integer)
+   real*8, dimension(numLdasVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
    integer*8, dimension(numLdasVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numLdasVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numLdasVars) :: fillReal ! Fill value (before conversion to integer)
@@ -204,8 +204,8 @@ type rtDomainMeta
    character (len=64), dimension(numRtDomainVars) :: coordNames ! Coordinate names for each variable. 
    integer*8, dimension(numRtDomainVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numRtDomainVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real*8, dimension(numRtDomainVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real*8, dimension(numRtDomainVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numRtDomainVars) :: validMinDbl ! Valid minimum (before conversion to integer)
+   real*8, dimension(numRtDomainVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
    integer*8, dimension(numRtDomainVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numRtDomainVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numRtDomainVars) :: fillReal ! Fill value (before conversion to integer)
@@ -274,8 +274,8 @@ type lakeMeta
    character (len=64), dimension(numLakeVars) :: coordNames ! Coordinate names for each variable. 
    integer*8, dimension(numLakeVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numLakeVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real*8, dimension(numLakeVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real*8, dimension(numLakeVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numLakeVars) :: validMinDbl ! Valid minimum (before conversion to integer)
+   real*8, dimension(numLakeVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
    integer*8, dimension(numLakeVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numLakeVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numLakeVars) :: fillReal ! Fill value (before conversion to integer)
@@ -344,8 +344,8 @@ type chrtGrdMeta
    character (len=64), dimension(numChGrdVars) :: coordNames ! Coordinate names for each variable. 
    integer*8, dimension(numChGrdVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numChGrdVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real*8, dimension(numChGrdVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real*8, dimension(numChGrdVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numChGrdVars) :: validMinDbl ! Valid minimum (before conversion to integer)
+   real*8, dimension(numChGrdVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
    integer*8, dimension(numChGrdVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numChGrdVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numChGrdVars) :: fillReal ! Fill value (before conversion to integer)
@@ -418,8 +418,8 @@ type lsmMeta
    integer, dimension(numLsmVars) :: numLev ! Number of levels for each variable.
    integer*8, dimension(numLsmVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numLsmVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real*8, dimension(numLsmVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real*8, dimension(numLsmVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numLsmVars) :: validMinDbl ! Valid minimum (before conversion to integer)
+   real*8, dimension(numLsmVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
    integer*8, dimension(numLsmVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numLsmVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numLsmVars) :: fillReal ! Fill value (before conversion to integer)
@@ -489,8 +489,8 @@ type chObsMeta
    character (len=64), dimension(numChObsVars) :: coordNames ! Coordinate names for each variable. 
    integer*8, dimension(numChObsVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numChObsVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real*8, dimension(numChObsVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real*8, dimension(numChObsVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numChObsVars) :: validMinDbl ! Valid minimum (before conversion to integer)
+   real*8, dimension(numChObsVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
    integer*8, dimension(numChObsVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numChObsVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numChObsVars) :: fillReal ! Fill value (before conversion to integer)
@@ -562,8 +562,8 @@ type gwMeta
    !character (len=64), dimension(numGwVars) :: coordNames ! Coordinate names for each variable. 
    integer*8, dimension(numGwVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numGwVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real*8, dimension(numGwVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real*8, dimension(numGwVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numGwVars) :: validMinDbl ! Valid minimum (before conversion to integer)
+   real*8, dimension(numGwVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
    integer*8, dimension(numGwVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numGwVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numGwVars) :: fillReal ! Fill value (before conversion to integer)
@@ -746,9 +746,9 @@ subroutine initChrtDict(chrtOutDict,diagFlag,procId)
                               -9999.0,-9999.0,-9999.0,-9999.0]
    chrtOutDict%missingReal(:) = [-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,&
                                  -9999.0,-9999.0,-9999.0,-9999.0,-9999.0]
-   chrtOutDict%validMinReal(:) = [0.0,-500000.0,0.0,0.0,0.0,0.0,0.0,0.0,&
-                                  0.0,0.0]
-   chrtOutDict%validMaxReal(:) = [50000.0d0, 50000.0d0, 50000.0d0, 50000.0d0, 50000.0d0, &
+   chrtOutDict%validMinDbl(:) = [0.0d0, -50000.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, &
+                                  0.0d0, 0.0d0]
+   chrtOutDict%validMaxDbl(:) = [50000.0d0, 50000.0d0, 50000.0d0, 50000.0d0, 50000.0d0, &
                                   20000.0d0, 20000.0d0, 20000.0d0, 50000.0d0, &
                                   50000.0d0]
    ! Loop through and calculate missing/fill/min/max values that will be placed
@@ -756,16 +756,16 @@ subroutine initChrtDict(chrtOutDict,diagFlag,procId)
    do i=1,numChVars
       chrtOutDict%fillComp(i) = &
            nint((chrtOutDict%fillReal(i)     + chrtOutDict%addOffset(i)), 8) * &
-           nint(one_real / chrtOutDict%scaleFactor(i), 8)
+           nint(one_dbl / chrtOutDict%scaleFactor(i), 8)
       chrtOutDict%missingComp(i) = &
            nint((chrtOutDict%missingReal(i)  + chrtOutDict%addOffset(i)), 8) * &
-           nint(one_real / chrtOutDict%scaleFactor(i), 8)
+           nint(one_dbl / chrtOutDict%scaleFactor(i), 8)
       chrtOutDict%validMinComp(i) = &
-           nint((chrtOutDict%validMinReal(i) + chrtOutDict%addOffset(i)) * &
-                nint(one_real / chrtOutDict%scaleFactor(i), 8), 8)
+           nint((chrtOutDict%validMinDbl(i) + chrtOutDict%addOffset(i)) * &
+                nint(one_dbl / chrtOutDict%scaleFactor(i), 8), 8)
       chrtOutDict%validMaxComp(i) = &
-           nint((chrtOutDict%validMaxReal(i) + chrtOutDict%addOffset(i)) * &
-                nint(one_real / chrtOutDict%scaleFactor(i), 8), 8)
+           nint((chrtOutDict%validMaxDbl(i) + chrtOutDict%addOffset(i)) * &
+                nint(one_dbl / chrtOutDict%scaleFactor(i), 8), 8)
    end do
 end subroutine initChrtDict
 
@@ -1205,32 +1205,45 @@ subroutine initLdasDict(ldasOutDict,procId,diagFlag)
                               -9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,&
                               -9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,&
                               -9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0]
-   ldasOutDict%validMinReal(:) = [0.0,0.0,0.0,0.0,0.0,-1000.0,-1.0,-1500.0,0.0,0.0,-1500.0,-1500.0,-1500.0,-1500.0,-1500.0,-100.0,-100.0,0.0,&
-                                  -100.0,-100.0,0.0,-5.0,-5.0,0.0,0.0,0.0,0.0,-100.0,-100.0,-100.0,-1500.0,-1500.0,-1500.0,-1500.0,-1500.0,&
-                                  -1500.0,-1500.0,-1500.0,-1500.0,-1500.0,-1500.0,-1500.0,-1500.0,-1500.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,&
-                                  0.0,-1000.0,0.0,-100.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,-5.0,-5.0,-5.0,-5.0,-5.0,-5.0,-5.0,-5.0,0.0,0.0,0.0,&
-                                  0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,-1000.0,-5.0,0.0,0.0,0.0,0.0,0.0,0.0]
-   ldasOutDict%validMaxReal(:) = [100.0,100.0,1.0,20.0,20.0,3000.0,1.0,1500.0,100.0,1.0,1500.0,1500.0,1500.0,1500.0,1500.0,100.0,100.0,1.0,100.0,&
-                                  100000.0,100000.0,30000.0,30000.0,10.0,10000.0,10000.0,1.0E+6,1.0E+6,1.0E+6,&
-                                  1.0E+6,1500.0,1500.0,1500.0,1500.0,1500.0,1500.0,1500.0,1500.0,1500.0,1500.0,1500.0,1500.0,&
-                                  1500.0,1500.0,400.0,400.0,400.0,400.0,400.0,400.0,400.0,400.0,1.0,1.0,100000.0,1.0,100.0,100000.0,100000.0,&
-                                  400.0,1.0,400.0,1.0,100.0,100000.0,100.0,10.0,1.0,100000.0,100000.0,5.0,5.0,5.0,5.0,5.0,5.0,5.0,5.0,1000.0,1000.0,&
-                                  1000.0,1000.0,5000.0,5000.0,1000.0,1000.0,1000.0,1000.0,1000.0,1.0E+6,30000.0,1.0,1.0,1.0,400.0,1.0,1.0]
+   ldasOutDict%validMinDbl(:) = [ &
+        0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, -1000.0d0, -1.0d0, -1500.0d0, 0.0d0, 0.0d0, &
+        -1500.0d0, -1500.0d0, -1500.0d0, -1500.0d0, -1500.0d0, -100.0d0, -100.0d0, 0.0d0, &
+        -100.0d0, -100.0d0, 0.0d0, -5.0d0, -5.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, -100.0d0, &
+        -100.0d0, -100.0d0, -1500.0d0, -1500.0d0, -1500.0d0, -1500.0d0, -1500.0d0, &
+        -1500.0d0, -1500.0d0, -1500.0d0, -1500.0d0, -1500.0d0, -1500.0d0, -1500.0d0, &
+        -1500.0d0, -1500.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, &
+        0.0d0, -1000.0d0, 0.0d0, -100.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, &
+        0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, -5.0d0, -5.0d0, -5.0d0, -5.0d0, -5.0d0, &
+        -5.0d0, -5.0d0, -5.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, &
+        0.0d0, 0.0d0, 0.0d0, -1000.0d0, -5.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0 &
+   ]
+   ldasOutDict%validMaxDbl(:) = [ &
+        100.0d0, 100.0d0, 1.0d0, 20.0d0, 20.0d0, 3000.0d0, 1.0d0, 1500.0d0, 100.0d0, 1.0d0, &
+        1500.0d0, 1500.0d0, 1500.0d0, 1500.0d0, 1500.0d0, 100.0d0, 100.0d0, 1.0d0, 100.0d0, &
+        100000.0d0, 100000.0d0, 30000.0d0, 30000.0d0, 10.0d0, 10000.0d0, 10000.0d0, 1.0D+6, &
+        1.0D+6, 1.0D+6, 1.0D+6, 1500.0d0, 1500.0d0, 1500.0d0, 1500.0d0, 1500.0d0, 1500.0d0, &
+        1500.0d0, 1500.0d0, 1500.0d0, 1500.0d0, 1500.0d0, 1500.0d0, 1500.0d0, 1500.0d0, 400.0d0, &
+        400.0d0, 400.0d0, 400.0d0, 400.0d0, 400.0d0, 400.0d0, 400.0d0, 1.0d0, 1.0d0, 100000.0d0, &
+        1.0d0, 100.0d0, 100000.0d0, 100000.0d0, 400.0d0, 1.0d0, 400.0d0, 1.0d0, 100.0d0, 100000.0d0, &
+        100.0d0, 10.0d0, 1.0d0, 100000.0d0, 100000.0d0, 5.0d0, 5.0d0, 5.0d0, 5.0d0, 5.0d0, 5.0d0, &
+        5.0d0, 5.0d0, 1000.0d0, 1000.0d0, 1000.0d0, 1000.0d0, 5000.0d0, 5000.0d0, 1000.0d0, 1000.0d0, &
+        1000.0d0, 1000.0d0, 1000.0d0, 1.0D+6, 30000.0d0, 1.0d0, 1.0d0, 1.0d0, 400.0d0, 1.0d0, 1.0d0 &
+   ]
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numLdasVars
       ldasOutDict%fillComp(i) = &
            nint((ldasOutDict%fillReal(i)     + ldasOutDict%addOffset(i)), 8) * &
-           nint(one_real / ldasOutDict%scaleFactor(i), 8)
+           nint(one_dbl / ldasOutDict%scaleFactor(i), 8)
       ldasOutDict%missingComp(i) = &
            nint((ldasOutDict%missingReal(i)  + ldasOutDict%addOffset(i)), 8) * &
-           nint(one_real / ldasOutDict%scaleFactor(i), 8)
+           nint(one_dbl / ldasOutDict%scaleFactor(i), 8)
       ldasOutDict%validMinComp(i) = &
-           nint((ldasOutDict%validMinReal(i) + ldasOutDict%addOffset(i)) * &
-                nint(one_real / ldasOutDict%scaleFactor(i), 8), 8)
+           nint((ldasOutDict%validMinDbl(i) + ldasOutDict%addOffset(i)) * &
+                nint(one_dbl / ldasOutDict%scaleFactor(i), 8), 8)
       ldasOutDict%validMaxComp(i) = &
-           nint((ldasOutDict%validMaxReal(i) + ldasOutDict%addOffset(i)) * &
-                nint(one_real / ldasOutDict%scaleFactor(i), 8), 8)
+           nint((ldasOutDict%validMaxDbl(i) + ldasOutDict%addOffset(i)) * &
+                nint(one_dbl / ldasOutDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initLdasDict
@@ -1542,24 +1555,24 @@ subroutine initRtDomainDict(rtDomainDict,procId,diagFlag)
    rtDomainDict%timeZeroFlag(:) = [1,1,1,1,1]
    rtDomainDict%missingReal(:) = [-9999.0,-9999.0,-9999.0,-9999.0,-9999.0]
    rtDomainDict%fillReal(:) = [-9999.0,-9999.0,-9999.0,-9999.0,-9999.0]
-   rtDomainDict%validMinReal(:) = [0.0,0.0,0.0,-1000000.0,0.0]
-   rtDomainDict%validMaxReal(:) = [100.0,1000000.0,1000000.0,1000000.0,100.0]
+   rtDomainDict%validMinDbl(:) = [0.0d0, 0.0d0, 0.0d0, -1000000.0d0, 0.0d0]
+   rtDomainDict%validMaxDbl(:) = [100.0d0, 1000000.0d0, 1000000.0d0, 1000000.0d0, 100.0d0]
 
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numRtDomainVars
       rtDomainDict%fillComp(i) = &
            nint((rtDomainDict%fillReal(i)     + rtDomainDict%addOffset(i)), 8) * &
-           nint(one_real / rtDomainDict%scaleFactor(i), 8)
+           nint(one_dbl / rtDomainDict%scaleFactor(i), 8)
       rtDomainDict%missingComp(i) = &
            nint((rtDomainDict%missingReal(i)  + rtDomainDict%addOffset(i)), 8) * &
-           nint(one_real / rtDomainDict%scaleFactor(i), 8)
+           nint(one_dbl / rtDomainDict%scaleFactor(i), 8)
       rtDomainDict%validMinComp(i) = &
-           nint((rtDomainDict%validMinReal(i) + rtDomainDict%addOffset(i)) * &
-                nint(one_real / rtDomainDict%scaleFactor(i), 8), 8)
+           nint((rtDomainDict%validMinDbl(i) + rtDomainDict%addOffset(i)) * &
+                nint(one_dbl / rtDomainDict%scaleFactor(i), 8), 8)
       rtDomainDict%validMaxComp(i) = &
-           nint((rtDomainDict%validMaxReal(i) + rtDomainDict%addOffset(i)) * &
-                nint(one_real / rtDomainDict%scaleFactor(i), 8), 8)
+           nint((rtDomainDict%validMaxDbl(i) + rtDomainDict%addOffset(i)) * &
+                nint(one_dbl / rtDomainDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initRtDomainDict
@@ -1660,24 +1673,24 @@ subroutine initLakeDict(lakeOutDict,procId,diagFlag)
    lakeOutDict%timeZeroFlag(:) = [1,1]
    lakeOutDict%fillReal(:) = [-9999.0,-9999.0]
    lakeOutDict%missingReal(:) = [-9999.0,-9999.0]
-   lakeOutDict%validMinReal(:) = [-10000.0,-10000.0]
-   lakeOutDict%validMaxreal(:) = [10000.0,10000.0]
+   lakeOutDict%validMinDbl(:) = [-10000.0d0, -10000.0d0]
+   lakeOutDict%validMaxDbl(:) = [10000.0d0, 10000.0d0]
 
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numLakeVars
       lakeOutDict%fillComp(i) = &
            nint((lakeOutDict%fillReal(i)     + lakeOutDict%addOffset(i)), 8) * &
-           nint(one_real / lakeOutDict%scaleFactor(i), 8)
+           nint(one_dbl / lakeOutDict%scaleFactor(i), 8)
       lakeOutDict%missingComp(i) = &
            nint((lakeOutDict%missingReal(i)  + lakeOutDict%addOffset(i)), 8) * &
-           nint(one_real / lakeOutDict%scaleFactor(i), 8)
+           nint(one_dbl / lakeOutDict%scaleFactor(i), 8)
       lakeOutDict%validMinComp(i) = &
-           nint((lakeOutDict%validMinReal(i) + lakeOutDict%addOffset(i)) * &
-                nint(one_real / lakeOutDict%scaleFactor(i), 8), 8)
+           nint((lakeOutDict%validMinDbl(i) + lakeOutDict%addOffset(i)) * &
+                nint(one_dbl / lakeOutDict%scaleFactor(i), 8), 8)
       lakeOutDict%validMaxComp(i) = &
-           nint((lakeOutDict%validMaxReal(i) + lakeOutDict%addOffset(i)) * &
-                nint(one_real / lakeOutDict%scaleFactor(i), 8), 8)
+           nint((lakeOutDict%validMaxDbl(i) + lakeOutDict%addOffset(i)) * &
+                nint(one_dbl / lakeOutDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initLakeDict
@@ -1984,24 +1997,24 @@ subroutine initChrtGrdDict(chrtGrdDict,procId,diagFlag)
    chrtGrdDict%timeZeroFlag(:) = [1]
    chrtGrdDict%missingReal(:) = [-9999.0]
    chrtGrdDict%fillReal(:) = [-9999.0]
-   chrtGrdDict%validMinReal(:) = [0.0]
-   chrtGrdDict%validMaxReal(:) = [50000.0]
+   chrtGrdDict%validMinDbl(:) = [0.0d0]
+   chrtGrdDict%validMaxDbl(:) = [50000.0d0]
 
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numChGrdVars
       chrtGrdDict%fillComp(i) = &
            nint((chrtGrdDict%fillReal(i)     + chrtGrdDict%addOffset(i)), 8) * &
-           nint(one_real / chrtGrdDict%scaleFactor(i), 8)
+           nint(one_dbl / chrtGrdDict%scaleFactor(i), 8)
       chrtGrdDict%missingComp(i) = &
            nint((chrtGrdDict%missingReal(i)  + chrtGrdDict%addOffset(i)), 8) * &
-           nint(one_real / chrtGrdDict%scaleFactor(i), 8)
+           nint(one_dbl / chrtGrdDict%scaleFactor(i), 8)
       chrtGrdDict%validMinComp(i) = &
-           nint((chrtGrdDict%validMinReal(i) + chrtGrdDict%addOffset(i)) * &
-                nint(one_real / chrtGrdDict%scaleFactor(i), 8), 8)
+           nint((chrtGrdDict%validMinDbl(i) + chrtGrdDict%addOffset(i)) * &
+                nint(one_dbl / chrtGrdDict%scaleFactor(i), 8), 8)
       chrtGrdDict%validMaxComp(i) = &
-           nint((chrtGrdDict%validMaxReal(i) + chrtGrdDict%addOffset(i)) * &
-                nint(one_real / chrtGrdDict%scaleFactor(i), 8), 8)
+           nint((chrtGrdDict%validMaxDbl(i) + chrtGrdDict%addOffset(i)) * &
+                nint(one_dbl / chrtGrdDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initChrtGrdDict
@@ -2285,25 +2298,25 @@ subroutine initLsmOutDict(lsmOutDict,procId,diagFlag)
                                 -9999.0,-9999.0,-9999.0,-9999.0]
    lsmOutDict%fillReal(:) = [-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,&
                              -9999.0,-9999.0,-9999.0,-9999.0]
-   lsmOutDict%validMinReal(:) = [150.0,0.0,0.0,150.0,0.0,0.0,150.0,0.0,0.0,&
-                                 150.0,0.0,0.0,0.0,0.0]
-   lsmOutDict%validMaxReal(:) = [400.0,1.0,1.0,400.0,1.0,1.0,400.0,1.0,1.0,&
-                                 400.0,1.0,1.0,100000.0,100000.0]
+   lsmOutDict%validMinDbl(:) = [150.0d0, 0.0d0, 0.0d0, 150.0d0, 0.0d0, 0.0d0, 150.0d0, 0.0d0, 0.0d0, &
+                                 150.0d0, 0.0d0, 0.0d0, 0.0d0, 0.0d0]
+   lsmOutDict%validMaxDbl(:) = [400.0d0, 1.0d0, 1.0d0, 400.0d0, 1.0d0, 1.0d0, 400.0d0, 1.0d0, 1.0d0, &
+                                 400.0d0, 1.0d0, 1.0d0, 100000.0d0, 100000.0d0]
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numLsmVars
       lsmOutDict%fillComp(i) = &
            nint((lsmOutDict%fillReal(i)     + lsmOutDict%addOffset(i)), 8) * &
-           nint(one_real / lsmOutDict%scaleFactor(i), 8)
+           nint(one_dbl / lsmOutDict%scaleFactor(i), 8)
       lsmOutDict%missingComp(i) = &
            nint((lsmOutDict%missingReal(i)  + lsmOutDict%addOffset(i)), 8) * &
-           nint(one_real / lsmOutDict%scaleFactor(i), 8)
+           nint(one_dbl / lsmOutDict%scaleFactor(i), 8)
       lsmOutDict%validMinComp(i) = &
-           nint((lsmOutDict%validMinReal(i) + lsmOutDict%addOffset(i)) * &
-                nint(one_real / lsmOutDict%scaleFactor(i), 8), 8)
+           nint((lsmOutDict%validMinDbl(i) + lsmOutDict%addOffset(i)) * &
+                nint(one_dbl / lsmOutDict%scaleFactor(i), 8), 8)
       lsmOutDict%validMaxComp(i) = &
-           nint((lsmOutDict%validMaxReal(i) + lsmOutDict%addOffset(i)) * &
-                nint(one_real / lsmOutDict%scaleFactor(i), 8), 8)
+           nint((lsmOutDict%validMaxDbl(i) + lsmOutDict%addOffset(i)) * &
+                nint(one_dbl / lsmOutDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initLsmOutDict
@@ -2409,23 +2422,23 @@ subroutine initChanObsDict(chObsDict,diagFlag,procId)
    chObsDict%timeZeroFlag(:) = [1]
    chObsDict%fillReal(:) = [-9999.0]
    chObsDict%missingReal(:) = [-9999.0]
-   chObsDict%validMinReal(:) = [0.0]
-   chObsDict%validMaxReal(:) = [50000.0]
+   chObsDict%validMinDbl(:) = [0.0d0]
+   chObsDict%validMaxDbl(:) = [50000.0d0]
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numChObsVars
       chObsDict%fillComp(i) = &
            nint((chObsDict%fillReal(i)     + chObsDict%addOffset(i)), 8) * &
-           nint(one_real / chObsDict%scaleFactor(i), 8)
+           nint(one_dbl / chObsDict%scaleFactor(i), 8)
       chObsDict%missingComp(i) = &
            nint((chObsDict%missingReal(i)  + chObsDict%addOffset(i)), 8) * &
-           nint(one_real / chObsDict%scaleFactor(i), 8)
+           nint(one_dbl / chObsDict%scaleFactor(i), 8)
       chObsDict%validMinComp(i) = &
-           nint((chObsDict%validMinReal(i) + chObsDict%addOffset(i)) * &
-                nint(one_real / chObsDict%scaleFactor(i), 8), 8)
+           nint((chObsDict%validMinDbl(i) + chObsDict%addOffset(i)) * &
+                nint(one_dbl / chObsDict%scaleFactor(i), 8), 8)
       chObsDict%validMaxComp(i) = &
-           nint((chObsDict%validMaxReal(i) + chObsDict%addOffset(i)) * &
-                nint(one_real / chObsDict%scaleFactor(i), 8), 8)
+           nint((chObsDict%validMaxDbl(i) + chObsDict%addOffset(i)) * &
+                nint(one_dbl / chObsDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initChanObsDict
@@ -2484,24 +2497,24 @@ subroutine initGwDict(gwOutDict)
    gwOutDict%timeZeroFlag(:) = [0,0,1]
    gwOutDict%fillReal(:) = [-9999.0,-9999.0,-9999.0]
    gwOutDict%missingReal(:) = [-9999.0,-9999.0,-9999.0]
-   gwOutDict%validMinReal(:) = [-10000.0,-10000.0,-10000.0]
-   gwOutDict%validMaxreal(:) = [10000.0,10000.0,10000.0]
+   gwOutDict%validMinDbl(:) = [-10000.0d0, -10000.0d0, -10000.0d0]
+   gwOutDict%validMaxDbl(:) = [10000.0d0, 10000.0d0, 10000.0d0]
 
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numGwVars
       gwOutDict%fillComp(i) = &
            nint((gwOutDict%fillReal(i)     + gwOutDict%addOffset(i)), 8) * &
-           nint(one_real / gwOutDict%scaleFactor(i), 8)
+           nint(one_dbl / gwOutDict%scaleFactor(i), 8)
       gwOutDict%missingComp(i) = &
            nint((gwOutDict%missingReal(i)  + gwOutDict%addOffset(i)), 8) * &
-           nint(one_real / gwOutDict%scaleFactor(i), 8)
+           nint(one_dbl / gwOutDict%scaleFactor(i), 8)
       gwOutDict%validMinComp(i) = &
-           nint((gwOutDict%validMinReal(i) + gwOutDict%addOffset(i)) * &
-                nint(one_real / gwOutDict%scaleFactor(i), 8), 8)
+           nint((gwOutDict%validMinDbl(i) + gwOutDict%addOffset(i)) * &
+                nint(one_dbl / gwOutDict%scaleFactor(i), 8), 8)
       gwOutDict%validMaxComp(i) = &
-           nint((gwOutDict%validMaxReal(i) + gwOutDict%addOffset(i)) * &
-                nint(one_real / gwOutDict%scaleFactor(i), 8), 8)
+           nint((gwOutDict%validMaxDbl(i) + gwOutDict%addOffset(i)) * &
+                nint(one_dbl / gwOutDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initGwDict

--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -53,8 +53,8 @@ type chrtMeta
    character (len=64), dimension(numChVars) :: coordNames ! Coordinate names for each variable. 
    integer*8, dimension(numChVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numChVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real, dimension(numChVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real, dimension(numChVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numChVars) :: validMinReal ! Valid minimum (before conversion to integer)
+   real*8, dimension(numChVars) :: validMaxReal ! Valid maximum (before converstion to integer)
    integer*8, dimension(numChVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numChVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numChVars) :: fillReal ! Fill value (before conversion to integer)
@@ -75,7 +75,7 @@ type chrtMeta
    character (len=64) :: rTimeStName ! standard_name - usually forecast_reference_time
    character (len=64) :: rTimeUnits ! Usually seconds since 1/1/1970
    ! feature_id attributes
-   character (len=64) :: featureIdLName ! long_name - usually Reach ID
+   character (len=256) :: featureIdLName ! long_name - usually Reach ID
    character (len=256) :: featureIdComment ! Comment attribute
    character (len=64) :: cfRole ! cf_role attribute
    ! latitude variable attributes
@@ -129,8 +129,8 @@ type ldasMeta
    integer, dimension(numLdasVars) :: numLev ! Number of levels for each variable.
    integer*8, dimension(numLdasVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numLdasVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real, dimension(numLdasVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real, dimension(numLdasVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numLdasVars) :: validMinReal ! Valid minimum (before conversion to integer)
+   real*8, dimension(numLdasVars) :: validMaxReal ! Valid maximum (before converstion to integer)
    integer*8, dimension(numLdasVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numLdasVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numLdasVars) :: fillReal ! Fill value (before conversion to integer)
@@ -202,8 +202,8 @@ type rtDomainMeta
    character (len=64), dimension(numRtDomainVars) :: coordNames ! Coordinate names for each variable. 
    integer*8, dimension(numRtDomainVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numRtDomainVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real, dimension(numRtDomainVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real, dimension(numRtDomainVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numRtDomainVars) :: validMinReal ! Valid minimum (before conversion to integer)
+   real*8, dimension(numRtDomainVars) :: validMaxReal ! Valid maximum (before converstion to integer)
    integer*8, dimension(numRtDomainVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numRtDomainVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numRtDomainVars) :: fillReal ! Fill value (before conversion to integer)
@@ -272,8 +272,8 @@ type lakeMeta
    character (len=64), dimension(numLakeVars) :: coordNames ! Coordinate names for each variable. 
    integer*8, dimension(numLakeVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numLakeVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real, dimension(numLakeVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real, dimension(numLakeVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numLakeVars) :: validMinReal ! Valid minimum (before conversion to integer)
+   real*8, dimension(numLakeVars) :: validMaxReal ! Valid maximum (before converstion to integer)
    integer*8, dimension(numLakeVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numLakeVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numLakeVars) :: fillReal ! Fill value (before conversion to integer)
@@ -297,7 +297,7 @@ type lakeMeta
    character (len=64) :: lakeIdLName ! long_name - usually Lake COMMON ID
    character (len=256) :: LakeIdComment ! Comment attribute
    ! feature_id attributes
-   character (len=64) :: featureIdLName ! long_name - usually lake COMMON ID
+   character (len=256) :: featureIdLName ! long_name - usually lake COMMON ID
    character (len=256) :: featureIdComment ! Comment attribute
    character (len=64) :: cfRole ! cf_role attribute
    ! latitude variable attributes
@@ -342,8 +342,8 @@ type chrtGrdMeta
    character (len=64), dimension(numChGrdVars) :: coordNames ! Coordinate names for each variable. 
    integer*8, dimension(numChGrdVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numChGrdVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real, dimension(numChGrdVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real, dimension(numChGrdVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numChGrdVars) :: validMinReal ! Valid minimum (before conversion to integer)
+   real*8, dimension(numChGrdVars) :: validMaxReal ! Valid maximum (before converstion to integer)
    integer*8, dimension(numChGrdVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numChGrdVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numChGrdVars) :: fillReal ! Fill value (before conversion to integer)
@@ -416,8 +416,8 @@ type lsmMeta
    integer, dimension(numLsmVars) :: numLev ! Number of levels for each variable.
    integer*8, dimension(numLsmVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numLsmVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real, dimension(numLsmVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real, dimension(numLsmVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numLsmVars) :: validMinReal ! Valid minimum (before conversion to integer)
+   real*8, dimension(numLsmVars) :: validMaxReal ! Valid maximum (before converstion to integer)
    integer*8, dimension(numLsmVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numLsmVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numLsmVars) :: fillReal ! Fill value (before conversion to integer)
@@ -487,8 +487,8 @@ type chObsMeta
    character (len=64), dimension(numChObsVars) :: coordNames ! Coordinate names for each variable. 
    integer*8, dimension(numChObsVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numChObsVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real, dimension(numChObsVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real, dimension(numChObsVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numChObsVars) :: validMinReal ! Valid minimum (before conversion to integer)
+   real*8, dimension(numChObsVars) :: validMaxReal ! Valid maximum (before converstion to integer)
    integer*8, dimension(numChObsVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numChObsVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numChObsVars) :: fillReal ! Fill value (before conversion to integer)
@@ -510,7 +510,7 @@ type chObsMeta
    character (len=64) :: rTimeStName ! standard_name - usually forecast_reference_time
    character (len=64) :: rTimeUnits ! Usually seconds since 1/1/1970
    ! feature_id attributes
-   character (len=64) :: featureIdLName ! long_name - usually Reach ID
+   character (len=256) :: featureIdLName ! long_name - usually Reach ID
    character (len=256) :: featureIdComment ! Comment attribute
    character (len=64) :: cfRole ! cf_role attribute
    ! latitude variable attributes
@@ -560,8 +560,8 @@ type gwMeta
    !character (len=64), dimension(numGwVars) :: coordNames ! Coordinate names for each variable. 
    integer*8, dimension(numGwVars) :: validMinComp ! Valid min (after conversion to integer)
    integer*8, dimension(numGwVars) :: validMaxComp ! Valid max (after conversion to integer)
-   real, dimension(numGwVars) :: validMinReal ! Valid minimum (before conversion to integer)
-   real, dimension(numGwVars) :: validMaxReal ! Valid maximum (before converstion to integer)
+   real*8, dimension(numGwVars) :: validMinReal ! Valid minimum (before conversion to integer)
+   real*8, dimension(numGwVars) :: validMaxReal ! Valid maximum (before converstion to integer)
    integer*8, dimension(numGwVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numGwVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numGwVars) :: fillReal ! Fill value (before conversion to integer)
@@ -587,7 +587,7 @@ type gwMeta
    character (len=64) :: gwIdLName ! long_name - usually gw bucket ID
    character (len=256) :: gwIdComment ! Comment attribute
    ! feature_id attributes
-   character (len=64) :: featureIdLName ! long_name - usually gw bucket ID
+   character (len=256) :: featureIdLName ! long_name - usually gw bucket ID
    character (len=256) :: featureIdComment ! Comment attribute
    character (len=64) :: cfRole ! cf_role attribute
    ! latitude variable attributes
@@ -707,7 +707,7 @@ subroutine initChrtDict(chrtOutDict,diagFlag,procId)
  
    ! Next establish feature_id attributes. Given this is merged community, we
    chrtOutDict%featureIdLName = 'Reach ID'
-   chrtOutDict%featureIdComment = 'Gage Points Specified by User in Routelink file'
+   chrtOutDict%featureIdComment = 'NHDPlusv2 ComIDs within CONUS, arbitrary Reach IDs outside of CONUS'
    chrtOutDict%cfRole = 'timeseries_id'   
 
    ! Now establish attributes for output variables.
@@ -724,7 +724,7 @@ subroutine initChrtDict(chrtOutDict,diagFlag,procId)
                               "Runoff from bottom of soil to bucket",&
                               "Accumulated runoff from terrain routing",&
                               "Accumulated runoff from gw bucket"]
-   chrtOutDict%units(:) = [character(len=64) :: "m3 s-1","m3 s-1","m3 s-1","ms-1",&
+   chrtOutDict%units(:) = [character(len=64) :: "m3 s-1","m3 s-1","m3 s-1","m s-1",&
                                                 "meter","m3 s-1","m3 s-1",&
                                                 "m3","m3","m3"]
    chrtOutDict%coordNames(:) = [character(len=64) :: "latitude longitude","latitude longitude",&
@@ -746,15 +746,24 @@ subroutine initChrtDict(chrtOutDict,diagFlag,procId)
                                  -9999.0,-9999.0,-9999.0,-9999.0,-9999.0]
    chrtOutDict%validMinReal(:) = [0.0,-500000.0,0.0,0.0,0.0,0.0,0.0,0.0,&
                                   0.0,0.0]
-   chrtOutDict%validMaxReal(:) = [500000.0,500000.0,500000.0,500000.0,500000.0,&
-                                  500000.0,500000.0,500000.0,500000.0,500000.0]
+   chrtOutDict%validMaxReal(:) = [50000.0d0, 50000.0d0, 50000.0d0, 50000.0d0, 50000.0d0, &
+                                  20000.0d0, 20000.0d0, 20000.0d0, 50000.0d0, &
+                                  50000.0d0]
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numChVars
-      chrtOutDict%fillComp(i) = int((chrtOutDict%fillReal(i)+chrtOutDict%addOffset(i))/chrtOutDict%scaleFactor(i))
-      chrtOutDict%missingComp(i) = int((chrtOutDict%missingReal(i)+chrtOutDict%addOffset(i))/chrtOutDict%scaleFactor(i))
-      chrtOutDict%validMinComp(i) = int((chrtOutDict%validMinReal(i)+chrtOutDict%addOffset(i))/chrtOutDict%scaleFactor(i))
-      chrtOutDict%validMaxComp(i) = int((chrtOutDict%validMaxReal(i)+chrtOutDict%addOffset(i))/chrtOutDict%scaleFactor(i))
+      chrtOutDict%fillComp(i) = &
+           nint((chrtOutDict%fillReal(i)     + chrtOutDict%addOffset(i)), 8) * &
+           nint(1.0 / chrtOutDict%scaleFactor(i), 8)
+      chrtOutDict%missingComp(i) = &
+           nint((chrtOutDict%missingReal(i)  + chrtOutDict%addOffset(i)), 8) * &
+           nint(1.0 / chrtOutDict%scaleFactor(i), 8)
+      chrtOutDict%validMinComp(i) = &
+           nint((chrtOutDict%validMinReal(i) + chrtOutDict%addOffset(i)) * &
+                nint(1.0 / chrtOutDict%scaleFactor(i), 8), 8)
+      chrtOutDict%validMaxComp(i) = &
+           nint((chrtOutDict%validMaxReal(i) + chrtOutDict%addOffset(i)) * &
+                nint(1.0 / chrtOutDict%scaleFactor(i), 8), 8)
    end do
 end subroutine initChrtDict
 
@@ -1136,14 +1145,14 @@ subroutine initLdasDict(ldasOutDict,procId,diagFlag)
                             "g m-2","g m-2","g m-2","g m-2","g m-2","g m-2","g m-2s-1 CO2",&
                             "g m-2s-1 C","g m-2s-1 C","umol CO2 m-2 s-1","W m-2",&
                             "mm","mm","1","1","1","K","-","-"]
-   ldasOutDict%scaleFactor(:) = [1.0,1.0,0.01,0.1,0.1,0.1,0.01,0.1,0.000001,0.01,&
-                                 0.1,0.1,0.1,0.1,0.1,0.000001,0.000001,0.01,&
-                                 0.000001,0.01,0.001,0.01,0.01,0.00001,0.01,&
+   ldasOutDict%scaleFactor(:) = [1.0,1.0,0.01,0.1,0.1,0.1,0.01,0.1,0.00001,0.01,&
+                                 0.1,0.1,0.1,0.1,0.1,0.00001,0.00001,0.01,&
+                                 0.00001,0.01,0.001,0.01,0.01,0.00001,0.01,&
                                  0.01,0.01,0.01,0.01,0.01,0.1,0.1,0.1,0.1,&
                                  0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,&
                                  0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.0001,0.0001,&
                                  0.1,0.01,0.00001,0.01,0.01,0.1,0.01,0.1,0.01,&
-                                 0.0001,0.1,0.000001,1.0,0.001,0.01,0.01,0.00001,&
+                                 0.0001,0.1,0.00001,1.0,0.001,0.01,0.01,0.00001,&
                                  0.00001,0.00001,0.00001,0.00001,0.00001,0.00001,&
                                  0.00001,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,&
                                  0.01,0.01,0.01,0.01,0.01,0.01,0.001,0.001,0.1,0.01,0.01]
@@ -1208,10 +1217,18 @@ subroutine initLdasDict(ldasOutDict,procId,diagFlag)
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numLdasVars
-      ldasOutDict%fillComp(i) = NINT((ldasOutDict%fillReal(i)+ldasOutDict%addOffset(i))/ldasOutDict%scaleFactor(i))
-      ldasOutDict%missingComp(i) = NINT((ldasOutDict%missingReal(i)+ldasOutDict%addOffset(i))/ldasOutDict%scaleFactor(i))
-      ldasOutDict%validMinComp(i) = NINT((ldasOutDict%validMinReal(i)+ldasOutDict%addOffset(i))/ldasOutDict%scaleFactor(i))
-      ldasOutDict%validMaxComp(i) = NINT((ldasOutDict%validMaxReal(i)+ldasOutDict%addOffset(i))/ldasOutDict%scaleFactor(i))
+      ldasOutDict%fillComp(i) = &
+           nint((ldasOutDict%fillReal(i)     + ldasOutDict%addOffset(i)), 8) * &
+           nint(1.0 / ldasOutDict%scaleFactor(i), 8)
+      ldasOutDict%missingComp(i) = &
+           nint((ldasOutDict%missingReal(i)  + ldasOutDict%addOffset(i)), 8) * &
+           nint(1.0 / ldasOutDict%scaleFactor(i), 8)
+      ldasOutDict%validMinComp(i) = &
+           nint((ldasOutDict%validMinReal(i) + ldasOutDict%addOffset(i)) * &
+                nint(1.0 / ldasOutDict%scaleFactor(i), 8), 8)
+      ldasOutDict%validMaxComp(i) = &
+           nint((ldasOutDict%validMaxReal(i) + ldasOutDict%addOffset(i)) * &
+                nint(1.0 / ldasOutDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initLdasDict
@@ -1529,10 +1546,18 @@ subroutine initRtDomainDict(rtDomainDict,procId,diagFlag)
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numRtDomainVars
-      rtDomainDict%fillComp(i) = NINT((rtDomainDict%fillReal(i)+rtDomainDict%addOffset(i))/rtDomainDict%scaleFactor(i))
-      rtDomainDict%missingComp(i) = NINT((rtDomainDict%missingReal(i)+rtDomainDict%addOffset(i))/rtDomainDict%scaleFactor(i))
-      rtDomainDict%validMinComp(i) = NINT((rtDomainDict%validMinReal(i)+rtDomainDict%addOffset(i))/rtDomainDict%scaleFactor(i))
-      rtDomainDict%validMaxComp(i) = NINT((rtDomainDict%validMaxReal(i)+rtDomainDict%addOffset(i))/rtDomainDict%scaleFactor(i))
+      rtDomainDict%fillComp(i) = &
+           nint((rtDomainDict%fillReal(i)     + rtDomainDict%addOffset(i)), 8) * &
+           nint(1.0 / rtDomainDict%scaleFactor(i), 8)
+      rtDomainDict%missingComp(i) = &
+           nint((rtDomainDict%missingReal(i)  + rtDomainDict%addOffset(i)), 8) * &
+           nint(1.0 / rtDomainDict%scaleFactor(i), 8)
+      rtDomainDict%validMinComp(i) = &
+           nint((rtDomainDict%validMinReal(i) + rtDomainDict%addOffset(i)) * &
+                nint(1.0 / rtDomainDict%scaleFactor(i), 8), 8)
+      rtDomainDict%validMaxComp(i) = &
+           nint((rtDomainDict%validMaxReal(i) + rtDomainDict%addOffset(i)) * &
+                nint(1.0 / rtDomainDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initRtDomainDict
@@ -1639,10 +1664,18 @@ subroutine initLakeDict(lakeOutDict,procId,diagFlag)
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numLakeVars
-      lakeOutDict%fillComp(i) = NINT((lakeOutDict%fillReal(i)+lakeOutDict%addOffset(i))/lakeOutDict%scaleFactor(i))
-      lakeOutDict%missingComp(i) = NINT((lakeOutDict%missingReal(i)+lakeOutDict%addOffset(i))/lakeOutDict%scaleFactor(i))
-      lakeOutDict%validMinComp(i) = NINT((lakeOutDict%validMinReal(i)+lakeOutDict%addOffset(i))/lakeOutDict%scaleFactor(i))
-      lakeOutDict%validMaxComp(i) = NINT((lakeOutDict%validMaxReal(i)+lakeOutDict%addOffset(i))/lakeOutDict%scaleFactor(i))
+      lakeOutDict%fillComp(i) = &
+           nint((lakeOutDict%fillReal(i)     + lakeOutDict%addOffset(i)), 8) * &
+           nint(1.0 / lakeOutDict%scaleFactor(i), 8)
+      lakeOutDict%missingComp(i) = &
+           nint((lakeOutDict%missingReal(i)  + lakeOutDict%addOffset(i)), 8) * &
+           nint(1.0 / lakeOutDict%scaleFactor(i), 8)
+      lakeOutDict%validMinComp(i) = &
+           nint((lakeOutDict%validMinReal(i) + lakeOutDict%addOffset(i)) * &
+                nint(1.0 / lakeOutDict%scaleFactor(i), 8), 8)
+      lakeOutDict%validMaxComp(i) = &
+           nint((lakeOutDict%validMaxReal(i) + lakeOutDict%addOffset(i)) * &
+                nint(1.0 / lakeOutDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initLakeDict
@@ -1950,15 +1983,23 @@ subroutine initChrtGrdDict(chrtGrdDict,procId,diagFlag)
    chrtGrdDict%missingReal(:) = [-9999.0]
    chrtGrdDict%fillReal(:) = [-9999.0]
    chrtGrdDict%validMinReal(:) = [0.0]
-   chrtGrdDict%validMaxReal(:) = [500000.0]
+   chrtGrdDict%validMaxReal(:) = [50000.0]
 
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numChGrdVars
-      chrtGrdDict%fillComp(i) = NINT((chrtGrdDict%fillReal(i)+chrtGrdDict%addOffset(i))/chrtGrdDict%scaleFactor(i))
-      chrtGrdDict%missingComp(i) = NINT((chrtGrdDict%missingReal(i)+chrtGrdDict%addOffset(i))/chrtGrdDict%scaleFactor(i))
-      chrtGrdDict%validMinComp(i) = NINT((chrtGrdDict%validMinReal(i)+chrtGrdDict%addOffset(i))/chrtGrdDict%scaleFactor(i))
-      chrtGrdDict%validMaxComp(i) = NINT((chrtGrdDict%validMaxReal(i)+chrtGrdDict%addOffset(i))/chrtGrdDict%scaleFactor(i))
+      chrtGrdDict%fillComp(i) = &
+           nint((chrtGrdDict%fillReal(i)     + chrtGrdDict%addOffset(i)), 8) * &
+           nint(1.0 / chrtGrdDict%scaleFactor(i), 8)
+      chrtGrdDict%missingComp(i) = &
+           nint((chrtGrdDict%missingReal(i)  + chrtGrdDict%addOffset(i)), 8) * &
+           nint(1.0 / chrtGrdDict%scaleFactor(i), 8)
+      chrtGrdDict%validMinComp(i) = &
+           nint((chrtGrdDict%validMinReal(i) + chrtGrdDict%addOffset(i)) * &
+                nint(1.0 / chrtGrdDict%scaleFactor(i), 8), 8)
+      chrtGrdDict%validMaxComp(i) = &
+           nint((chrtGrdDict%validMaxReal(i) + chrtGrdDict%addOffset(i)) * &
+                nint(1.0 / chrtGrdDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initChrtGrdDict
@@ -2249,10 +2290,18 @@ subroutine initLsmOutDict(lsmOutDict,procId,diagFlag)
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numLsmVars
-      lsmOutDict%fillComp(i) = NINT((lsmOutDict%fillReal(i)+lsmOutDict%addOffset(i))/lsmOutDict%scaleFactor(i))
-      lsmOutDict%missingComp(i) = NINT((lsmOutDict%missingReal(i)+lsmOutDict%addOffset(i))/lsmOutDict%scaleFactor(i))
-      lsmOutDict%validMinComp(i) = NINT((lsmOutDict%validMinReal(i)+lsmOutDict%addOffset(i))/lsmOutDict%scaleFactor(i))
-      lsmOutDict%validMaxComp(i) = NINT((lsmOutDict%validMaxReal(i)+lsmOutDict%addOffset(i))/lsmOutDict%scaleFactor(i))
+      lsmOutDict%fillComp(i) = &
+           nint((lsmOutDict%fillReal(i)     + lsmOutDict%addOffset(i)), 8) * &
+           nint(1.0 / lsmOutDict%scaleFactor(i), 8)
+      lsmOutDict%missingComp(i) = &
+           nint((lsmOutDict%missingReal(i)  + lsmOutDict%addOffset(i)), 8) * &
+           nint(1.0 / lsmOutDict%scaleFactor(i), 8)
+      lsmOutDict%validMinComp(i) = &
+           nint((lsmOutDict%validMinReal(i) + lsmOutDict%addOffset(i)) * &
+                nint(1.0 / lsmOutDict%scaleFactor(i), 8), 8)
+      lsmOutDict%validMaxComp(i) = &
+           nint((lsmOutDict%validMaxReal(i) + lsmOutDict%addOffset(i)) * &
+                nint(1.0 / lsmOutDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initLsmOutDict
@@ -2359,14 +2408,22 @@ subroutine initChanObsDict(chObsDict,diagFlag,procId)
    chObsDict%fillReal(:) = [-9999.0]
    chObsDict%missingReal(:) = [-9999.0]
    chObsDict%validMinReal(:) = [0.0]
-   chObsDict%validMaxReal(:) = [500000.0]
+   chObsDict%validMaxReal(:) = [50000.0]
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numChObsVars
-      chObsDict%fillComp(i) = int((chObsDict%fillReal(i)+chObsDict%addOffset(i))/chObsDict%scaleFactor(i))
-      chObsDict%missingComp(i) = int((chObsDict%missingReal(i)+chObsDict%addOffset(i))/chObsDict%scaleFactor(i))
-      chObsDict%validMinComp(i) = int((chObsDict%validMinReal(i)+chObsDict%addOffset(i))/chObsDict%scaleFactor(i))
-      chObsDict%validMaxComp(i) = int((chObsDict%validMaxReal(i)+chObsDict%addOffset(i))/chObsDict%scaleFactor(i))
+      chObsDict%fillComp(i) = &
+           nint((chObsDict%fillReal(i)     + chObsDict%addOffset(i)), 8) * &
+           nint(1.0 / chObsDict%scaleFactor(i), 8)
+      chObsDict%missingComp(i) = &
+           nint((chObsDict%missingReal(i)  + chObsDict%addOffset(i)), 8) * &
+           nint(1.0 / chObsDict%scaleFactor(i), 8)
+      chObsDict%validMinComp(i) = &
+           nint((chObsDict%validMinReal(i) + chObsDict%addOffset(i)) * &
+                nint(1.0 / chObsDict%scaleFactor(i), 8), 8)
+      chObsDict%validMaxComp(i) = &
+           nint((chObsDict%validMaxReal(i) + chObsDict%addOffset(i)) * &
+                nint(1.0 / chObsDict%scaleFactor(i), 8), 8)
    end do
 
 end subroutine initChanObsDict
@@ -2430,11 +2487,19 @@ subroutine initGwDict(gwOutDict)
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.
    do i=1,numGwVars
-      gwOutDict%fillComp(i) = NINT((gwOutDict%fillReal(i)+gwOutDict%addOffset(i))/gwOutDict%scaleFactor(i))
-      gwOutDict%missingComp(i) = NINT((gwOutDict%missingReal(i)+gwOutDict%addOffset(i))/gwOutDict%scaleFactor(i))
-      gwOutDict%validMinComp(i) = NINT((gwOutDict%validMinReal(i)+gwOutDict%addOffset(i))/gwOutDict%scaleFactor(i))
-      gwOutDict%validMaxComp(i) = NINT((gwOutDict%validMaxReal(i)+gwOutDict%addOffset(i))/gwOutDict%scaleFactor(i))
-end do
+      gwOutDict%fillComp(i) = &
+           nint((gwOutDict%fillReal(i)     + gwOutDict%addOffset(i)), 8) * &
+           nint(1.0 / gwOutDict%scaleFactor(i), 8)
+      gwOutDict%missingComp(i) = &
+           nint((gwOutDict%missingReal(i)  + gwOutDict%addOffset(i)), 8) * &
+           nint(1.0 / gwOutDict%scaleFactor(i), 8)
+      gwOutDict%validMinComp(i) = &
+           nint((gwOutDict%validMinReal(i) + gwOutDict%addOffset(i)) * &
+                nint(1.0 / gwOutDict%scaleFactor(i), 8), 8)
+      gwOutDict%validMaxComp(i) = &
+           nint((gwOutDict%validMaxReal(i) + gwOutDict%addOffset(i)) * &
+                nint(1.0 / gwOutDict%scaleFactor(i), 8), 8)
+   end do
 
 end subroutine initGwDict
 


### PR DESCRIPTION
Per OWP request, changing the following in the output routines:
1.) Removing vis_nir and soil_layers_stag from LDAS/RTOUT files when unused.
2.) Modifying calculation of integer conversion to maintain expected fill and valid range values. 
3.) Increasing the long range field length to prevent long name attributes from being chopped.
4.) Changing velocity units from "ms-1" to "m s-1"
5.) Reverting CHRTOUT feature_id comment field. 
6.) Modifying variable scale_factor and valid min/max values to prevent integers from exceeding 4-byte integer ranges. 