### PR TITLE
Update README.md with correct DOI URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/NCAR/wrf_hydro_nwm_public.svg?branch=master)](https://travis-ci.org/NCAR/wrf_hydro_nwm_public)
 [![Release](https://img.shields.io/github/release/NCAR/wrf_hydro_nwm_public.svg)](https://github.com/NCAR/wrf_hydro_nwm_public/releases/latest)
-[![DOI](.github/badges/doi.svg)](https://ezid.cdlib.org/id/doi:10.5065/D6J38RBJ)
+[![DOI](.github/badges/doi.svg)](https://dx.doi.org/10.5065/D6J38RBJ)
 
 ## Description
 This is the code repository for [WRF-Hydro®](https://ral.ucar.edu/projects/wrf_hydro).


### PR DESCRIPTION
Update the DOI link on the repository's README.md page to point to the correct page.

Addresses issue #377 