### PR TITLE
Noah-MP snow density checks

### DIFF
--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -6728,6 +6728,7 @@ ENDIF   ! CROPTYPE == 0
    REAL, DIMENSION(-NSNOW+1:0) :: EPORE     !effective porosity = porosity - VOL_ICE
    REAL :: PROPOR, TEMP
    REAL :: PONDING1, PONDING2
+   REAL, PARAMETER :: max_liq_mass_fraction = 0.4
 ! ----------------------------------------------------------------------
 
 !for the case when SNEQV becomes '0' after 'COMBINE'
@@ -6807,6 +6808,10 @@ ENDIF   ! CROPTYPE == 0
      END IF
      QOUT = QOUT*DENH2O
      SNLIQ(J) = SNLIQ(J) - QOUT
+     IF((SNLIQ(J)/(SNICE(J)+SNLIQ(J))) > max_liq_mass_fraction) THEN
+       QOUT = QOUT + (SNLIQ(J) - max_liq_mass_fraction/(1.0 - max_liq_mass_fraction)*SNICE(J))
+       SNLIQ(J) = max_liq_mass_fraction/(1.0 - max_liq_mass_fraction)*SNICE(J)
+     ENDIF
      QIN = QOUT
    END DO
 

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -5415,6 +5415,7 @@ ENDIF   ! CROPTYPE == 0
         SNEQV  = MAX(0.,TEMP1-XM(1))  
         PROPOR = SNEQV/TEMP1
         SNOWH  = MAX(0.,PROPOR * SNOWH)
+        SNOWH  = MIN(MAX(SNOWH,SNEQV/500.0),SNEQV/50.0)  ! limit adjustment to a reasonable density
         HEATR  = HM(1) - HFUS*(TEMP1-SNEQV)/DT  
         IF (HEATR > 0.) THEN
               XM(1) = HEATR*DT/HFUS             
@@ -6746,6 +6747,7 @@ ENDIF   ! CROPTYPE == 0
       SNEQV  = SNEQV - QSNSUB*DT + QSNFRO*DT
       PROPOR = SNEQV/TEMP
       SNOWH  = MAX(0.,PROPOR * SNOWH)
+      SNOWH  = MIN(MAX(SNOWH,SNEQV/500.0),SNEQV/50.0)  ! limit adjustment to a reasonable density
 
       IF(SNEQV < 0.) THEN
          SICE(1) = SICE(1) + SNEQV/(DZSNSO(1)*1000.)

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -6665,6 +6665,7 @@ ENDIF   ! CROPTYPE == 0
            ! The change in DZ due to compaction
 
            DZSNSO(J) = DZSNSO(J)*(1.+PDZDTC)
+           DZSNSO(J) = max(DZSNSO(J),SNICE(J)/DENICE + SNLIQ(J)/DENH2O)
         END IF
 
         ! Pressure of overlying snow
@@ -6807,6 +6808,10 @@ ENDIF   ! CROPTYPE == 0
      QOUT = QOUT*DENH2O
      SNLIQ(J) = SNLIQ(J) - QOUT
      QIN = QOUT
+   END DO
+
+   DO J = ISNOW+1, 0
+     DZSNSO(J) = MAX(DZSNSO(J),SNLIQ(J)/DENH2O + SNICE(J)/DENICE)
    END DO
 
 ! Liquid water from snow bottom to soil

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -6252,10 +6252,12 @@ ENDIF   ! CROPTYPE == 0
              IF(J /= 0) THEN
                 SNLIQ(J+1) = SNLIQ(J+1) + SNLIQ(J)
                 SNICE(J+1) = SNICE(J+1) + SNICE(J)
+                DZSNSO(J+1) = DZSNSO(J+1) + DZSNSO(J)
              ELSE
                IF (ISNOW_OLD < -1) THEN    ! MB/KM: change to ISNOW
                 SNLIQ(J-1) = SNLIQ(J-1) + SNLIQ(J)
                 SNICE(J-1) = SNICE(J-1) + SNICE(J)
+                DZSNSO(J-1) = DZSNSO(J-1) + DZSNSO(J)
                ELSE
 	         IF(SNICE(J) >= 0.) THEN
                   PONDING1 = SNLIQ(J)    ! ISNOW WILL GET SET TO ZERO BELOW; PONDING1 WILL GET 


### PR DESCRIPTION
This PR addresses #372 

TYPE: enhancement, bug fix

KEYWORDS: Noah-MP, snow model

SOURCE: Michael Barlage (NCAR)

DESCRIPTION OF CHANGES:

Limit snow density to not exceed that of constituent combination of liquid/ice. Also, impose stricter lower limits when the snow is in no-layer mode. Liquid fraction should also be limited based on observations.

LIST OF MODIFIED FILES:
M module_sf_noahmplsm.F
