### PR TITLE
Fix critical bug in Noah MPI initialization

### DIFF
--- a/trunk/NDHMS/Land_models/Noah/IO_code/Noah_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/Noah/IO_code/Noah_hrldas_driver.F
@@ -510,6 +510,7 @@ program Noah_hrldas_driver
 
 #ifdef MPP_LAND
   call MPP_LAND_INIT()
+  call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
 #else
   rank = 0
 #endif


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Noah, MPI, HYDRO_COMM_WORLD

SOURCE: Ryan Cabell (NCAR)

DESCRIPTION OF CHANGES:

A bug was introduced when moving Noah from its own MPI initialization to the mpp_land module initialization where the local copy of the MPI_COMM_RANK was no longer being retrieved. This caused no obvious issues when running with one CPU, but caused a hang with OpenMPI and a crash with Intel MPI.

This commit adds a call to MPI_COMM_RANK back in where it had been removed.

Produces no answer changes.

LIST OF MODIFIED FILES:

trunk/NDHMS/Land_models/Noah/IO_code/Noah_hrldas_driver.F

TESTS CONDUCTED:

Model compiled with Noah LSM runs correctly without hanging when using > 1 CPU, on multiple MPI implementations.