### PR TITLE
Fix MPI for coupled WRF + WRF-Hydro

### DIFF
--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -28,9 +28,9 @@ module module_NoahMP_hrldas_driver
   USE config_base, only: wrf_hydro, noah_lsm
 #ifdef MPP_LAND
   use module_mpp_land, only: MPP_LAND_PAR_INI, mpp_land_init, getLocalXY, mpp_land_bcast_char, mpp_land_sync
-  use module_mpp_land, only: check_land, node_info, fatal_error_stop, numprocs
-  use module_cpl_land, only: cpl_land_init
-  use mpi
+  use module_mpp_land, only: check_land, node_info, numprocs
+  use module_cpl_land, only: cpl_land_init, fatal_error_stop
+  !use mpi
 #endif
 #ifdef WRF_HYDRO
   use module_NWM_io, only: output_NoahMP_NWM

--- a/trunk/NDHMS/MPP/CPL_WRF.F
+++ b/trunk/NDHMS/MPP/CPL_WRF.F
@@ -21,11 +21,12 @@
 !   This is used as a coupler with the WRF model.
 MODULE MODULE_CPL_LAND
 
-  !use module_mpp_land, only: HYDRO_COMM_WORLD
+    use mpi
+    use, intrinsic :: iso_fortran_env, only: error_unit
 
   IMPLICIT NONE
 
-  integer, public :: HYDRO_COMM_WORLD = -1
+  integer, public :: HYDRO_COMM_WORLD = MPI_COMM_NULL
   integer my_global_id
  
   integer total_pe_num
@@ -56,7 +57,6 @@ MODULE MODULE_CPL_LAND
 
   subroutine CPL_LAND_INIT(istart,iend,jstart,jend)
       implicit none
-   include "mpif.h"
       integer ierr
       logical mpi_inited
       integer istart,iend,jstart,jend
@@ -69,12 +69,17 @@ MODULE MODULE_CPL_LAND
 
       CALL mpi_initialized( mpi_inited, ierr )
       if ( .NOT. mpi_inited ) then
-          call mpi_init(ierr)
-          HYDRO_COMM_WORLD = MPI_COMM_WORLD
+        call mpi_init(ierr)
+        if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_INIT failed")
+      endif
+      if (HYDRO_COMM_WORLD == MPI_COMM_NULL) then
+        call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
+        if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_COMM_DUP failed")
       endif
 
       call MPI_COMM_RANK( HYDRO_COMM_WORLD, my_global_id, ierr )
       call MPI_COMM_SIZE( HYDRO_COMM_WORLD, total_pe_num, ierr )
+      if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_COMM_RANK and/or MPI_COMM_SIZE failed")
 
       allocate(node_info(9,total_pe_num))
 
@@ -126,7 +131,6 @@ MODULE MODULE_CPL_LAND
 
      subroutine send_info()
         implicit none
-   include "mpif.h"
         integer,allocatable,dimension(:,:) :: tmp_info
         integer  ierr, i,size, tag
         integer mpp_status(MPI_STATUS_SIZE)
@@ -222,4 +226,14 @@ MODULE MODULE_CPL_LAND
      return
      end subroutine find_down
 
+    ! stop the job due to the fatal error.
+    subroutine fatal_error_stop(msg)
+        character(len=*) :: msg
+        integer :: ierr
+        write(error_unit,*) "The job is stoped due to the fatal error. ", trim(msg)
+        call flush(error_unit)
+        CALL MPI_Abort(HYDRO_COMM_WORLD, 1, ierr)
+        call MPI_Finalize(ierr)
+        return
+    end  subroutine fatal_error_stop
 END MODULE MODULE_CPL_LAND

--- a/trunk/NDHMS/MPP/mpp_land.F
+++ b/trunk/NDHMS/MPP/mpp_land.F
@@ -23,7 +23,7 @@ MODULE MODULE_MPP_LAND
 
   use MODULE_CPL_LAND
   use mpi
-  use, intrinsic :: iso_fortran_env, only: error_unit
+  
   IMPLICIT NONE
   !integer, public :: HYDRO_COMM_WORLD ! communicator for WRF-Hydro - moved to MODULE_CPL_LAND
   integer, public :: left_id,right_id,up_id,down_id,my_id
@@ -109,7 +109,7 @@ MODULE MODULE_MPP_LAND
         right_id = my_id + 1 
         if( left_right_p .eq. 0) left_id = -1
         if( left_right_p .eq. (left_right_np-1) ) right_id =-1
-
+    
 !    ### the IO node is the last processor.
 !yw        IO_id = numprocs - 1
          IO_id = 0
@@ -141,8 +141,8 @@ MODULE MODULE_MPP_LAND
 
   !old subroutine MPP_LAND_INIT(flag, ew_numprocs, sn_numprocs)
   subroutine MPP_LAND_INIT()
-    !    ### initialize the land model logically based on the two D method. 
-    !    ### Call this function directly if it is nested with WRF.
+!    ### initialize the land model logically based on the two D method. 
+!    ### Call this function directly if it is nested with WRF.
     implicit none
     integer :: ierr, provided
     integer :: ew_numprocs, sn_numprocs  ! input the processors in x and y direction.
@@ -155,7 +155,8 @@ MODULE MODULE_MPP_LAND
     if ( .not. mpi_inited ) then
        call MPI_INIT_THREAD( MPI_THREAD_FUNNELED, provided, ierr )
        if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_INIT failed")
-
+    endif
+    if (HYDRO_COMM_WORLD == MPI_COMM_NULL) then
        call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
        if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_COMM_DUP failed")
     endif
@@ -2043,7 +2044,6 @@ MODULE MODULE_MPP_LAND
 !  subroutine get_globalDim(ix,g_ix)
 !     implicit none
 !     integer ix,g_ix, ierr
-!     include "mpif.h"
 !
 !     if ( my_id .eq. IO_id ) then
 !           g_ix = ix
@@ -2281,19 +2281,6 @@ MODULE MODULE_MPP_LAND
        call mpp_land_bcast_int1d(vinout)
    
   end subroutine mpp_collect_1d_int_mem
-
-     ! stop the job and log fatal error.
-     subroutine fatal_error_stop(msg)
-         character(len=*) :: msg
-         integer          :: ierr
-
-         write(error_unit,*) "Job stopped due to a fatal error: ", trim(msg)
-         call flush(error_unit)
-         call mpp_land_abort()
-         call MPI_finalize(ierr)
-
-         stop 1
-     end subroutine fatal_error_stop
 
      subroutine updateLake_seqInt(in,nsize,in0)
        implicit none


### PR DESCRIPTION
After some MPI changes that came in after version 5.0 the coupled build of WRF + WRF-Hydro was broken (see issue #383). This is simply a forward-port of a fix that was PRed into the v5.1.1 branch, re-applied to the `master` branch.

* Remove MPI_COMM_DUP from `if (.NOT. mpi_inited)`  statement

* Add additional checks for valid MPI_COMM:

   * Check if HYDRO_COMM_WORLD is not MPI_COMM_NULL, and if so, skip re-duplicating it

* Added additional MPI error logging

* Per the above, moved the error logging into the CPL_LAND module, and updated NoahMP driver to find it in the right place