### PR TITLE
Fixes to the overland routing off configuration.

### DIFF
--- a/trunk/NDHMS/Data_Rec/module_namelist.F
+++ b/trunk/NDHMS/Data_Rec/module_namelist.F
@@ -196,8 +196,8 @@ CONTAINS
    if(output_channelBucket_influx .ne. 0) then
       if(nlst%dt .ne. out_dt*60) &
            call hydro_stop("read_rt_nlst:: output_channelBucket_influx =! 0 inconsistent with out_dt and NOAH_TIMESTEP choices.")
-      if(output_channelBucket_influx .eq. 2 .and. GWBASESWCRT .ne. 1) &
-           call hydro_stop("read_rt_nlst:: output_channelBucket_influx = 2 but GWBASESWCRT != 1.")
+      if(output_channelBucket_influx .eq. 2 .and. GWBASESWCRT .ne. 1 .and. GWBASESWCRT .ne. 2) &
+           call hydro_stop("read_rt_nlst:: output_channelBucket_influx = 2 but GWBASESWCRT != 1 or 2.")
    end if
 
    if(CHANRTSWCRT .eq. 0 .and. channel_option .lt. 3) channel_option = 3

--- a/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
+++ b/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
@@ -259,6 +259,7 @@ module module_HYDRO_drv
 if(nlst_rt(did)%SUBRTSWCRT         .gt. 0 .or. &
    nlst_rt(did)%OVRTSWCRT          .gt. 0 .or. &
    nlst_rt(did)%GWBASESWCRT        .gt. 0 .or. &
+   nlst_rt(did)%CHANRTSWCRT        .gt. 0 .or. &
    nlst_rt(did)%channel_only       .gt. 0 .or. & 
    nlst_rt(did)%channelBucket_only .gt. 0      ) then
           
