### PR TITLE
Fix bug in CHRTOUT code with io_form_outputs=0

### DIFF
--- a/trunk/NDHMS/Routing/module_HYDRO_io.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_io.F
@@ -9670,7 +9670,7 @@ if (io_config_outputs .le. 0) then
      !-- prevChild
 !        iret = nf90_def_var(ncid, "prevChild", NF90_INT, (/stationdim/), varid)
 !        iret = nf90_put_att(ncid, varid, 'long_name', 'record number of the previous record for the same station')
-        iret = nf90_put_att(ncid, varid, '_FillValue', -1)
+!        iret = nf90_put_att(ncid, varid, '_FillValue', -1)
 
      !-- lastChild
 !        iret = nf90_def_var(ncid, "lastChild", NF90_INT, (/stationdim/), varid)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Noah, CHRTOUT, netcdf

SOURCE: Ryan Cabell (NCAR)

DESCRIPTION OF CHANGES:

An erroneously uncommented line in a commented-out chunk of code in the `output_chrt2()` subroutine in `module_HYDRO_io.F` was setting an invalid _FillValue value in the CHRTOUT NetCDF file. This subroutine is only used when `io_form_outputs=0`, as it is when using the Noah LSM.

This commit adds in the appropriate comment character ("`!`").

Produces no answer changes.

LIST OF MODIFIED FILES:

trunk/NDHMS/Routing/module_HYDRO_io.F

TESTS CONDUCTED:

Model compiled with Noah LSM produces CHRTOUT netcdf files.