### PR TITLE
Update CMakeLists and FindNetCDF.cmake module

### DIFF
--- a/trunk/NDHMS/CMakeLists.txt
+++ b/trunk/NDHMS/CMakeLists.txt
@@ -197,6 +197,8 @@ include_directories(AFTER ${PROJECT_SOURCE_DIR}/Data_Rec)
 # build the various sup-projects
 add_subdirectory("utils")
 add_subdirectory("MPP")
+add_subdirectory("IO")
+add_subdirectory("OrchestratorLayer")
 add_subdirectory("Debug_Utilities")
 add_subdirectory("Routing/Overland")
 add_subdirectory("Routing/Subsurface")
@@ -212,7 +214,9 @@ if (WRF_HYDRO_NUDGING STREQUAL "1")
 endif (WRF_HYDRO_NUDGING STREQUAL "1")
 
 # add module dependencies
-add_dependencies(hydro_debug_utils hydro_mpp) 
+add_dependencies(hydro_debug_utils hydro_mpp)
+
+add_dependencies(hydro_orchestrator hydro_netcdf_layer)
 
 add_dependencies(hydro_routing hydro_mpp)
 add_dependencies(hydro_routing hydro_routing_overland)
@@ -335,7 +339,7 @@ elseif(HYDRO_LSM MATCHES "Noah")
         target_link_libraries(wrfhydro.exe hydro_routing_reservoirs_levelpool)
         target_link_libraries(wrfhydro.exe hydro_routing_reservoirs_hybrid)
         target_link_libraries(wrfhydro.exe hydro_routing_reservoirs)        
-	target_link_libraries(wrfhydro.exe noah_util)
+	    target_link_libraries(wrfhydro.exe noah_util)
         target_link_libraries(wrfhydro.exe noah)
         target_link_libraries(wrfhydro.exe hydro_noah_cpl)
         target_link_libraries(wrfhydro.exe ${NETCDF_LIBRARIES})

--- a/trunk/NDHMS/IO/CMakeLists.txt
+++ b/trunk/NDHMS/IO/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required (VERSION 2.8)
+
+# build the orchestrator static library
+add_library(hydro_netcdf_layer STATIC
+        netcdf_layer.f90
+        )

--- a/trunk/NDHMS/OrchestratorLayer/CMakeLists.txt
+++ b/trunk/NDHMS/OrchestratorLayer/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required (VERSION 2.8)
+
+# build the orchestrator static library
+add_library(hydro_orchestrator STATIC
+        config.f90
+        io_manager.f90
+        orchestrator.f90
+        )
+
+target_link_libraries(hydro_orchestrator PUBLIC hydro_netcdf_layer)

--- a/trunk/NDHMS/Routing/CMakeLists.txt
+++ b/trunk/NDHMS/Routing/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(hydro_routing STATIC
 
 target_link_libraries(hydro_routing PUBLIC hydro_mpp)
 target_link_libraries(hydro_routing PUBLIC hydro_utils)
+target_link_libraries(hydro_routing PUBLIC hydro_orchestrator)
 target_link_libraries(hydro_routing PUBLIC hydro_routing_overland)
 target_link_libraries(hydro_routing PUBLIC hydro_routing_subsurface)
 #target_link_libraries(hydro_routing PUBLIC hydro_routing_groundwater)

--- a/trunk/NDHMS/cmake-modules/FindNetCDF.cmake
+++ b/trunk/NDHMS/cmake-modules/FindNetCDF.cmake
@@ -63,7 +63,7 @@ NetCDF_check_interface (CXX netcdfcpp.h netcdf_c++)
 NetCDF_check_interface (F77 netcdf.inc  netcdff)
 NetCDF_check_interface (F90 netcdf.mod  netcdff)
 
-set (NETCDF_LIBRARIES "${NetCDF_libs}" CACHE STRING "All NetCDF libraries required for interface level")
+set (NETCDF_LIBRARIES ${NetCDF_libs} CACHE INTERNAL "All NetCDF libraries required for interface level")
 
 # handle the QUIETLY and REQUIRED arguments and set NETCDF_FOUND to TRUE if
 # all listed variables are TRUE


### PR DESCRIPTION
The recent Orchestrator PR broke the CMake-based build system. This PR fixes that by adding in missing CMakeList.txt files, updates existing ones to use these new modules, and fixes a bug in the FindNetCDF.cmake tool to support systems where the NetCDF C and Fortran libraries are in separate dynamic library files. This fixes #389.