@@ -655,9 +656,31 @@ if (nlst_rt(did)%GWBASESWCRT        .ne. 0 .or. &
       if(nlst_rt(did)%OVRTSWCRT .ne. 0) then
          call OverlandRouting_drv(did)
       else
-         rt_domain(did)%overland%control%surface_water_head_routing = rt_domain(did)%overland%control%infiltration_excess
+         !ADCHANGE: Updating landRunoff instead of surface_water_head_routing. This now allows 
+         !          landRunoff to include both infxsrt from the LSM and exfiltration (if subsfc 
+         !          is active) and prevents surface_water_head_routing from inadvertently being 
+         !          passed back to the LSM.
+         if (nlst_rt(did)%UDMP_OPT .eq. 1) then
+           ! If subsurface is on, we update landRunOff to include the updated term w/ exfiltration.
+           ! If subsurface is off, landRunOff does not change from original value so we leave as-is.
+           if (nlst_rt(did)%SUBRTSWCRT .ne. 0) then
+             rt_domain(did)%landRunOff = rt_domain(did)%overland%control%infiltration_excess
+           endif
+         else
+           ! If overland is off and subsurface is on, we need to update INFXSRT (LSM grid)
+           ! since that is what gets fed through the buckets into the channels. So we aggregate
+           ! the high-res infiltration_excess back to coarse grid.
+           if (nlst_rt(did)%SUBRTSWCRT .ne. 0) then
+             call RunoffAggregate(rt_domain(did)%overland%control%infiltration_excess, &
+                                  rt_domain(did)%INFXSRT, nlst_rt(did)%AGGFACTRT, &
+                                  rt_domain(did)%ix, rt_domain(did)%jx)
+           endif
+         endif
+         ! In either case, if overland is off we need to zero-out surface_water_head since this
+         ! water is being scraped into channel and should NOT be passed back to the LSM.
          rt_domain(did)%overland%control%infiltration_excess = 0.
-      endif
+         rt_domain(did)%overland%control%surface_water_head_routing = 0.
+     endif
 #ifdef HYDRO_D
       call system_clock(count=clock_count_2, count_rate=clock_rate)
       timeOr = timeOr     + float(clock_count_2-clock_count_1)/float(clock_rate)
@@ -1309,7 +1332,38 @@ IF ( (RT_DOMAIN(did)%SMCRT(IXXRT,JYYRT,KRT)-RT_DOMAIN(did)%SMCMAXRT(IXXRT,JYYRT,
         enddo
 
       end subroutine RunOffDisag
-      
+
+
+! This routine was extracted from the aggregateDomain routine above to do simple depth aggregation.
+! There might be a simpler way.
+subroutine RunoffAggregate(runoff_in, runoff_out, aggfactrt, ix, jx)
+  implicit none
+  ! Input variables
+  integer, intent(in) :: aggfactrt, ix, jx
+  real, intent(in), dimension(:,:) :: runoff_in
+  real, intent(inout), dimension(:,:) :: runoff_out
+  ! Local variables
+  integer :: i, j, aggfacyrt, aggfacxrt, ixxrt, jyyrt
+  real :: runoffagg
+  do j=1,jx
+    do i=1,ix
+    runoffagg = 0.
+    do aggfacyrt=aggfactrt-1,0,-1
+      do aggfacxrt=aggfactrt-1,0,-1
+        ixxrt = i * aggfactrt - aggfacxrt
+        jyyrt = j * aggfactrt - aggfacyrt
+#ifdef MPP_LAND
+        if(left_id.ge.0) ixxrt = ixxrt+1
+        if(down_id.ge.0) jyyrt = jyyrt+1
+#endif
+        runoffagg = runoffagg + runoff_in(ixxrt,jyyrt)
+      end do
+    end do
+   runoff_out(i,j) = runoffagg / (aggfactrt**2)
+  end do
+end do
+end subroutine RunoffAggregate
+
 
 subroutine HYDRO_ini(ntime, did,ix0,jx0, vegtyp,soltyp)
 implicit none

--- a/trunk/NDHMS/Routing/module_GW_baseflow.F
+++ b/trunk/NDHMS/Routing/module_GW_baseflow.F
@@ -140,10 +140,6 @@ contains
                    ii =  LUDRSL(k)%cell_i(m)
                    jj =  LUDRSL(k)%cell_j(m)
                    if(ii .gt. 0 .and. jj .gt. 0) then
-                      if(OVRTSWCRT.ne.1) then
-                           LQLateral(k) = LQLateral(k)+runoff1x(ii,jj)*LUDRSL(k)%cellWeight(m)/1000 &
-                               *cellArea(ii,jj)
-                      endif
                            LQLateral(k) = LQLateral(k)+runoff2x(ii,jj)*LUDRSL(k)%cellWeight(m)/1000 &
                                *cellArea(ii,jj)
                    endif

--- a/trunk/NDHMS/Routing/module_GW_baseflow.F
+++ b/trunk/NDHMS/Routing/module_GW_baseflow.F
@@ -272,6 +272,7 @@ contains
    real, intent(in),dimension(numbasns)              :: C,ex,z_mx
    real, intent(out),dimension(numbasns)             :: qout_gwsubbas
    real, intent(out),dimension(numbasns)             :: qin_gwsubbas
+   real, dimension(numbasns)                         :: qin_gwsubbas_surf
    real*8                                            :: z_gwsubbas(numbasns)
    real                                              :: qout_max, qout_spill, z_gw_spill
    real, intent(inout),dimension(numbasns)           :: z_gwsubbas_tmp
@@ -281,9 +282,9 @@ contains
    integer, intent(in)                               :: OVRTSWCRT
    
 
-   real*8, dimension(numbasns)                      :: sum_perc8,ct_bas8
-   real, dimension(numbasns)                        :: sum_perc
-   real, dimension(numbasns)                        :: net_perc
+   real*8, dimension(numbasns)                      :: sum_perc8, ct_bas8, sum_perc8_surf
+   real, dimension(numbasns)                        :: sum_perc, sum_perc_surf
+   real, dimension(numbasns)                        :: net_perc, net_perc_surf
 
    real, dimension(numbasns)                        :: ct_bas
    real, dimension(numbasns)                        :: gwbas_pix_ct
@@ -295,9 +296,12 @@ contains
 !!!Initialize variables...
    ct_bas8 = 0
    sum_perc8 = 0.
+   sum_perc8_surf = 0.
    net_perc = 0.
+   net_perc_surf = 0.
    qout_gwsubbas = 0.
    qin_gwsubbas = 0.
+   qin_gwsubbas_surf = 0.
    z_gwsubbas = z_gwsubbas_tmp
 
 !Assign local value of runoff2 (drainage) for flux caluclation to buckets...
@@ -322,11 +326,11 @@ contains
 
        do bas=1,numbasns
          if(gwsubbasmsk(i,j).eq.basnsInd(bas) ) then
-           if(OVRTSWCRT.ne.0) then
-             sum_perc8(bas) = sum_perc8(bas)+runoff2x(i,j)  !Add only drainage to bucket...runoff2x in (mm)
-           else
-             sum_perc8(bas) = sum_perc8(bas)+runoff1x(i,j)+runoff2x(i,j)  !Add sfc water & drainage to bucket...runoff1x and runoff2x in (mm)
+           !ADCHANGE: Separate surface input from subsurface
+           if(OVRTSWCRT.eq.0) then
+             sum_perc8_surf(bas) = sum_perc8_surf(bas)+runoff1x(i,j)
            end if
+           sum_perc8(bas) = sum_perc8(bas)+runoff2x(i,j)  !Add only drainage to bucket...runoff2x in (mm)
            ct_bas8(bas) = ct_bas8(bas) + 1
          end if
        end do
@@ -335,9 +339,11 @@ contains
 
 #ifdef MPP_LAND
     call gw_sum_real(sum_perc8,numbasns,gnumbasns,basnsInd)
+    call gw_sum_real(sum_perc8_surf,numbasns,gnumbasns,basnsInd)
     call gw_sum_real(ct_bas8,numbasns,gnumbasns,basnsInd)
 #endif
    sum_perc = sum_perc8
+   sum_perc_surf = sum_perc8_surf
    ct_bas = ct_bas8
    
 
@@ -355,6 +361,10 @@ contains
      qin_gwsubbas(bas) = net_perc(bas)/1000.* &
                          ct_bas(bas)*basns_area(bas)/DT    !units (m^3/s)
 
+!ADCHANGE: Separate tracking for surface runoff term to push straight to pass-through
+     net_perc_surf(bas) = sum_perc_surf(bas) / ct_bas(bas)   !units (mm)
+     qin_gwsubbas_surf(bas) = net_perc_surf(bas)/1000.* &
+                         ct_bas(bas)*basns_area(bas)/DT    !units (m^3/s)
 
 !Adjust level of GW depth...(conceptual GW bucket units (mm))
 !DJG...old change to cms inflow...     z_gwsubbas(bas) = z_gwsubbas(bas) + net_perc(bas) / 1000.0   ! (m)
@@ -426,7 +436,8 @@ contains
                        ct_bas(bas)*basns_area(bas))*1000.   ! units (mm)	
 
 !DJG...Combine calculated bucket discharge and amount spilled from bucket...
-     qout_gwsubbas(bas) = qout_gwsubbas(bas) + qout_spill   ! units (cms)
+!ADCHANGE: Add in surface runoff as direct pass-through
+     qout_gwsubbas(bas) = qout_gwsubbas(bas) + qout_spill + qin_gwsubbas_surf(bas)  ! units (cms)
 
 
 !DJG...debug     write (6,*) "DJG...after",C(bas),ex(bas),z_gwsubbas(bas),z_mx(bas),z_gwsubbas(bas)/z_mx(bas), qout_gwsubbas(bas), qout_spill


### PR DESCRIPTION
Answer changes only when overland routing is off (affects UDMP and non-UDMP). Moved surface runoff that was mapped through GW buckets in non-UDMP configs to behave as pass-through only (as opposed to bucket attenuation; ugdrunoff is still through bucket). Both are combined for gwout. Confirmed ncores and perfect restarts. Needs at least one new output var to fully track all WB components (TBD).