### PR TITLE
Gridded channel slope fix

### DIFF
--- a/trunk/NDHMS/Routing/module_channel_routing.F
+++ b/trunk/NDHMS/Routing/module_channel_routing.F
@@ -92,8 +92,8 @@ real ::  z20, dzx
 ! added by Wei Yu for bad data.
 
 dzx = (z1 - z20)/dx
-if(dzx .lt. 0.002) then
-   z2 = z1 - dx*0.002
+if(dzx .lt. 0.02) then
+   z2 = z1 - dx*0.02
 else
    z2 = z20
 endif


### PR DESCRIPTION
Gridded channel slope check adjustment from Yates to fix instability in high flows in low slopes. Corrects negative flows in hyper-res and Luzon test cases. @dnyates and @laurareads should review/confirm I have this correct. Potentially answer changing (channel fluxes only) in gridded channel configs.