### PR TITLE
Use MPP_LAND_INIT() in Noah coupling vs direct MPI init

### DIFF
--- a/trunk/NDHMS/Land_models/Noah/IO_code/Makefile
+++ b/trunk/NDHMS/Land_models/Noah/IO_code/Makefile
@@ -18,7 +18,7 @@ Noah_hrldas_driver.o: Noah_hrldas_driver.F
 	$(RM) $(*).f
 	$(CPP) $(CPPFLAGS) $(CPPHRLDAS) $(*).F > $(*).f
 	$(COMPILERF90) -o $(@) -c $(F90FLAGS) $(FREESOURCE) $(MODFLAG). \
-	$(MODFLAG)../Noah $(MODFLAG)../Utility_routines $(NETCDFMOD) $(*).f
+	$(MODFLAG)../Noah $(MODFLAG)../Utility_routines -I../../../MPP $(NETCDFMOD) $(*).f
 	$(RM) $(*).f
 	@echo ""
 

--- a/trunk/NDHMS/Land_models/Noah/IO_code/Noah_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/Noah/IO_code/Noah_hrldas_driver.F
@@ -28,7 +28,7 @@ program Noah_hrldas_driver
   USE module_date_utilities
 
 #ifdef MPP_LAND
-  use module_mpp_land, only: MPP_LAND_PAR_INI, mpp_land_init
+  use module_mpp_land, only: MPP_LAND_PAR_INI, mpp_land_init, HYDRO_COMM_WORLD
   IMPLICIT NONE
   include "mpif.h"
 #else
@@ -1215,10 +1215,10 @@ program Noah_hrldas_driver
  endif  ! end of rank if block
 
 #ifdef MPP_LAND
-   call mpi_bcast(ix,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-   call mpi_bcast(jx,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-   call mpi_bcast(nsoil,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-   call mpi_bcast(ntime,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
+   call mpi_bcast(ix,1,MPI_INTEGER,0,HYDRO_COMM_WORLD,ierr)
+   call mpi_bcast(jx,1,MPI_INTEGER,0,HYDRO_COMM_WORLD,ierr)
+   call mpi_bcast(nsoil,1,MPI_INTEGER,0,HYDRO_COMM_WORLD,ierr)
+   call mpi_bcast(ntime,1,MPI_INTEGER,0,HYDRO_COMM_WORLD,ierr)
 #endif
 
   print*, "ix =, jx =", ix,jx

--- a/trunk/NDHMS/Land_models/Noah/IO_code/Noah_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/Noah/IO_code/Noah_hrldas_driver.F
@@ -27,10 +27,12 @@ program Noah_hrldas_driver
   USE module_sfcdif_wrf
   USE module_date_utilities
 
-  IMPLICIT NONE
-
 #ifdef MPP_LAND
+  use module_mpp_land, only: MPP_LAND_PAR_INI, mpp_land_init
+  IMPLICIT NONE
   include "mpif.h"
+#else
+  IMPLICIT NONE
 #endif
 
   character(len=9), parameter :: version = "v20110427"
@@ -507,9 +509,7 @@ program Noah_hrldas_driver
 #endif
 
 #ifdef MPP_LAND
-  call MPI_INIT(ierr)
-  if (ierr /= MPI_SUCCESS) stop "MPI_INIT"
-  call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+  call MPP_LAND_INIT()
 #else
   rank = 0
 #endif

--- a/trunk/NDHMS/MPP/mpp_land.F
+++ b/trunk/NDHMS/MPP/mpp_land.F
@@ -108,7 +108,7 @@ MODULE MODULE_MPP_LAND
         right_id = my_id + 1 
         if( left_right_p .eq. 0) left_id = -1
         if( left_right_p .eq. (left_right_np-1) ) right_id =-1
-    
+
 !    ### the IO node is the last processor.
 !yw        IO_id = numprocs - 1
          IO_id = 0
@@ -153,11 +153,14 @@ MODULE MODULE_MPP_LAND
     call mpi_initialized( mpi_inited, ierr )
     if ( .not. mpi_inited ) then
        call MPI_INIT_THREAD( MPI_THREAD_FUNNELED, provided, ierr )
+       if (ierr /= MPI_SUCCESS) error stop "MPI Error: MPI_INIT faile"
        call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
+       if (ierr /= MPI_SUCCESS) error stop "MPI Error: MPI_COMM_DUP failed"
     endif
 
     call MPI_COMM_RANK( HYDRO_COMM_WORLD, my_id, ierr )
     call MPI_COMM_SIZE( HYDRO_COMM_WORLD, numprocs, ierr )
+    if (ierr /= MPI_SUCCESS) error stop "MPI Error: MPI_COMM_RANK and/or MPI_COMM_SIZE failed"
 
     !     create 2d logical mapping of the CPU.
     call log_map2d()


### PR DESCRIPTION
**TYPE**: bug fix

**KEYWORDS**: Noah, MPI, MPP_Land

**SOURCE**: Ryan Cabell (NCAR)

**DESCRIPTION OF CHANGES:**

The Noah LSM coupling used a direct, private initialization of MPI that caused conflict with the new HYDRO_COMM_WORLD facility that was added recently to `mpp_land.F`. Not using the `MPP_LAND_INIT()` leaves the new private communicator uninitialized, leading to a segfault when attempting to access it later.

This commit updates `Noah_hrldas_driver.F` to use the new common MPP/MPI initialization scheme, `mpp_land.F` to include error handling that was being done in the Noah driver, and an update to the `Noah/IO_Code Makefile` to include the MPP module.

Produces no answer changes.

**LIST OF MODIFIED FILES:**

trunk/NDHMS/Land_models/Noah/IO_code/Makefile
trunk/NDHMS/Land_models/Noah/IO_code/Noah_hrldas_driver.F
trunk/NDHMS/MPP/mpp_land.F

**TESTS CONDUCTED:**

Noah runs complete without crashing when using the uninitialized `HYDRO_COMM_WORLD`