### PR TITLE
Change reading reservoir_type from lake parameter file to reservoir parameter file

### DIFF
--- a/trunk/NDHMS/Data_Rec/module_namelist.F
+++ b/trunk/NDHMS/Data_Rec/module_namelist.F
@@ -261,17 +261,7 @@ CONTAINS
   nlst%reservoir_parameter_file = reservoir_parameter_file
   nlst%reservoir_timeslice_path = reservoir_timeslice_path
   nlst%reservoir_observation_lookback_hours = reservoir_observation_lookback_hours
-
-  ! If in retrospective mode, set default reservoir_observation_update_time_interval_seconds to one day
-  if ( io_config_outputs .eq. 1 .or. io_config_outputs .eq. 5 ) then
-    nlst%reservoir_observation_update_time_interval_seconds = reservoir_observation_update_time_interval_seconds
-  else
-    nlst%reservoir_observation_update_time_interval_seconds = 1e9 ! default to very large value for forecast modes
-
-    if ( reservoir_observation_update_time_interval_seconds .ne. 1e9 .and. nlst%reservoir_persistence) then
-        print *, "reservoir_observation_update_time_interval_seconds automatically set to 1e9 in all forecast modes."
-    end if
-  end if
+  nlst%reservoir_observation_update_time_interval_seconds = reservoir_observation_update_time_interval_seconds
 
 #ifdef MPP_LAND
   call mpp_land_bcast_char(256,nlst%RESTART_FILE)

--- a/trunk/NDHMS/Data_Rec/module_namelist.F
+++ b/trunk/NDHMS/Data_Rec/module_namelist.F
@@ -54,7 +54,7 @@ CONTAINS
           character(len=256) :: route_direction_f=""
           character(len=256) :: route_order_f=""
           logical            :: reservoir_persistence
-          character(len=256) :: reservoir_persistence_parameter_file=""
+          character(len=256) :: reservoir_parameter_file=""
           character(len=256) :: reservoir_timeslice_path = ""
           integer            :: reservoir_observation_lookback_hours
           integer            :: reservoir_observation_update_time_interval_seconds
@@ -121,7 +121,7 @@ CONTAINS
                     GwSpinCycles, GwPreCycles, GwSpinUp, GwPreDiag, GwPreDiagInterval, gwIhShift, &
                     GWBASESWCRT, gwChanCondSw, gwChanCondConstIn, gwChanCondConstOut , &
                     route_topo_f,route_chan_f,route_link_f, compound_channel, route_lake_f, &
-                    reservoir_persistence, reservoir_persistence_parameter_file, reservoir_timeslice_path, &
+                    reservoir_persistence, reservoir_parameter_file, reservoir_timeslice_path, &
                     reservoir_observation_lookback_hours, reservoir_observation_update_time_interval_seconds, &
                     route_direction_f,route_order_f, gwbasmskfil, geo_finegrid_flnm, gwstrmfil, &
                     GW_RESTART,RSTRT_SWC,TERADJ_SOLAR, sys_cpl, &
@@ -258,7 +258,7 @@ CONTAINS
   nlst%SOLVEG_INITSWC = SOLVEG_INITSWC
   nlst%reservoir_obs_dir = "testDirectory"
   nlst%reservoir_persistence = reservoir_persistence
-  nlst%reservoir_persistence_parameter_file = reservoir_persistence_parameter_file
+  nlst%reservoir_parameter_file = reservoir_parameter_file
   nlst%reservoir_timeslice_path = reservoir_timeslice_path
   nlst%reservoir_observation_lookback_hours = reservoir_observation_lookback_hours
 
@@ -278,7 +278,7 @@ CONTAINS
   call mpp_land_bcast_char(256,nlst%hydrotbl_f)
   call mpp_land_bcast_char(1024,nlst%reservoir_obs_dir)
   call mpp_land_bcast_log1(nlst%reservoir_persistence)
-  call mpp_land_bcast_char(256,nlst%reservoir_persistence_parameter_file )
+  call mpp_land_bcast_char(256,nlst%reservoir_parameter_file )
   call mpp_land_bcast_char(256,nlst%reservoir_timeslice_path)
   call mpp_land_bcast_int1(nlst%reservoir_observation_lookback_hours)
   call mpp_land_bcast_int1(nlst%reservoir_observation_update_time_interval_seconds)
@@ -499,7 +499,7 @@ CONTAINS
     write(6,*) " nlst%route_link_f ", route_link_f
     write(6,*) " nlst%compound_channel ", compound_channel
     write(6,*) " nlst%route_lake_f ",route_lake_f
-    write(6,*) " nlst%reservoir_persistence_parameter_file ", reservoir_persistence_parameter_file
+    write(6,*) " nlst%reservoir_parameter_file ", reservoir_parameter_file
     write(6,*) " nlst%reservoir_timeslice_path ", reservoir_timeslice_path
     write(6,*) " nlst%reservoir_observation_lookback_hours ", nlst%reservoir_observation_lookback_hours
     write(6,*) " nlst%reservoir_observation_update_time_interval_seconds ", nlst%reservoir_observation_update_time_interval_seconds
@@ -771,17 +771,17 @@ subroutine rt_nlst_check(nlst)
    end if
 
    if(nlst%reservoir_persistence) then
-      if(len(trim(nlst%reservoir_persistence_parameter_file)) .eq. 0) then
-         call hydro_stop('hydro.namelist ERROR: You MUST specify a reservoir_persistence_parameter_file for &
+      if(len(trim(nlst%reservoir_parameter_file)) .eq. 0) then
+         call hydro_stop('hydro.namelist ERROR: You MUST specify a reservoir_parameter_file for &
          inputs to persistence type reservoirs.')
       endif
       if(len(trim(nlst%reservoir_timeslice_path)) .eq. 0) then
          call hydro_stop('hydro.namelist ERROR: You MUST specify a reservoir_timeslice_path for &
          reservoir persistence capability.')
       endif
-      if(len(trim(nlst%reservoir_persistence_parameter_file)) .ne. 0) then
-        inquire(file=trim(nlst%reservoir_persistence_parameter_file),exist=fileExists)
-        if (.not. fileExists) call hydro_stop('hydro.namelist ERROR: reservoir_persistence_parameter_file not found.')
+      if(len(trim(nlst%reservoir_parameter_file)) .ne. 0) then
+        inquire(file=trim(nlst%reservoir_parameter_file),exist=fileExists)
+        if (.not. fileExists) call hydro_stop('hydro.namelist ERROR: reservoir_parameter_file not found.')
       endif
     end if
 end subroutine rt_nlst_check

--- a/trunk/NDHMS/Data_Rec/namelist.inc
+++ b/trunk/NDHMS/Data_Rec/namelist.inc
@@ -42,7 +42,7 @@
           character(len=256) :: route_link_f=""
           character(len=256) :: route_lake_f=""
           logical            :: reservoir_persistence
-          character(len=256) :: reservoir_persistence_parameter_file=""
+          character(len=256) :: reservoir_parameter_file=""
           character(len=256) :: reservoir_timeslice_path=""
           integer            :: reservoir_observation_lookback_hours
           integer            :: reservoir_observation_update_time_interval_seconds

--- a/trunk/NDHMS/OrchestratorLayer/config.f90
+++ b/trunk/NDHMS/OrchestratorLayer/config.f90
@@ -37,11 +37,11 @@ module config_base
      integer            :: soil_data_option = 1
      integer            :: pedotransfer_option = 0
      integer            :: crop_option = 0
-     
+
      integer            :: split_output_count = 1
      integer            :: khour
      integer            :: kday = -999
-     real               :: zlvl 
+     real               :: zlvl
      character(len=256) :: hrldas_setup_file = " "
      character(len=256) :: mmf_runoff_file = " "
      character(len=256) :: external_veg_filename_template = " "
@@ -90,7 +90,7 @@ module config_base
 
      integer :: io_config_outputs  ! used for NCEP REALTIME OUTPUT
      integer :: io_form_outputs ! Flag to turn specify level of internal compression
-     integer :: t0OutputFlag  
+     integer :: t0OutputFlag
      integer :: channel_only, channelBucket_only
      integer :: output_channelBucket_influx ! used for FORCE_TYPE 9 and 10
 
@@ -117,7 +117,7 @@ module config_base
      character(len=256) :: geo_finegrid_flnm =""
      character(len=256) :: udmap_file =""
      character(len=256) :: GWBUCKPARM_file = ""
-     integer :: reservoir_data_ingest ! STUB FOR USE OF REALTIME RESERVOIR DISCHARGE DATA. CURRENTLY NOT IN USE. 
+     integer :: reservoir_data_ingest ! STUB FOR USE OF REALTIME RESERVOIR DISCHARGE DATA. CURRENTLY NOT IN USE.
      character(len=1024) :: reservoir_obs_dir = ""
 
      logical :: compound_channel
@@ -142,7 +142,7 @@ module config_base
      integer            :: minNumPairsBiasPersist
      integer            :: maxAgePairsBiasPersist
      logical            :: invDistTimeWeightBias
-     logical            :: noConstInterfBias  
+     logical            :: noConstInterfBias
      character(len=256) :: timeSlicePath
      integer            :: nLastObs
      integer            :: bucket_loss
@@ -150,7 +150,7 @@ module config_base
    contains
 
      procedure, pass(self) :: check => rt_nlst_check
-     
+
   END TYPE namelist_rt_
 
   type, public :: Configuration_
@@ -188,7 +188,7 @@ contains
 
     !  ! Go through and make some logical checks for each hydro.namelist option.
     !  ! Some of these checks will depend on specific options chosen by the user.
-    
+
     if( (self%sys_cpl .lt. 1) .or. (self%sys_cpl .gt. 4) ) then
        call hydro_stop("hydro.namelist ERROR: Invalid sys_cpl value specified.")
     endif
@@ -619,12 +619,12 @@ contains
        nlst(did)%reservoir_observation_update_time_interval_seconds = reservoir_observation_update_time_interval_seconds
     else
        nlst(did)%reservoir_observation_update_time_interval_seconds = 1e9 ! default to very large value for forecast modes
-       
+
        if ( reservoir_observation_update_time_interval_seconds .ne. 1e9 .and. nlst(did)%reservoir_persistence) then
           print *, "reservoir_observation_update_time_interval_seconds automatically set to 1e9 in all forecast modes."
        end if
     end if
-    
+
     write(nlst(did)%hgrid,'(I1)') igrid
 
     if(RESTART_FILE .eq. "") rst_typ = 0
@@ -713,10 +713,10 @@ contains
     nlst(did)%route_lake_f = route_lake_f
 
     nlst(did)%reservoir_persistence = reservoir_persistence
-    nlst(did)%reservoir_persistence_parameter_file = ""!reservoir_persistence_parameter_file
-    nlst(did)%reservoir_timeslice_path = ""!reservoir_timeslice_path
-    nlst(did)%reservoir_observation_lookback_hours = 18!reservoir_observation_lookback_hours
-    nlst(did)%reservoir_observation_update_time_interval_seconds = 86400!reservoir_observation_update_time_interval_seconds
+    nlst(did)%reservoir_persistence_parameter_file = reservoir_persistence_parameter_file
+    nlst(did)%reservoir_timeslice_path = reservoir_timeslice_path
+    nlst(did)%reservoir_observation_lookback_hours = reservoir_observation_lookback_hours
+    nlst(did)%reservoir_observation_update_time_interval_seconds = reservoir_observation_update_time_interval_seconds
 
     nlst(did)%route_direction_f =  route_direction_f
     nlst(did)%route_order_f =  route_order_f
@@ -847,13 +847,13 @@ contains
          start_year, start_month, start_day, start_hour, start_min, &
          outdir, &
          restart_filename_requested, restart_frequency_hours, output_timestep, &
-         
+
          dynamic_veg_option, canopy_stomatal_resistance_option, &
          btr_option, runoff_option, surface_drag_option, supercooled_water_option, &
          frozen_soil_option, radiative_transfer_option, snow_albedo_option, &
          pcp_partition_option, tbot_option, temp_time_scheme_option, &
          glacier_option, surface_resistance_option, &
-         
+
          split_output_count, &
          khour, kday, zlvl, hrldas_setup_file, mmf_runoff_file, &
          spatial_filename, &
@@ -922,7 +922,7 @@ contains
     wrf_hydro%forc_typ = forc_typ
     wrf_hydro%snow_assim = 0!snow_assim
 
-    noah_lsm%indir = indir 
+    noah_lsm%indir = indir
     noah_lsm%nsoil = nsoil ! number of soil layers
     noah_lsm%forcing_timestep = forcing_timestep
     noah_lsm%noah_timestep = noah_timestep
@@ -953,7 +953,7 @@ contains
     noah_lsm%soil_data_option = soil_data_option
     noah_lsm%pedotransfer_option = pedotransfer_option
     noah_lsm%crop_option = crop_option
-    
+
     noah_lsm%split_output_count = split_output_count
     noah_lsm%khour = khour
     noah_lsm%kday = -999!kday
@@ -972,5 +972,5 @@ contains
     noah_lsm%spatial_filename = spatial_filename
 
   end subroutine init_noah_lsm_and_wrf_hydro
-  
+
 end module config_base

--- a/trunk/NDHMS/OrchestratorLayer/config.f90
+++ b/trunk/NDHMS/OrchestratorLayer/config.f90
@@ -106,7 +106,7 @@ module config_base
      character(len=256) :: route_link_f=""
      character(len=256) :: route_lake_f=""
      logical            :: reservoir_persistence
-     character(len=256) :: reservoir_persistence_parameter_file=""
+     character(len=256) :: reservoir_parameter_file=""
      character(len=256) :: reservoir_timeslice_path=""
      integer            :: reservoir_observation_lookback_hours = 18
      integer            :: reservoir_observation_update_time_interval_seconds = 86400
@@ -395,17 +395,17 @@ contains
    end if
 
    if(self%reservoir_persistence) then
-      if(len(trim(self%reservoir_persistence_parameter_file)) .eq. 0) then
-         call hydro_stop('hydro.namelist ERROR: You MUST specify a reservoir_persistence_parameter_file for &
+      if(len(trim(self%reservoir_parameter_file)) .eq. 0) then
+         call hydro_stop('hydro.namelist ERROR: You MUST specify a reservoir_parameter_file for &
          inputs to persistence type reservoirs.')
       endif
       if(len(trim(self%reservoir_timeslice_path)) .eq. 0) then
          call hydro_stop('hydro.namelist ERROR: You MUST specify a reservoir_timeslice_path for &
          reservoir persistence capability.')
       endif
-      if(len(trim(self%reservoir_persistence_parameter_file)) .ne. 0) then
-        inquire(file=trim(self%reservoir_persistence_parameter_file),exist=fileExists)
-        if (.not. fileExists) call hydro_stop('hydro.namelist ERROR: reservoir_persistence_parameter_file not found.')
+      if(len(trim(self%reservoir_parameter_file)) .ne. 0) then
+        inquire(file=trim(self%reservoir_parameter_file),exist=fileExists)
+        if (.not. fileExists) call hydro_stop('hydro.namelist ERROR: reservoir_parameter_file not found.')
       endif
     end if
   end subroutine rt_nlst_check
@@ -429,7 +429,7 @@ contains
     logical            :: compound_channel
     character(len=256) :: route_lake_f=""
     logical            :: reservoir_persistence
-    character(len=256) :: reservoir_persistence_parameter_file=""
+    character(len=256) :: reservoir_parameter_file=""
     character(len=256) :: reservoir_timeslice_path=""
     integer            :: reservoir_observation_lookback_hours = 18
     integer            :: reservoir_observation_update_time_interval_seconds = 86400
@@ -496,7 +496,7 @@ contains
          GwSpinCycles, GwPreCycles, GwSpinUp, GwPreDiag, GwPreDiagInterval, gwIhShift, &
          GWBASESWCRT, gwChanCondSw, gwChanCondConstIn, gwChanCondConstOut , &
          route_topo_f,route_chan_f,route_link_f, compound_channel, route_lake_f, &
-         reservoir_persistence, reservoir_persistence_parameter_file, reservoir_timeslice_path, &
+         reservoir_persistence, reservoir_parameter_file, reservoir_timeslice_path, &
          reservoir_observation_lookback_hours, reservoir_observation_update_time_interval_seconds, &
          route_direction_f,route_order_f,gwbasmskfil, geo_finegrid_flnm,&
          gwstrmfil,GW_RESTART,RSTRT_SWC,TERADJ_SOLAR, sys_cpl, &
@@ -610,7 +610,7 @@ contains
     nlst(did)%reservoir_obs_dir = "testDirectory"
 
     nlst(did)%reservoir_persistence = reservoir_persistence
-    nlst(did)%reservoir_persistence_parameter_file = reservoir_persistence_parameter_file
+    nlst(did)%reservoir_parameter_file = reservoir_parameter_file
     nlst(did)%reservoir_timeslice_path = reservoir_timeslice_path
     nlst(did)%reservoir_observation_lookback_hours = reservoir_observation_lookback_hours
 
@@ -713,7 +713,7 @@ contains
     nlst(did)%route_lake_f = route_lake_f
 
     nlst(did)%reservoir_persistence = reservoir_persistence
-    nlst(did)%reservoir_persistence_parameter_file = reservoir_persistence_parameter_file
+    nlst(did)%reservoir_parameter_file = reservoir_parameter_file
     nlst(did)%reservoir_timeslice_path = reservoir_timeslice_path
     nlst(did)%reservoir_observation_lookback_hours = reservoir_observation_lookback_hours
     nlst(did)%reservoir_observation_update_time_interval_seconds = reservoir_observation_update_time_interval_seconds

--- a/trunk/NDHMS/Routing/Reservoirs/Persistence_Level_Pool_Hybrid_Module_README.md
+++ b/trunk/NDHMS/Routing/Reservoirs/Persistence_Level_Pool_Hybrid_Module_README.md
@@ -82,7 +82,7 @@ This module requires five input parameters that are set in hydro.namelist.
 * ```reservoir_persistence``` is a boolean parameter that will need to be set to ```.TRUE.``` for this module to be activated. This will cause the model to read the Q_Type variable
 from LAKEPARM.nc, the lake parameter file. The Q_Type for a hybrid reservoir is currently set to '2' in the lake parameter file.
 
-* ```reservoir_persistence_parameter_file``` is the NetCDF parameter file that holds the weights and corresponding gage ID for each lake ID.
+* ```reservoir_parameter_file``` is the NetCDF parameter file that holds the weights and corresponding gage ID for each lake ID.
 
 * ```reservoir_timeslice_path``` is the path to all the
 timeslice files used by this module.

--- a/trunk/NDHMS/Routing/Reservoirs/module_reservoir_utilities.F
+++ b/trunk/NDHMS/Routing/Reservoirs/module_reservoir_utilities.F
@@ -203,6 +203,7 @@ contains
             ! Check to ensure that each lake id in the lake_id array in the reservoir parameter file matches
             ! each lake id in the lake_id array in the lake parameter file
             do lake_index = 1, number_of_lakes
+
                 if (lake_parameter_lake_ids(lake_index) .ne. reservoir_parameter_lake_ids(lake_index)) then
                     call hydro_stop("Lake ID array in the reservoir parameter file does not match the Lake ID array &
                     in the lake parameter file.")

--- a/trunk/NDHMS/Routing/Reservoirs/module_reservoir_utilities.F
+++ b/trunk/NDHMS/Routing/Reservoirs/module_reservoir_utilities.F
@@ -160,6 +160,78 @@ contains
 
     end subroutine modify_for_projected_storage
 
+    ! Reads the reservoir_type form the reservoir parameter file. This subroutine first checks to ensure that
+    ! the lake_id array in the reservoir parameter file matches the lake_id array in the lake parameter file and
+    ! calls hydro_stop if they do not match.
+    subroutine read_reservoir_type(reservoir_parameter_file, lake_parameter_lake_ids, number_of_lake_parameter_lakes, &
+        reservoir_types)
+        character(len=*), intent(in) :: reservoir_parameter_file
+        integer, dimension(:), intent(in) :: lake_parameter_lake_ids
+        integer, intent(in) :: number_of_lake_parameter_lakes
+        integer, dimension(:), intent(inout) :: reservoir_types
+        integer, allocatable, dimension(:) :: reservoir_parameter_lake_ids
+
+        integer, dimension(nf90_max_var_dims) :: dim_ids
+        integer :: ncid, var_id, lake_index, number_of_lakes, number_of_reservoir_types
+        integer :: status                        ! status of reading NetCDF
+
+        ! Open Reservoir Parameter NetCDF file
+        status = nf90_open(path = reservoir_parameter_file, mode = nf90_nowrite, ncid = ncid)
+        if (status /= nf90_noerr) call handle_err(status, "Could not open reservoir parameter file")
+
+        status = nf90_inq_varid(ncid, "lake_id", var_id)
+        if (status /= nf90_noerr) call handle_err(status, "lake_id")
+
+        status = nf90_inquire_variable(ncid, var_id, dimids = dim_ids)
+        if(status /= nf90_NoErr) call handle_err(status, "lake_id")
+
+        status = nf90_inquire_dimension(ncid, dim_ids(1), len = number_of_lakes)
+        if(status /= nf90_NoErr) call handle_err(status, "lake_id")
+
+        allocate(reservoir_parameter_lake_ids(number_of_lakes))
+
+        status = nf90_get_var(ncid, var_id, reservoir_parameter_lake_ids)
+        if (status /= nf90_noerr) call handle_err(status, "lake_id")
+
+        ! Check to ensure that the lake_id array size in the reservoir parameter file matches the lake_id array
+        ! size in the lake parameter file
+        if (number_of_lake_parameter_lakes .ne. number_of_lakes) then
+            call hydro_stop("Lake ID array in the reservoir parameter file does not match the Lake ID array &
+            in the lake parameter file.")
+
+        else
+            ! Check to ensure that each lake id in the lake_id array in the reservoir parameter file matches
+            ! each lake id in the lake_id array in the lake parameter file
+            do lake_index = 1, number_of_lakes
+                if (lake_parameter_lake_ids(lake_index) .ne. reservoir_parameter_lake_ids(lake_index)) then
+                    call hydro_stop("Lake ID array in the reservoir parameter file does not match the Lake ID array &
+                    in the lake parameter file.")
+                end if
+            end do
+        end if
+
+        status = nf90_inq_varid(ncid, "reservoir_type", var_id)
+        if (status /= nf90_noerr) call handle_err(status, "reservoir_type")
+
+        status = nf90_inquire_variable(ncid, var_id, dimids = dim_ids)
+        if(status /= nf90_NoErr) call handle_err(status, "reservoir_type")
+
+        status = nf90_inquire_dimension(ncid, dim_ids(1), len = number_of_reservoir_types)
+        if(status /= nf90_NoErr) call handle_err(status, "reservoir_type")
+
+        ! Check to ensure that the reservoir_type array size matches the lake_id array size.
+        if (number_of_reservoir_types .ne. number_of_lakes) then
+            call hydro_stop("Reservoir Type array size in the reservoir parameter file does not match the Lake ID array size &
+            in the lake parameter file.")
+        end if
+
+        status = nf90_get_var(ncid, var_id, reservoir_types)
+        if (status /= nf90_noerr) call handle_err(status, "reservoir_type")
+
+        if(allocated(reservoir_parameter_lake_ids)) deallocate(reservoir_parameter_lake_ids)
+
+    end subroutine read_reservoir_type
+
 
     ! Gets the dimensions of the gage arrays from the timeslice file
     subroutine get_timeslice_array_dimension(ncid, netcdf_array_name, number_of_gages)

--- a/trunk/NDHMS/Routing/module_HYDRO_io.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_io.F
@@ -4167,7 +4167,7 @@ end subroutine output_chrt
          iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lat_max", "90.0")
          iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lat_min", "-90.0")
          iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lon_max", "180.0")
-         iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lon_min", "-180.0")         
+         iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lon_min", "-180.0")
          iret = nf90_put_att(ncid, NF90_GLOBAL, "model_initialization_time", trim(nlst(1)%startdate))
          iret = nf90_put_att(ncid, NF90_GLOBAL, "station_dimension", "station")
          iret = nf90_put_att(ncid, NF90_GLOBAL, "missing_value", -9E15)
@@ -5172,8 +5172,8 @@ end subroutine mpp_output_chrt
 
      output_count = output_count + 1
 
-    iret = nf90_redef(ncid) 
-    iret = nf90_put_att(ncid, NF90_GLOBAL, "model_initialization_time", trim(nlst(1)%startdate))    
+    iret = nf90_redef(ncid)
+    iret = nf90_put_att(ncid, NF90_GLOBAL, "model_initialization_time", trim(nlst(1)%startdate))
     iret = nf90_put_att(ncid, NF90_GLOBAL, "model_output_valid_time", trim(nlst(1)%olddate))
     iret = nf90_enddef(ncid)
 
@@ -5339,7 +5339,7 @@ end subroutine mpp_output_chrt
       iret = nf90_put_att(ncid, NF90_GLOBAL, "missing_value", -9E15)
       iret = nf90_put_att(ncid, NF90_GLOBAL, "Conventions", convention)
       iret = nf90_put_att(ncid, NF90_GLOBAL, "model_initialization_time", trim(nlst(1)%startdate))
-      iret = nf90_put_att(ncid, NF90_GLOBAL, "model_output_valid_time", trim(nlst(1)%olddate)) 
+      iret = nf90_put_att(ncid, NF90_GLOBAL, "model_output_valid_time", trim(nlst(1)%olddate))
       iret = nf90_enddef(ncid)
 
       iret = nf90_inq_varid(ncid,"time", varid)
@@ -5681,7 +5681,7 @@ end subroutine mpp_output_chrt
 #ifdef HYDRO_D
          write(6,*) "output file ", outFile
 #endif
-! define dimension for variables 
+! define dimension for variables
           iret = nf90_def_dim(ncid, "depth", nlst(did)%nsoil, dimid_soil)  !-- 3-d soils
 #ifdef MPP_LAND
           iret = nf90_def_dim(ncid, "ix", global_nx, dimid_ix)  !-- make a decimated grid
@@ -5717,7 +5717,7 @@ end subroutine mpp_output_chrt
         call w_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%stc,"stc")
         call w_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%smc,"smc")
         call w_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%sh2ox,"sh2ox")
-        !call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%SMCMAX1,"smcmax1") 
+        !call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%SMCMAX1,"smcmax1")
         !call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%SMCREF1,"smcref1" )
         !call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%SMCWLT1,"smcwlt1"  )
         call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%INFXSRT,"infxsrt"  )
@@ -5791,7 +5791,7 @@ end subroutine mpp_output_chrt
    if( nlst(did)%channel_only       .eq. 0 .and. &
        nlst(did)%channelBucket_only .eq. 0         ) then
 
-! define dimension for variables 
+! define dimension for variables
           iret = nf90_def_dim(ncid, "depth", nlst(did)%nsoil, dimid_soil)  !-- 3-d soils
 #ifdef MPP_LAND
           iret = nf90_def_dim(ncid, "ix", global_nx, dimid_ix)  !-- make a decimated grid
@@ -5925,7 +5925,7 @@ end subroutine mpp_output_chrt
 
    end if  !  end if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
 !                    nlst(did)%OVRTSWCRT   .eq. 1 .or. &
-!                    nlst(did)%GWBASESWCRT .ne. 0       ) 
+!                    nlst(did)%GWBASESWCRT .ne. 0       )
 
    !         put global attribute
    iret = nf90_put_att(ncid, NF90_GLOBAL, "his_out_counts", rt_domain(did)%his_out_counts)
@@ -6125,7 +6125,7 @@ if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
 
    if(nlst(did)%GWBASESWCRT.eq.3) then
       if( nlst(did)%channel_only       .eq. 0 .and. &
-          nlst(did)%channelBucket_only .eq. 0         ) &           
+          nlst(did)%channelBucket_only .eq. 0         ) &
           call w_rst_rt_nc2(ncid,rt_domain(did)%ixrt,rt_domain(did)%jxrt,gw2d(did)%ho, "HEAD" )
    end if
 
@@ -6169,7 +6169,7 @@ end if  ! end if(nlst_rt(did)%SUBRTSWCRT  .eq. 1 .or. &
           write(iunit,ERR=101) rt_domain(did)%his_out_counts
 !         write(iunit,ERR=101) nlst(did)%olddate(1:19)
           write(iunit,ERR=101) nlst(did)%sincedate(1:19)
-!         write(iunit,ERR=101) nlst_rt(did)%DTCT 
+!         write(iunit,ERR=101) nlst_rt(did)%DTCT
           write(iunit,ERR=101) rt_domain(did)%stc
           write(iunit,ERR=101) rt_domain(did)%smc
           write(iunit,ERR=101) rt_domain(did)%sh2ox
@@ -6263,7 +6263,7 @@ end if  ! end if(nlst_rt(did)%SUBRTSWCRT  .eq. 1 .or. &
           read(iunit,ERR=101) rt_domain(did)%his_out_counts
 !         read(iunit,ERR=101) nlst_rt(did)%olddate(1:19)
           read(iunit,ERR=101) nlst(did)%sincedate(1:19)
-!         read(iunit,ERR=101) nlst_rt(did)%DTCT 
+!         read(iunit,ERR=101) nlst_rt(did)%DTCT
           read(iunit,ERR=101) rt_domain(did)%stc
           read(iunit,ERR=101) rt_domain(did)%smc
           read(iunit,ERR=101) rt_domain(did)%sh2ox
@@ -6688,12 +6688,12 @@ if(IO_id .eq. my_id) then
          write(logUnit,*) 'channel_only run:', nlst(did)%channel_only
          write(logUnit,*) 'channelBucket_only restart present:', channelBucket_only_in
          write(logUnit,*) 'channelBucket_only run:', nlst(did)%channelBucket_only
-         call flush(logUnit)         
+         call flush(logUnit)
          call hydro_stop('Channel Only: Restart file in consistent with forcing type.')
       end if
    end if
 
-   iret = nf90_get_att(ncid, NF90_GLOBAL, 'his_out_counts', rt_domain(did)%his_out_counts) 
+   iret = nf90_get_att(ncid, NF90_GLOBAL, 'his_out_counts', rt_domain(did)%his_out_counts)
    iret = nf90_get_att(ncid, NF90_GLOBAL, 'DTCT', nlst(did)%DTCT)
    iret = nf90_get_att(ncid,NF90_GLOBAL,"Since_Date",nlst(did)%sincedate(1:19))
 !   if( nlst(did)%channel_only       .eq. 1 .or. &
@@ -6727,7 +6727,7 @@ write(6,*) "nlst(did)%nsoil=",nlst(did)%nsoil
 if( nlst(did)%channel_only       .eq. 0 .and. &
     nlst(did)%channelBucket_only .eq. 0         ) then
 
-   if(nlst(did)%rst_typ .eq. 1 ) then 
+   if(nlst(did)%rst_typ .eq. 1 ) then
       call read_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%stc,"stc")
       call read_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%smc,"smc")
       call read_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%sh2ox,"sh2ox")
@@ -6747,8 +6747,8 @@ endif ! neither channel_only nor channelBucket_only
 if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
    nlst(did)%OVRTSWCRT   .eq. 1 .or. &
    nlst(did)%GWBASESWCRT .ne. 0       ) then
-   !! JLM ?? restarting channel depends on these options? 
-      
+   !! JLM ?? restarting channel depends on these options?
+
    if( nlst(did)%channel_only       .eq. 0 .and. &
        nlst(did)%channelBucket_only .eq. 0         ) then
 
@@ -6794,8 +6794,8 @@ if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
       endif
 
       if( nlst(did)%channel_only       .eq. 0 .and. &
-           nlst(did)%channelBucket_only .eq. 0         ) then 
-           
+           nlst(did)%channelBucket_only .eq. 0         ) then
+
          if(nlst(did)%SUBRTSWCRT.eq.1.or.nlst(did)%OVRTSWCRT.eq.1) then
             call read_rt_nc2(ncid,rt_domain(did)%ixrt,rt_domain(did)%jxrt,rt_domain(did)%overland%streams_and_lakes%surface_water_to_lake,"lake_inflort")
          endif
@@ -6803,7 +6803,7 @@ if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
 
    end if  !  end if(nlst_rt(did)%CHANRTSWCRT.eq.1)
 
-   if((nlst(did)%GWBASESWCRT .eq. 1 .or.  & 
+   if((nlst(did)%GWBASESWCRT .eq. 1 .or.  &
       nlst(did)%GWBASESWCRT .ge. 4) .and. &
       nlst(did)%GW_RESTART  .ne. 0 .and.  &
       rt_domain(did)%gnumbasns .gt. 0) then
@@ -7345,7 +7345,7 @@ subroutine READ_CHROUTING1( &
      Tw_CC,        n_CC,              HRZAREA,      LAKEMAXH, &
      WEIRH,        WEIRC,             WEIRL,        DAML,     &
      ORIFICEC,     ORIFICEA,          ORIFICEE,               &
-     persistence,  reservoir_type,    LATLAKE,      LONLAKE,  &
+     LATLAKE,      LONLAKE,                                   &
      ELEVLAKE,     dist,              ZELEV,        LAKENODE, &
      CH_NETLNK,    CHANXI,            CHANYJ,       CHLAT,    &
      CHLON,        channel_option,    LATVAL,       LONVAL,   &
@@ -7403,7 +7403,6 @@ integer, intent(INOUT), dimension(NLINKS)   :: CHANXI, CHANYJ
 integer , dimension(:) ::  LAKEIDM
 
 !--reservoir/lake attributes
-logical, intent(IN)			            :: persistence
 real, intent(INOUT),  dimension(:)      :: HRZAREA
 
 real, intent(INOUT),  dimension(:)      :: LAKEMAXH, WEIRH
@@ -7413,7 +7412,6 @@ real, intent(INOUT),  dimension(:)      :: DAML
 real, intent(INOUT),  dimension(:)      :: ORIFICEC
 real, intent(INOUT),  dimension(:)      :: ORIFICEA
 real, intent(INOUT),  dimension(:)      :: ORIFICEE
-integer, intent(INOUT), dimension(:)    :: reservoir_type
 real, intent(INOUT),  dimension(:)      :: LATLAKE,LONLAKE,ELEVLAKE
 real, intent(INOUT),  dimension(:)      :: ChSSlp, Bw, Tw
 real, intent(INOUT),  dimension(:)      :: Tw_CC, n_CC ! channel properties of compund
@@ -7530,8 +7528,7 @@ if (channel_option .eq. 3) then
           call flush(6)
           call read_route_lake_netcdf(trim(route_lake_f),HRZAREA, &
                 LAKEMAXH, WEIRH, WEIRC,WEIRL, DAML, ORIFICEC,       &
-                ORIFICEA,  ORIFICEE, persistence, reservoir_type, &
-                LAKEIDM, latlake, lonlake, ELEVLAKE)
+                ORIFICEA,  ORIFICEE, LAKEIDM, latlake, lonlake, ELEVLAKE)
         else
           open(unit=79,file=trim(route_lake_f), form='formatted',status='old')
           write(6,*) "Before read LAKEPARM from text ", trim(route_lake_f)
@@ -7541,7 +7538,7 @@ if (channel_option .eq. 3) then
           do i=1, NLAKES
             read (79,*,err=5101) tmp, HRZAREA(i),LAKEMAXH(i), &
             WEIRC(i), WEIRL(i), ORIFICEC(i), ORIFICEA(i), ORIFICEE(i),&
-            LATLAKE(i), LONLAKE(i),ELEVLAKE(i), WEIRH(i), reservoir_type(i)
+            LATLAKE(i), LONLAKE(i),ELEVLAKE(i), WEIRH(i)
           enddo
 5101      continue
           close(79)
@@ -7570,7 +7567,6 @@ if (channel_option .eq. 3) then
       call mpp_land_bcast_real(NLAKES,LATLAKE )
       call mpp_land_bcast_real(NLAKES,LONLAKE )
       call mpp_land_bcast_real(NLAKES,ELEVLAKE)
-      call mpp_land_bcast_int(NLAKES, reservoir_type)
    endif
 #endif
 end if  !! channel_option .eq. 3
@@ -8235,8 +8231,7 @@ subroutine read_routelink(&
      ChSSlp,       Bw,           Tw,       Tw_CC,      &
      n_CC,         LAKEIDA,      HRZAREA,              &
      LAKEMAXH,     WEIRH,        WEIRC,   WEIRL, DAML, &
-     ORIFICEC,     ORIFICEA,     ORIFICEE,             &
-     persistence,  reservoir_type,         LATLAKE,    &
+     ORIFICEC,     ORIFICEA,     ORIFICEE, LATLAKE,    &
      LONLAKE,      ELEVLAKE,     LAKEIDM,  LAKEIDX,    &
      route_link_f, route_lake_f, ZELEV,    CHLAT,      &
      CHLON,        NLINKSL,      LINKID,   GNLINKSL,   &
@@ -8254,8 +8249,6 @@ integer, intent(INOUT),  dimension(:)      :: LAKEIDA !lake COMid 4all link on f
 real,    intent(INOUT),  dimension(:)      :: HRZAREA
 real,    intent(INOUT),  dimension(:)      :: LAKEMAXH, WEIRH, WEIRC, WEIRL, DAML
 real,    intent(INOUT),  dimension(:)      :: ORIFICEC, ORIFICEA, ORIFICEE
-logical, intent(IN)                        :: persistence
-integer, intent(INOUT),  dimension(:)      :: reservoir_type
 real,    intent(INOUT),  dimension(:)      :: LATLAKE, LONLAKE, ELEVLAKE
 integer, intent(INOUT), dimension(:)       :: LAKEIDM !lake id in LAKEPARM table (.nc or .tbl)
 integer, intent(INOUT),  dimension(:)      :: LAKEIDX !seq index of lakes(1:Nlakes) mapped to COMID
@@ -8279,7 +8272,7 @@ call readLinkSL( GNLINKSL,NLINKSL,route_link_f, route_lake_f,maxorder, &
      QLINK,CHLON, CHLAT, ZELEV, MUSK, MUSX, CHANLEN, &
      MannN, So, ChSSlp, Bw, Tw, Tw_CC, n_CC, LAKEIDA, HRZAREA,  &
      LAKEMAXH, WEIRH, WEIRC, WEIRL, DAML, ORIFICEC, &
-     ORIFICEA, ORIFICEE, persistence, reservoir_type, gages, gageMiss, &
+     ORIFICEA, ORIFICEE, gages, gageMiss, &
      LAKEIDM, NLAKES, latlake, lonlake,ELEVLAKE)
 
 !--- get the lake configuration here.
@@ -8308,7 +8301,6 @@ if (NLAKES > 0) then
    call mpp_land_bcast_real(NLAKES,LATLAKE )
    call mpp_land_bcast_real(NLAKES,LONLAKE )
    call mpp_land_bcast_real(NLAKES,ELEVLAKE)
-   call mpp_land_bcast_int(NLAKES, reservoir_type)
 endif
 #endif
 
@@ -8321,7 +8313,7 @@ end subroutine read_routelink
                    QLINK,CHLON, CHLAT, ZELEV, MUSK, MUSX, CHANLEN, &
                    MannN, So, ChSSlp, Bw, Tw, Tw_CC, n_CC, LAKEIDA, HRZAREA,  &
                    LAKEMAXH,WEIRH,  WEIRC, WEIRL, DAML, ORIFICEC, &
-                   ORIFICEA, ORIFICEE, persistence, reservoir_type, gages, gageMiss,&
+                   ORIFICEA, ORIFICEE, gages, gageMiss,&
                    LAKEIDM,NLAKES, latlake, lonlake, ELEVLAKE)
 
         implicit none
@@ -8339,8 +8331,7 @@ end subroutine read_routelink
         character(len=15), intent(in) :: gageMiss
 
 !NLAKES
-        INTEGER, intent(out), dimension(:)  ::  LAKEIDM, reservoir_type
-        logical, intent(in)		            ::  persistence
+        INTEGER, intent(out), dimension(:)  ::  LAKEIDM
         REAL, intent(out), dimension(:) :: HRZAREA,LAKEMAXH, WEIRC, WEIRL, DAML, ORIFICEC, WEIRH, &
                    ORIFICEA, ORIFICEE, ELEVLAKE
 !end NLAKES
@@ -8427,7 +8418,7 @@ end subroutine read_routelink
           if(routeLakeNetcdf) then
              call read_route_lake_netcdf(route_lake_f,HRZAREA, &
                 LAKEMAXH, WEIRH, WEIRC, WEIRL, DAML, ORIFICEC,       &
-                ORIFICEA,  ORIFICEE, persistence, reservoir_type, LAKEIDM, latlake, lonlake, ELEVLAKE)
+                ORIFICEA,  ORIFICEE, LAKEIDM, latlake, lonlake, ELEVLAKE)
           endif
 
 !!- initialize channel  if missing in input
@@ -8486,7 +8477,6 @@ end subroutine read_routelink
            call mpp_land_bcast_real(NLAKES, ORIFICEE)
            call mpp_land_bcast_int(NLAKES, LAKEIDM)
            call mpp_land_bcast_real(NLAKES, ELEVLAKE)
-           call mpp_land_bcast_int(NLAKES, reservoir_type)
         endif
 
 
@@ -8585,7 +8575,7 @@ subroutine MPP_READ_CHROUTING_new(&
      n_CC,         HRZAREA,           LAKEMAXH,                  &
      WEIRH,        WEIRC,             WEIRL,          DAML,      &
      ORIFICEC,     ORIFICEA,          ORIFICEE,                  &
-     persistence,  reservoir_type,    LATLAKE,        LONLAKE,   &
+     LATLAKE,      LONLAKE,                                      &
      ELEVLAKE,     dist,              ZELEV,          LAKENODE,  &
      CH_NETLNK,    CHANXI,            CHANYJ,         CHLAT,     &
      CHLON,        channel_option,    LATVAL,         LONVAL,    &
@@ -8619,7 +8609,6 @@ integer, intent(INOUT),  dimension(NLINKS)   :: map_l2g
 !-- store the location x,y location of the channel element
 integer, intent(INOUT), dimension(NLINKS)   :: CHANXI, CHANYJ
 
-logical, intent(IN)                          :: persistence
 real, intent(INOUT),  dimension(NLAKES)      :: HRZAREA
 real, intent(INOUT),  dimension(NLAKES)      :: LAKEMAXH, WEIRH
 real, intent(INOUT),  dimension(NLAKES)      :: WEIRC
@@ -8628,7 +8617,6 @@ real, intent(INOUT),  dimension(NLAKES)      :: DAML
 real, intent(INOUT),  dimension(NLAKES)      :: ORIFICEC
 real, intent(INOUT),  dimension(NLAKES)      :: ORIFICEA
 real, intent(INOUT),  dimension(NLAKES)      :: ORIFICEE
-integer, intent(INOUT), dimension(NLAKES)    :: reservoir_type
 real, intent(INOUT),  dimension(NLAKES)      :: LATLAKE,LONLAKE,ELEVLAKE
 real, intent(INOUT), dimension(NLINKS)       :: ChSSlp, Bw, Tw
 real, intent(INOUT), dimension(NLINKS)       :: Tw_CC, n_CC
@@ -8659,7 +8647,7 @@ call READ_CHROUTING1( &
      n_CC,         HRZAREA,           LAKEMAXH,           &
      WEIRH,        WEIRC,             WEIRL,     DAML,    &
      ORIFICEC,     ORIFICEA,          ORIFICEE,           &
-     persistence,  reservoir_type,    LATLAKE,   LONLAKE, &
+     LATLAKE,      LONLAKE,                               &
      ELEVLAKE,     dist,              ZELEV,     LAKENODE,&
      CH_NETLNK,    CHANXI,            CHANYJ,    CHLAT,   &
      CHLON,        channel_option,    LATVAL,    LONVAL,  &
@@ -8737,7 +8725,6 @@ if (NLAKES > 0) then
    call mpp_land_bcast_real(NLAKES,LATLAKE)
    call mpp_land_bcast_real(NLAKES,LONLAKE)
    call mpp_land_bcast_real(NLAKES,ELEVLAKE)
-   call mpp_land_bcast_int(NLAKES, reservoir_type)
 endif
 
 link_location = CH_NETLNK
@@ -8792,7 +8779,7 @@ end subroutine MPP_READ_CHROUTING_new
            do i = 1, rt_domain(did)%gnlinks
               if(STRMFRXSTPTS(i) .gt. 0) then
                    write(75,114) nlst(did)%olddate(1:4),nlst(did)%olddate(6:7),nlst(did)%olddate(9:10), nlst(did)%olddate(12:13), &
-                         cnt,chlon(i),chlat(i),g_dayMean(i) 
+                         cnt,chlon(i),chlat(i),g_dayMean(i)
                    cnt = cnt + 1
               endif
            end do
@@ -8962,18 +8949,15 @@ end subroutine read_route_link_netcdf
 !
 subroutine read_route_lake_netcdf(route_lake_file,                         &
                                    HRZAREA,  LAKEMAXH, WEIRH,  WEIRC,    WEIRL, DAML,   &
-                                   ORIFICEC, ORIFICEA,  ORIFICEE,  persistence, &
-                                   reservoir_type, LAKEIDM, lakelat, lakelon, ELEVLAKE)
+                                   ORIFICEC, ORIFICEA,  ORIFICEE, LAKEIDM, &
+                                   lakelat, lakelon, ELEVLAKE)
 
     implicit none
     character(len=*),        intent(in)  :: route_lake_file
-    logical,                 intent(in)  :: persistence
     integer, dimension(:),   intent(out) :: LAKEIDM
     real,    dimension(:),   intent(out) :: HRZAREA,  LAKEMAXH, WEIRC,    WEIRL, WEIRH, DAML
     real,    dimension(:),   intent(out) :: ORIFICEC, ORIFICEA, ORIFICEE, lakelat, lakelon
     real,    dimension(:),   intent(out) :: ELEVLAKE
-    integer, dimension(:),   intent(out) :: reservoir_type
-
 
     integer :: iRet, ncid, ii, varid
     logical :: fatal_if_error
@@ -9001,9 +8985,6 @@ subroutine read_route_lake_netcdf(route_lake_file,                         &
     call get_1d_netcdf_real(ncid, 'OrificeC', ORIFICEC,  'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'OrificeA', ORIFICEA,  'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'OrificeE', ORIFICEE,  'read_route_lake_netcdf', .TRUE.)
-    if (persistence) then
-       call get_1d_netcdf_int(ncid, 'reservoir_type', reservoir_type, 'read_route_lake_netcdf', .TRUE.)
-    end if
     call get_1d_netcdf_real(ncid, 'lat', lakelat,        'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'lon', lakelon,        'read_route_lake_netcdf', .TRUE.)
     !remove the alt var. and add initial fractional depth var. LKR/DY
@@ -9956,7 +9937,7 @@ end subroutine output_chrt2
                allocate(g_basnsInd(rt_domain(did)%gnlinksl))
                gnbasns = rt_domain(did)%gnlinksl
           endif
-       endif 
+       endif
 
        if(nlst(did)%channel_option .ne. 3) then
           call ReachLS_write_io(rt_domain(did)%qin_gwsubbas,g_qin_gwsubbas)
@@ -10071,7 +10052,7 @@ end subroutine output_chrt2
                   //startdate(12:13)//':'//startdate(15:16)//':00'
 
      seconds_since = int(nlst(1)%out_dt*60*(rt_domain(1)%out_counts-1))
-     
+
      sec_valid_date = 'seconds since '//nlst(1)%startdate(1:4)//'-'//nlst(1)%startdate(6:7)//'-'//nlst(1)%startdate(9:10) &
                       //' '//nlst(1)%startdate(12:13)//':'//nlst(1)%startdate(15:16)//' UTC'
 
@@ -11086,7 +11067,7 @@ if(my_id .eq. io_id) then
    !if( (nlst_rt(did)%channel_only .eq. 0 .and. nlst_rt(did)%channelBucket_only .eq. 0) .and. &
    !    (channel_only_in .eq. 1 .or.  channelBucket_only_in .eq. 1)        ) &
    !    call hydro_stop('Channel Only: Forcing files in consistent with forcing type.')
-   !! Second row: 
+   !! Second row:
    if(nlst(did)%channel_only .eq. 1 .and. channelBucket_only_in .eq. 1) &
         write(6,*) "Warning: channelBucket_only output forcing channel_only run"
 
@@ -11143,7 +11124,7 @@ if(.FALSE.) then
 
    !! Calculate the current
    if(len .gt. 0) then  !! would the length be zero on some images?
-      rt_domain(did)%qout_gwsubbas = & 
+      rt_domain(did)%qout_gwsubbas = &
            real( (accBucket_in - rt_domain(did)%accBucket)/nlst(did)%DT )
       rt_domain(did)%QLateral      = &
            real( rt_domain(did)%qout_gwsubbas +     &

--- a/trunk/NDHMS/Routing/module_HYDRO_io.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_io.F
@@ -31,6 +31,7 @@ module module_HYDRO_io
    use config_base, only: nlst
    use module_RT_data, only: rt_domain
    use module_gw_gw2d_data, only: gw2d
+   use module_reservoir_utilities, only: read_reservoir_type
    use netcdf
 
    implicit none
@@ -4167,7 +4168,7 @@ end subroutine output_chrt
          iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lat_max", "90.0")
          iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lat_min", "-90.0")
          iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lon_max", "180.0")
-         iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lon_min", "-180.0")         
+         iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lon_min", "-180.0")
          iret = nf90_put_att(ncid, NF90_GLOBAL, "model_initialization_time", trim(nlst(1)%startdate))
          iret = nf90_put_att(ncid, NF90_GLOBAL, "station_dimension", "station")
          iret = nf90_put_att(ncid, NF90_GLOBAL, "missing_value", -9E15)
@@ -5172,8 +5173,8 @@ end subroutine mpp_output_chrt
 
      output_count = output_count + 1
 
-    iret = nf90_redef(ncid) 
-    iret = nf90_put_att(ncid, NF90_GLOBAL, "model_initialization_time", trim(nlst(1)%startdate))    
+    iret = nf90_redef(ncid)
+    iret = nf90_put_att(ncid, NF90_GLOBAL, "model_initialization_time", trim(nlst(1)%startdate))
     iret = nf90_put_att(ncid, NF90_GLOBAL, "model_output_valid_time", trim(nlst(1)%olddate))
     iret = nf90_enddef(ncid)
 
@@ -5339,7 +5340,7 @@ end subroutine mpp_output_chrt
       iret = nf90_put_att(ncid, NF90_GLOBAL, "missing_value", -9E15)
       iret = nf90_put_att(ncid, NF90_GLOBAL, "Conventions", convention)
       iret = nf90_put_att(ncid, NF90_GLOBAL, "model_initialization_time", trim(nlst(1)%startdate))
-      iret = nf90_put_att(ncid, NF90_GLOBAL, "model_output_valid_time", trim(nlst(1)%olddate)) 
+      iret = nf90_put_att(ncid, NF90_GLOBAL, "model_output_valid_time", trim(nlst(1)%olddate))
       iret = nf90_enddef(ncid)
 
       iret = nf90_inq_varid(ncid,"time", varid)
@@ -5681,7 +5682,7 @@ end subroutine mpp_output_chrt
 #ifdef HYDRO_D
          write(6,*) "output file ", outFile
 #endif
-! define dimension for variables 
+! define dimension for variables
           iret = nf90_def_dim(ncid, "depth", nlst(did)%nsoil, dimid_soil)  !-- 3-d soils
 #ifdef MPP_LAND
           iret = nf90_def_dim(ncid, "ix", global_nx, dimid_ix)  !-- make a decimated grid
@@ -5717,7 +5718,7 @@ end subroutine mpp_output_chrt
         call w_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%stc,"stc")
         call w_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%smc,"smc")
         call w_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%sh2ox,"sh2ox")
-        !call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%SMCMAX1,"smcmax1") 
+        !call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%SMCMAX1,"smcmax1")
         !call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%SMCREF1,"smcref1" )
         !call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%SMCWLT1,"smcwlt1"  )
         call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%INFXSRT,"infxsrt"  )
@@ -5791,7 +5792,7 @@ end subroutine mpp_output_chrt
    if( nlst(did)%channel_only       .eq. 0 .and. &
        nlst(did)%channelBucket_only .eq. 0         ) then
 
-! define dimension for variables 
+! define dimension for variables
           iret = nf90_def_dim(ncid, "depth", nlst(did)%nsoil, dimid_soil)  !-- 3-d soils
 #ifdef MPP_LAND
           iret = nf90_def_dim(ncid, "ix", global_nx, dimid_ix)  !-- make a decimated grid
@@ -5925,7 +5926,7 @@ end subroutine mpp_output_chrt
 
    end if  !  end if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
 !                    nlst(did)%OVRTSWCRT   .eq. 1 .or. &
-!                    nlst(did)%GWBASESWCRT .ne. 0       ) 
+!                    nlst(did)%GWBASESWCRT .ne. 0       )
 
    !         put global attribute
    iret = nf90_put_att(ncid, NF90_GLOBAL, "his_out_counts", rt_domain(did)%his_out_counts)
@@ -6125,7 +6126,7 @@ if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
 
    if(nlst(did)%GWBASESWCRT.eq.3) then
       if( nlst(did)%channel_only       .eq. 0 .and. &
-          nlst(did)%channelBucket_only .eq. 0         ) &           
+          nlst(did)%channelBucket_only .eq. 0         ) &
           call w_rst_rt_nc2(ncid,rt_domain(did)%ixrt,rt_domain(did)%jxrt,gw2d(did)%ho, "HEAD" )
    end if
 
@@ -6169,7 +6170,7 @@ end if  ! end if(nlst_rt(did)%SUBRTSWCRT  .eq. 1 .or. &
           write(iunit,ERR=101) rt_domain(did)%his_out_counts
 !         write(iunit,ERR=101) nlst(did)%olddate(1:19)
           write(iunit,ERR=101) nlst(did)%sincedate(1:19)
-!         write(iunit,ERR=101) nlst_rt(did)%DTCT 
+!         write(iunit,ERR=101) nlst_rt(did)%DTCT
           write(iunit,ERR=101) rt_domain(did)%stc
           write(iunit,ERR=101) rt_domain(did)%smc
           write(iunit,ERR=101) rt_domain(did)%sh2ox
@@ -6263,7 +6264,7 @@ end if  ! end if(nlst_rt(did)%SUBRTSWCRT  .eq. 1 .or. &
           read(iunit,ERR=101) rt_domain(did)%his_out_counts
 !         read(iunit,ERR=101) nlst_rt(did)%olddate(1:19)
           read(iunit,ERR=101) nlst(did)%sincedate(1:19)
-!         read(iunit,ERR=101) nlst_rt(did)%DTCT 
+!         read(iunit,ERR=101) nlst_rt(did)%DTCT
           read(iunit,ERR=101) rt_domain(did)%stc
           read(iunit,ERR=101) rt_domain(did)%smc
           read(iunit,ERR=101) rt_domain(did)%sh2ox
@@ -6688,12 +6689,12 @@ if(IO_id .eq. my_id) then
          write(logUnit,*) 'channel_only run:', nlst(did)%channel_only
          write(logUnit,*) 'channelBucket_only restart present:', channelBucket_only_in
          write(logUnit,*) 'channelBucket_only run:', nlst(did)%channelBucket_only
-         call flush(logUnit)         
+         call flush(logUnit)
          call hydro_stop('Channel Only: Restart file in consistent with forcing type.')
       end if
    end if
 
-   iret = nf90_get_att(ncid, NF90_GLOBAL, 'his_out_counts', rt_domain(did)%his_out_counts) 
+   iret = nf90_get_att(ncid, NF90_GLOBAL, 'his_out_counts', rt_domain(did)%his_out_counts)
    iret = nf90_get_att(ncid, NF90_GLOBAL, 'DTCT', nlst(did)%DTCT)
    iret = nf90_get_att(ncid,NF90_GLOBAL,"Since_Date",nlst(did)%sincedate(1:19))
 !   if( nlst(did)%channel_only       .eq. 1 .or. &
@@ -6727,7 +6728,7 @@ write(6,*) "nlst(did)%nsoil=",nlst(did)%nsoil
 if( nlst(did)%channel_only       .eq. 0 .and. &
     nlst(did)%channelBucket_only .eq. 0         ) then
 
-   if(nlst(did)%rst_typ .eq. 1 ) then 
+   if(nlst(did)%rst_typ .eq. 1 ) then
       call read_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%stc,"stc")
       call read_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%smc,"smc")
       call read_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%sh2ox,"sh2ox")
@@ -6747,8 +6748,8 @@ endif ! neither channel_only nor channelBucket_only
 if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
    nlst(did)%OVRTSWCRT   .eq. 1 .or. &
    nlst(did)%GWBASESWCRT .ne. 0       ) then
-   !! JLM ?? restarting channel depends on these options? 
-      
+   !! JLM ?? restarting channel depends on these options?
+
    if( nlst(did)%channel_only       .eq. 0 .and. &
        nlst(did)%channelBucket_only .eq. 0         ) then
 
@@ -6794,8 +6795,8 @@ if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
       endif
 
       if( nlst(did)%channel_only       .eq. 0 .and. &
-           nlst(did)%channelBucket_only .eq. 0         ) then 
-           
+           nlst(did)%channelBucket_only .eq. 0         ) then
+
          if(nlst(did)%SUBRTSWCRT.eq.1.or.nlst(did)%OVRTSWCRT.eq.1) then
             call read_rt_nc2(ncid,rt_domain(did)%ixrt,rt_domain(did)%jxrt,rt_domain(did)%overland%streams_and_lakes%surface_water_to_lake,"lake_inflort")
          endif
@@ -6803,7 +6804,7 @@ if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
 
    end if  !  end if(nlst_rt(did)%CHANRTSWCRT.eq.1)
 
-   if((nlst(did)%GWBASESWCRT .eq. 1 .or.  & 
+   if((nlst(did)%GWBASESWCRT .eq. 1 .or.  &
       nlst(did)%GWBASESWCRT .ge. 4) .and. &
       nlst(did)%GW_RESTART  .ne. 0 .and.  &
       rt_domain(did)%gnumbasns .gt. 0) then
@@ -7345,7 +7346,8 @@ subroutine READ_CHROUTING1( &
      Tw_CC,        n_CC,              HRZAREA,      LAKEMAXH, &
      WEIRH,        WEIRC,             WEIRL,        DAML,     &
      ORIFICEC,     ORIFICEA,          ORIFICEE,               &
-     persistence,  reservoir_type,    LATLAKE,      LONLAKE,  &
+     persistence,  reservoir_type,                            &
+     reservoir_parameter_file,        LATLAKE,      LONLAKE,  &
      ELEVLAKE,     dist,              ZELEV,        LAKENODE, &
      CH_NETLNK,    CHANXI,            CHANYJ,       CHLAT,    &
      CHLON,        channel_option,    LATVAL,       LONVAL,   &
@@ -7414,6 +7416,7 @@ real, intent(INOUT),  dimension(:)      :: ORIFICEC
 real, intent(INOUT),  dimension(:)      :: ORIFICEA
 real, intent(INOUT),  dimension(:)      :: ORIFICEE
 integer, intent(INOUT), dimension(:)    :: reservoir_type
+character(len=*), intent(in)            :: reservoir_parameter_file
 real, intent(INOUT),  dimension(:)      :: LATLAKE,LONLAKE,ELEVLAKE
 real, intent(INOUT),  dimension(:)      :: ChSSlp, Bw, Tw
 real, intent(INOUT),  dimension(:)      :: Tw_CC, n_CC ! channel properties of compund
@@ -7531,7 +7534,7 @@ if (channel_option .eq. 3) then
           call read_route_lake_netcdf(trim(route_lake_f),HRZAREA, &
                 LAKEMAXH, WEIRH, WEIRC,WEIRL, DAML, ORIFICEC,       &
                 ORIFICEA,  ORIFICEE, persistence, reservoir_type, &
-                LAKEIDM, latlake, lonlake, ELEVLAKE)
+                reservoir_parameter_file, LAKEIDM, latlake, lonlake, ELEVLAKE, NLAKES)
         else
           open(unit=79,file=trim(route_lake_f), form='formatted',status='old')
           write(6,*) "Before read LAKEPARM from text ", trim(route_lake_f)
@@ -8236,7 +8239,8 @@ subroutine read_routelink(&
      n_CC,         LAKEIDA,      HRZAREA,              &
      LAKEMAXH,     WEIRH,        WEIRC,   WEIRL, DAML, &
      ORIFICEC,     ORIFICEA,     ORIFICEE,             &
-     persistence,  reservoir_type,         LATLAKE,    &
+     persistence,  reservoir_type,                     &
+     reservoir_parameter_file,   LATLAKE,              &
      LONLAKE,      ELEVLAKE,     LAKEIDM,  LAKEIDX,    &
      route_link_f, route_lake_f, ZELEV,    CHLAT,      &
      CHLON,        NLINKSL,      LINKID,   GNLINKSL,   &
@@ -8256,6 +8260,7 @@ real,    intent(INOUT),  dimension(:)      :: LAKEMAXH, WEIRH, WEIRC, WEIRL, DAM
 real,    intent(INOUT),  dimension(:)      :: ORIFICEC, ORIFICEA, ORIFICEE
 logical, intent(IN)                        :: persistence
 integer, intent(INOUT),  dimension(:)      :: reservoir_type
+character(len=*), intent(in)               :: reservoir_parameter_file
 real,    intent(INOUT),  dimension(:)      :: LATLAKE, LONLAKE, ELEVLAKE
 integer, intent(INOUT), dimension(:)       :: LAKEIDM !lake id in LAKEPARM table (.nc or .tbl)
 integer, intent(INOUT),  dimension(:)      :: LAKEIDX !seq index of lakes(1:Nlakes) mapped to COMID
@@ -8279,8 +8284,8 @@ call readLinkSL( GNLINKSL,NLINKSL,route_link_f, route_lake_f,maxorder, &
      QLINK,CHLON, CHLAT, ZELEV, MUSK, MUSX, CHANLEN, &
      MannN, So, ChSSlp, Bw, Tw, Tw_CC, n_CC, LAKEIDA, HRZAREA,  &
      LAKEMAXH, WEIRH, WEIRC, WEIRL, DAML, ORIFICEC, &
-     ORIFICEA, ORIFICEE, persistence, reservoir_type, gages, gageMiss, &
-     LAKEIDM, NLAKES, latlake, lonlake,ELEVLAKE)
+     ORIFICEA, ORIFICEE, persistence, reservoir_type, reservoir_parameter_file, &
+     gages, gageMiss, LAKEIDM, NLAKES, latlake, lonlake,ELEVLAKE)
 
 !--- get the lake configuration here.
 #ifdef MPP_LAND
@@ -8321,8 +8326,8 @@ end subroutine read_routelink
                    QLINK,CHLON, CHLAT, ZELEV, MUSK, MUSX, CHANLEN, &
                    MannN, So, ChSSlp, Bw, Tw, Tw_CC, n_CC, LAKEIDA, HRZAREA,  &
                    LAKEMAXH,WEIRH,  WEIRC, WEIRL, DAML, ORIFICEC, &
-                   ORIFICEA, ORIFICEE, persistence, reservoir_type, gages, gageMiss,&
-                   LAKEIDM,NLAKES, latlake, lonlake, ELEVLAKE)
+                   ORIFICEA, ORIFICEE, persistence, reservoir_type, reservoir_parameter_file, &
+                   gages, gageMiss, LAKEIDM,NLAKES, latlake, lonlake, ELEVLAKE)
 
         implicit none
         character(len=*) :: route_link_f,route_lake_f
@@ -8341,6 +8346,7 @@ end subroutine read_routelink
 !NLAKES
         INTEGER, intent(out), dimension(:)  ::  LAKEIDM, reservoir_type
         logical, intent(in)		            ::  persistence
+        character(len=*), intent(in)        ::  reservoir_parameter_file
         REAL, intent(out), dimension(:) :: HRZAREA,LAKEMAXH, WEIRC, WEIRL, DAML, ORIFICEC, WEIRH, &
                    ORIFICEA, ORIFICEE, ELEVLAKE
 !end NLAKES
@@ -8427,7 +8433,8 @@ end subroutine read_routelink
           if(routeLakeNetcdf) then
              call read_route_lake_netcdf(route_lake_f,HRZAREA, &
                 LAKEMAXH, WEIRH, WEIRC, WEIRL, DAML, ORIFICEC,       &
-                ORIFICEA,  ORIFICEE, persistence, reservoir_type, LAKEIDM, latlake, lonlake, ELEVLAKE)
+                ORIFICEA,  ORIFICEE, persistence, reservoir_type, reservoir_parameter_file, &
+                LAKEIDM, latlake, lonlake, ELEVLAKE, NLAKES)
           endif
 
 !!- initialize channel  if missing in input
@@ -8585,7 +8592,8 @@ subroutine MPP_READ_CHROUTING_new(&
      n_CC,         HRZAREA,           LAKEMAXH,                  &
      WEIRH,        WEIRC,             WEIRL,          DAML,      &
      ORIFICEC,     ORIFICEA,          ORIFICEE,                  &
-     persistence,  reservoir_type,    LATLAKE,        LONLAKE,   &
+     persistence,  reservoir_type,    reservoir_parameter_file,  &
+     LATLAKE,        LONLAKE,                                    &
      ELEVLAKE,     dist,              ZELEV,          LAKENODE,  &
      CH_NETLNK,    CHANXI,            CHANYJ,         CHLAT,     &
      CHLON,        channel_option,    LATVAL,         LONVAL,    &
@@ -8629,6 +8637,7 @@ real, intent(INOUT),  dimension(NLAKES)      :: ORIFICEC
 real, intent(INOUT),  dimension(NLAKES)      :: ORIFICEA
 real, intent(INOUT),  dimension(NLAKES)      :: ORIFICEE
 integer, intent(INOUT), dimension(NLAKES)    :: reservoir_type
+character(len=*), intent(in)                 :: reservoir_parameter_file
 real, intent(INOUT),  dimension(NLAKES)      :: LATLAKE,LONLAKE,ELEVLAKE
 real, intent(INOUT), dimension(NLINKS)       :: ChSSlp, Bw, Tw
 real, intent(INOUT), dimension(NLINKS)       :: Tw_CC, n_CC
@@ -8659,7 +8668,8 @@ call READ_CHROUTING1( &
      n_CC,         HRZAREA,           LAKEMAXH,           &
      WEIRH,        WEIRC,             WEIRL,     DAML,    &
      ORIFICEC,     ORIFICEA,          ORIFICEE,           &
-     persistence,  reservoir_type,    LATLAKE,   LONLAKE, &
+     persistence,  reservoir_type,                        &
+     reservoir_parameter_file,        LATLAKE,   LONLAKE, &
      ELEVLAKE,     dist,              ZELEV,     LAKENODE,&
      CH_NETLNK,    CHANXI,            CHANYJ,    CHLAT,   &
      CHLON,        channel_option,    LATVAL,    LONVAL,  &
@@ -8792,7 +8802,7 @@ end subroutine MPP_READ_CHROUTING_new
            do i = 1, rt_domain(did)%gnlinks
               if(STRMFRXSTPTS(i) .gt. 0) then
                    write(75,114) nlst(did)%olddate(1:4),nlst(did)%olddate(6:7),nlst(did)%olddate(9:10), nlst(did)%olddate(12:13), &
-                         cnt,chlon(i),chlat(i),g_dayMean(i) 
+                         cnt,chlon(i),chlat(i),g_dayMean(i)
                    cnt = cnt + 1
               endif
            end do
@@ -8963,11 +8973,14 @@ end subroutine read_route_link_netcdf
 subroutine read_route_lake_netcdf(route_lake_file,                         &
                                    HRZAREA,  LAKEMAXH, WEIRH,  WEIRC,    WEIRL, DAML,   &
                                    ORIFICEC, ORIFICEA,  ORIFICEE,  persistence, &
-                                   reservoir_type, LAKEIDM, lakelat, lakelon, ELEVLAKE)
+                                   reservoir_type, reservoir_parameter_file, &
+                                   LAKEIDM, lakelat, lakelon, ELEVLAKE, NLAKES)
 
     implicit none
     character(len=*),        intent(in)  :: route_lake_file
+    integer,                 intent(in)  :: NLAKES
     logical,                 intent(in)  :: persistence
+    character(len=*),        intent(in)  :: reservoir_parameter_file
     integer, dimension(:),   intent(out) :: LAKEIDM
     real,    dimension(:),   intent(out) :: HRZAREA,  LAKEMAXH, WEIRC,    WEIRL, WEIRH, DAML
     real,    dimension(:),   intent(out) :: ORIFICEC, ORIFICEA, ORIFICEE, lakelat, lakelon
@@ -9001,9 +9014,6 @@ subroutine read_route_lake_netcdf(route_lake_file,                         &
     call get_1d_netcdf_real(ncid, 'OrificeC', ORIFICEC,  'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'OrificeA', ORIFICEA,  'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'OrificeE', ORIFICEE,  'read_route_lake_netcdf', .TRUE.)
-    if (persistence) then
-       call get_1d_netcdf_int(ncid, 'reservoir_type', reservoir_type, 'read_route_lake_netcdf', .TRUE.)
-    end if
     call get_1d_netcdf_real(ncid, 'lat', lakelat,        'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'lon', lakelon,        'read_route_lake_netcdf', .TRUE.)
     !remove the alt var. and add initial fractional depth var. LKR/DY
@@ -9014,6 +9024,12 @@ subroutine read_route_lake_netcdf(route_lake_file,                         &
        write(*,'("read_route_lake_netcdf: Problem closing: ''", A, "''")') trim(route_lake_file)
        if (fatal_IF_ERROR) call hydro_stop("read_route_lake_netcdf: Problem closing file.")
     end if
+
+   ! If reservoir_persistence is set to true, then call function to read reservoir_type
+   ! from the reservoir parameter file
+   if (persistence) then
+       call read_reservoir_type(reservoir_parameter_file, LAKEIDM, NLAKES, reservoir_type)
+   end if
 
 #ifdef HYDRO_D
     ii = size(LAKEIDM)
@@ -9956,7 +9972,7 @@ end subroutine output_chrt2
                allocate(g_basnsInd(rt_domain(did)%gnlinksl))
                gnbasns = rt_domain(did)%gnlinksl
           endif
-       endif 
+       endif
 
        if(nlst(did)%channel_option .ne. 3) then
           call ReachLS_write_io(rt_domain(did)%qin_gwsubbas,g_qin_gwsubbas)
@@ -10071,7 +10087,7 @@ end subroutine output_chrt2
                   //startdate(12:13)//':'//startdate(15:16)//':00'
 
      seconds_since = int(nlst(1)%out_dt*60*(rt_domain(1)%out_counts-1))
-     
+
      sec_valid_date = 'seconds since '//nlst(1)%startdate(1:4)//'-'//nlst(1)%startdate(6:7)//'-'//nlst(1)%startdate(9:10) &
                       //' '//nlst(1)%startdate(12:13)//':'//nlst(1)%startdate(15:16)//' UTC'
 
@@ -11086,7 +11102,7 @@ if(my_id .eq. io_id) then
    !if( (nlst_rt(did)%channel_only .eq. 0 .and. nlst_rt(did)%channelBucket_only .eq. 0) .and. &
    !    (channel_only_in .eq. 1 .or.  channelBucket_only_in .eq. 1)        ) &
    !    call hydro_stop('Channel Only: Forcing files in consistent with forcing type.')
-   !! Second row: 
+   !! Second row:
    if(nlst(did)%channel_only .eq. 1 .and. channelBucket_only_in .eq. 1) &
         write(6,*) "Warning: channelBucket_only output forcing channel_only run"
 
@@ -11143,7 +11159,7 @@ if(.FALSE.) then
 
    !! Calculate the current
    if(len .gt. 0) then  !! would the length be zero on some images?
-      rt_domain(did)%qout_gwsubbas = & 
+      rt_domain(did)%qout_gwsubbas = &
            real( (accBucket_in - rt_domain(did)%accBucket)/nlst(did)%DT )
       rt_domain(did)%QLateral      = &
            real( rt_domain(did)%qout_gwsubbas +     &

--- a/trunk/NDHMS/Routing/module_HYDRO_io.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_io.F
@@ -4167,7 +4167,7 @@ end subroutine output_chrt
          iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lat_max", "90.0")
          iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lat_min", "-90.0")
          iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lon_max", "180.0")
-         iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lon_min", "-180.0")
+         iret = nf90_put_att(ncid, NF90_GLOBAL, "geospatial_lon_min", "-180.0")         
          iret = nf90_put_att(ncid, NF90_GLOBAL, "model_initialization_time", trim(nlst(1)%startdate))
          iret = nf90_put_att(ncid, NF90_GLOBAL, "station_dimension", "station")
          iret = nf90_put_att(ncid, NF90_GLOBAL, "missing_value", -9E15)
@@ -5172,8 +5172,8 @@ end subroutine mpp_output_chrt
 
      output_count = output_count + 1
 
-    iret = nf90_redef(ncid)
-    iret = nf90_put_att(ncid, NF90_GLOBAL, "model_initialization_time", trim(nlst(1)%startdate))
+    iret = nf90_redef(ncid) 
+    iret = nf90_put_att(ncid, NF90_GLOBAL, "model_initialization_time", trim(nlst(1)%startdate))    
     iret = nf90_put_att(ncid, NF90_GLOBAL, "model_output_valid_time", trim(nlst(1)%olddate))
     iret = nf90_enddef(ncid)
 
@@ -5339,7 +5339,7 @@ end subroutine mpp_output_chrt
       iret = nf90_put_att(ncid, NF90_GLOBAL, "missing_value", -9E15)
       iret = nf90_put_att(ncid, NF90_GLOBAL, "Conventions", convention)
       iret = nf90_put_att(ncid, NF90_GLOBAL, "model_initialization_time", trim(nlst(1)%startdate))
-      iret = nf90_put_att(ncid, NF90_GLOBAL, "model_output_valid_time", trim(nlst(1)%olddate))
+      iret = nf90_put_att(ncid, NF90_GLOBAL, "model_output_valid_time", trim(nlst(1)%olddate)) 
       iret = nf90_enddef(ncid)
 
       iret = nf90_inq_varid(ncid,"time", varid)
@@ -5681,7 +5681,7 @@ end subroutine mpp_output_chrt
 #ifdef HYDRO_D
          write(6,*) "output file ", outFile
 #endif
-! define dimension for variables
+! define dimension for variables 
           iret = nf90_def_dim(ncid, "depth", nlst(did)%nsoil, dimid_soil)  !-- 3-d soils
 #ifdef MPP_LAND
           iret = nf90_def_dim(ncid, "ix", global_nx, dimid_ix)  !-- make a decimated grid
@@ -5717,7 +5717,7 @@ end subroutine mpp_output_chrt
         call w_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%stc,"stc")
         call w_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%smc,"smc")
         call w_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%sh2ox,"sh2ox")
-        !call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%SMCMAX1,"smcmax1")
+        !call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%SMCMAX1,"smcmax1") 
         !call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%SMCREF1,"smcref1" )
         !call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%SMCWLT1,"smcwlt1"  )
         call w_rst_nc2(ncid,rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%INFXSRT,"infxsrt"  )
@@ -5791,7 +5791,7 @@ end subroutine mpp_output_chrt
    if( nlst(did)%channel_only       .eq. 0 .and. &
        nlst(did)%channelBucket_only .eq. 0         ) then
 
-! define dimension for variables
+! define dimension for variables 
           iret = nf90_def_dim(ncid, "depth", nlst(did)%nsoil, dimid_soil)  !-- 3-d soils
 #ifdef MPP_LAND
           iret = nf90_def_dim(ncid, "ix", global_nx, dimid_ix)  !-- make a decimated grid
@@ -5925,7 +5925,7 @@ end subroutine mpp_output_chrt
 
    end if  !  end if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
 !                    nlst(did)%OVRTSWCRT   .eq. 1 .or. &
-!                    nlst(did)%GWBASESWCRT .ne. 0       )
+!                    nlst(did)%GWBASESWCRT .ne. 0       ) 
 
    !         put global attribute
    iret = nf90_put_att(ncid, NF90_GLOBAL, "his_out_counts", rt_domain(did)%his_out_counts)
@@ -6125,7 +6125,7 @@ if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
 
    if(nlst(did)%GWBASESWCRT.eq.3) then
       if( nlst(did)%channel_only       .eq. 0 .and. &
-          nlst(did)%channelBucket_only .eq. 0         ) &
+          nlst(did)%channelBucket_only .eq. 0         ) &           
           call w_rst_rt_nc2(ncid,rt_domain(did)%ixrt,rt_domain(did)%jxrt,gw2d(did)%ho, "HEAD" )
    end if
 
@@ -6169,7 +6169,7 @@ end if  ! end if(nlst_rt(did)%SUBRTSWCRT  .eq. 1 .or. &
           write(iunit,ERR=101) rt_domain(did)%his_out_counts
 !         write(iunit,ERR=101) nlst(did)%olddate(1:19)
           write(iunit,ERR=101) nlst(did)%sincedate(1:19)
-!         write(iunit,ERR=101) nlst_rt(did)%DTCT
+!         write(iunit,ERR=101) nlst_rt(did)%DTCT 
           write(iunit,ERR=101) rt_domain(did)%stc
           write(iunit,ERR=101) rt_domain(did)%smc
           write(iunit,ERR=101) rt_domain(did)%sh2ox
@@ -6263,7 +6263,7 @@ end if  ! end if(nlst_rt(did)%SUBRTSWCRT  .eq. 1 .or. &
           read(iunit,ERR=101) rt_domain(did)%his_out_counts
 !         read(iunit,ERR=101) nlst_rt(did)%olddate(1:19)
           read(iunit,ERR=101) nlst(did)%sincedate(1:19)
-!         read(iunit,ERR=101) nlst_rt(did)%DTCT
+!         read(iunit,ERR=101) nlst_rt(did)%DTCT 
           read(iunit,ERR=101) rt_domain(did)%stc
           read(iunit,ERR=101) rt_domain(did)%smc
           read(iunit,ERR=101) rt_domain(did)%sh2ox
@@ -6688,12 +6688,12 @@ if(IO_id .eq. my_id) then
          write(logUnit,*) 'channel_only run:', nlst(did)%channel_only
          write(logUnit,*) 'channelBucket_only restart present:', channelBucket_only_in
          write(logUnit,*) 'channelBucket_only run:', nlst(did)%channelBucket_only
-         call flush(logUnit)
+         call flush(logUnit)         
          call hydro_stop('Channel Only: Restart file in consistent with forcing type.')
       end if
    end if
 
-   iret = nf90_get_att(ncid, NF90_GLOBAL, 'his_out_counts', rt_domain(did)%his_out_counts)
+   iret = nf90_get_att(ncid, NF90_GLOBAL, 'his_out_counts', rt_domain(did)%his_out_counts) 
    iret = nf90_get_att(ncid, NF90_GLOBAL, 'DTCT', nlst(did)%DTCT)
    iret = nf90_get_att(ncid,NF90_GLOBAL,"Since_Date",nlst(did)%sincedate(1:19))
 !   if( nlst(did)%channel_only       .eq. 1 .or. &
@@ -6727,7 +6727,7 @@ write(6,*) "nlst(did)%nsoil=",nlst(did)%nsoil
 if( nlst(did)%channel_only       .eq. 0 .and. &
     nlst(did)%channelBucket_only .eq. 0         ) then
 
-   if(nlst(did)%rst_typ .eq. 1 ) then
+   if(nlst(did)%rst_typ .eq. 1 ) then 
       call read_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%stc,"stc")
       call read_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%smc,"smc")
       call read_rst_nc3(ncid,rt_domain(did)%ix,rt_domain(did)%jx,nlst(did)%nsoil,rt_domain(did)%sh2ox,"sh2ox")
@@ -6747,8 +6747,8 @@ endif ! neither channel_only nor channelBucket_only
 if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
    nlst(did)%OVRTSWCRT   .eq. 1 .or. &
    nlst(did)%GWBASESWCRT .ne. 0       ) then
-   !! JLM ?? restarting channel depends on these options?
-
+   !! JLM ?? restarting channel depends on these options? 
+      
    if( nlst(did)%channel_only       .eq. 0 .and. &
        nlst(did)%channelBucket_only .eq. 0         ) then
 
@@ -6794,8 +6794,8 @@ if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
       endif
 
       if( nlst(did)%channel_only       .eq. 0 .and. &
-           nlst(did)%channelBucket_only .eq. 0         ) then
-
+           nlst(did)%channelBucket_only .eq. 0         ) then 
+           
          if(nlst(did)%SUBRTSWCRT.eq.1.or.nlst(did)%OVRTSWCRT.eq.1) then
             call read_rt_nc2(ncid,rt_domain(did)%ixrt,rt_domain(did)%jxrt,rt_domain(did)%overland%streams_and_lakes%surface_water_to_lake,"lake_inflort")
          endif
@@ -6803,7 +6803,7 @@ if(nlst(did)%SUBRTSWCRT  .eq. 1 .or. &
 
    end if  !  end if(nlst_rt(did)%CHANRTSWCRT.eq.1)
 
-   if((nlst(did)%GWBASESWCRT .eq. 1 .or.  &
+   if((nlst(did)%GWBASESWCRT .eq. 1 .or.  & 
       nlst(did)%GWBASESWCRT .ge. 4) .and. &
       nlst(did)%GW_RESTART  .ne. 0 .and.  &
       rt_domain(did)%gnumbasns .gt. 0) then
@@ -7345,7 +7345,7 @@ subroutine READ_CHROUTING1( &
      Tw_CC,        n_CC,              HRZAREA,      LAKEMAXH, &
      WEIRH,        WEIRC,             WEIRL,        DAML,     &
      ORIFICEC,     ORIFICEA,          ORIFICEE,               &
-     LATLAKE,      LONLAKE,                                   &
+     persistence,  reservoir_type,    LATLAKE,      LONLAKE,  &
      ELEVLAKE,     dist,              ZELEV,        LAKENODE, &
      CH_NETLNK,    CHANXI,            CHANYJ,       CHLAT,    &
      CHLON,        channel_option,    LATVAL,       LONVAL,   &
@@ -7403,6 +7403,7 @@ integer, intent(INOUT), dimension(NLINKS)   :: CHANXI, CHANYJ
 integer , dimension(:) ::  LAKEIDM
 
 !--reservoir/lake attributes
+logical, intent(IN)			            :: persistence
 real, intent(INOUT),  dimension(:)      :: HRZAREA
 
 real, intent(INOUT),  dimension(:)      :: LAKEMAXH, WEIRH
@@ -7412,6 +7413,7 @@ real, intent(INOUT),  dimension(:)      :: DAML
 real, intent(INOUT),  dimension(:)      :: ORIFICEC
 real, intent(INOUT),  dimension(:)      :: ORIFICEA
 real, intent(INOUT),  dimension(:)      :: ORIFICEE
+integer, intent(INOUT), dimension(:)    :: reservoir_type
 real, intent(INOUT),  dimension(:)      :: LATLAKE,LONLAKE,ELEVLAKE
 real, intent(INOUT),  dimension(:)      :: ChSSlp, Bw, Tw
 real, intent(INOUT),  dimension(:)      :: Tw_CC, n_CC ! channel properties of compund
@@ -7528,7 +7530,8 @@ if (channel_option .eq. 3) then
           call flush(6)
           call read_route_lake_netcdf(trim(route_lake_f),HRZAREA, &
                 LAKEMAXH, WEIRH, WEIRC,WEIRL, DAML, ORIFICEC,       &
-                ORIFICEA,  ORIFICEE, LAKEIDM, latlake, lonlake, ELEVLAKE)
+                ORIFICEA,  ORIFICEE, persistence, reservoir_type, &
+                LAKEIDM, latlake, lonlake, ELEVLAKE)
         else
           open(unit=79,file=trim(route_lake_f), form='formatted',status='old')
           write(6,*) "Before read LAKEPARM from text ", trim(route_lake_f)
@@ -7538,7 +7541,7 @@ if (channel_option .eq. 3) then
           do i=1, NLAKES
             read (79,*,err=5101) tmp, HRZAREA(i),LAKEMAXH(i), &
             WEIRC(i), WEIRL(i), ORIFICEC(i), ORIFICEA(i), ORIFICEE(i),&
-            LATLAKE(i), LONLAKE(i),ELEVLAKE(i), WEIRH(i)
+            LATLAKE(i), LONLAKE(i),ELEVLAKE(i), WEIRH(i), reservoir_type(i)
           enddo
 5101      continue
           close(79)
@@ -7567,6 +7570,7 @@ if (channel_option .eq. 3) then
       call mpp_land_bcast_real(NLAKES,LATLAKE )
       call mpp_land_bcast_real(NLAKES,LONLAKE )
       call mpp_land_bcast_real(NLAKES,ELEVLAKE)
+      call mpp_land_bcast_int(NLAKES, reservoir_type)
    endif
 #endif
 end if  !! channel_option .eq. 3
@@ -8231,7 +8235,8 @@ subroutine read_routelink(&
      ChSSlp,       Bw,           Tw,       Tw_CC,      &
      n_CC,         LAKEIDA,      HRZAREA,              &
      LAKEMAXH,     WEIRH,        WEIRC,   WEIRL, DAML, &
-     ORIFICEC,     ORIFICEA,     ORIFICEE, LATLAKE,    &
+     ORIFICEC,     ORIFICEA,     ORIFICEE,             &
+     persistence,  reservoir_type,         LATLAKE,    &
      LONLAKE,      ELEVLAKE,     LAKEIDM,  LAKEIDX,    &
      route_link_f, route_lake_f, ZELEV,    CHLAT,      &
      CHLON,        NLINKSL,      LINKID,   GNLINKSL,   &
@@ -8249,6 +8254,8 @@ integer, intent(INOUT),  dimension(:)      :: LAKEIDA !lake COMid 4all link on f
 real,    intent(INOUT),  dimension(:)      :: HRZAREA
 real,    intent(INOUT),  dimension(:)      :: LAKEMAXH, WEIRH, WEIRC, WEIRL, DAML
 real,    intent(INOUT),  dimension(:)      :: ORIFICEC, ORIFICEA, ORIFICEE
+logical, intent(IN)                        :: persistence
+integer, intent(INOUT),  dimension(:)      :: reservoir_type
 real,    intent(INOUT),  dimension(:)      :: LATLAKE, LONLAKE, ELEVLAKE
 integer, intent(INOUT), dimension(:)       :: LAKEIDM !lake id in LAKEPARM table (.nc or .tbl)
 integer, intent(INOUT),  dimension(:)      :: LAKEIDX !seq index of lakes(1:Nlakes) mapped to COMID
@@ -8272,7 +8279,7 @@ call readLinkSL( GNLINKSL,NLINKSL,route_link_f, route_lake_f,maxorder, &
      QLINK,CHLON, CHLAT, ZELEV, MUSK, MUSX, CHANLEN, &
      MannN, So, ChSSlp, Bw, Tw, Tw_CC, n_CC, LAKEIDA, HRZAREA,  &
      LAKEMAXH, WEIRH, WEIRC, WEIRL, DAML, ORIFICEC, &
-     ORIFICEA, ORIFICEE, gages, gageMiss, &
+     ORIFICEA, ORIFICEE, persistence, reservoir_type, gages, gageMiss, &
      LAKEIDM, NLAKES, latlake, lonlake,ELEVLAKE)
 
 !--- get the lake configuration here.
@@ -8301,6 +8308,7 @@ if (NLAKES > 0) then
    call mpp_land_bcast_real(NLAKES,LATLAKE )
    call mpp_land_bcast_real(NLAKES,LONLAKE )
    call mpp_land_bcast_real(NLAKES,ELEVLAKE)
+   call mpp_land_bcast_int(NLAKES, reservoir_type)
 endif
 #endif
 
@@ -8313,7 +8321,7 @@ end subroutine read_routelink
                    QLINK,CHLON, CHLAT, ZELEV, MUSK, MUSX, CHANLEN, &
                    MannN, So, ChSSlp, Bw, Tw, Tw_CC, n_CC, LAKEIDA, HRZAREA,  &
                    LAKEMAXH,WEIRH,  WEIRC, WEIRL, DAML, ORIFICEC, &
-                   ORIFICEA, ORIFICEE, gages, gageMiss,&
+                   ORIFICEA, ORIFICEE, persistence, reservoir_type, gages, gageMiss,&
                    LAKEIDM,NLAKES, latlake, lonlake, ELEVLAKE)
 
         implicit none
@@ -8331,7 +8339,8 @@ end subroutine read_routelink
         character(len=15), intent(in) :: gageMiss
 
 !NLAKES
-        INTEGER, intent(out), dimension(:)  ::  LAKEIDM
+        INTEGER, intent(out), dimension(:)  ::  LAKEIDM, reservoir_type
+        logical, intent(in)		            ::  persistence
         REAL, intent(out), dimension(:) :: HRZAREA,LAKEMAXH, WEIRC, WEIRL, DAML, ORIFICEC, WEIRH, &
                    ORIFICEA, ORIFICEE, ELEVLAKE
 !end NLAKES
@@ -8418,7 +8427,7 @@ end subroutine read_routelink
           if(routeLakeNetcdf) then
              call read_route_lake_netcdf(route_lake_f,HRZAREA, &
                 LAKEMAXH, WEIRH, WEIRC, WEIRL, DAML, ORIFICEC,       &
-                ORIFICEA,  ORIFICEE, LAKEIDM, latlake, lonlake, ELEVLAKE)
+                ORIFICEA,  ORIFICEE, persistence, reservoir_type, LAKEIDM, latlake, lonlake, ELEVLAKE)
           endif
 
 !!- initialize channel  if missing in input
@@ -8477,6 +8486,7 @@ end subroutine read_routelink
            call mpp_land_bcast_real(NLAKES, ORIFICEE)
            call mpp_land_bcast_int(NLAKES, LAKEIDM)
            call mpp_land_bcast_real(NLAKES, ELEVLAKE)
+           call mpp_land_bcast_int(NLAKES, reservoir_type)
         endif
 
 
@@ -8575,7 +8585,7 @@ subroutine MPP_READ_CHROUTING_new(&
      n_CC,         HRZAREA,           LAKEMAXH,                  &
      WEIRH,        WEIRC,             WEIRL,          DAML,      &
      ORIFICEC,     ORIFICEA,          ORIFICEE,                  &
-     LATLAKE,      LONLAKE,                                      &
+     persistence,  reservoir_type,    LATLAKE,        LONLAKE,   &
      ELEVLAKE,     dist,              ZELEV,          LAKENODE,  &
      CH_NETLNK,    CHANXI,            CHANYJ,         CHLAT,     &
      CHLON,        channel_option,    LATVAL,         LONVAL,    &
@@ -8609,6 +8619,7 @@ integer, intent(INOUT),  dimension(NLINKS)   :: map_l2g
 !-- store the location x,y location of the channel element
 integer, intent(INOUT), dimension(NLINKS)   :: CHANXI, CHANYJ
 
+logical, intent(IN)                          :: persistence
 real, intent(INOUT),  dimension(NLAKES)      :: HRZAREA
 real, intent(INOUT),  dimension(NLAKES)      :: LAKEMAXH, WEIRH
 real, intent(INOUT),  dimension(NLAKES)      :: WEIRC
@@ -8617,6 +8628,7 @@ real, intent(INOUT),  dimension(NLAKES)      :: DAML
 real, intent(INOUT),  dimension(NLAKES)      :: ORIFICEC
 real, intent(INOUT),  dimension(NLAKES)      :: ORIFICEA
 real, intent(INOUT),  dimension(NLAKES)      :: ORIFICEE
+integer, intent(INOUT), dimension(NLAKES)    :: reservoir_type
 real, intent(INOUT),  dimension(NLAKES)      :: LATLAKE,LONLAKE,ELEVLAKE
 real, intent(INOUT), dimension(NLINKS)       :: ChSSlp, Bw, Tw
 real, intent(INOUT), dimension(NLINKS)       :: Tw_CC, n_CC
@@ -8647,7 +8659,7 @@ call READ_CHROUTING1( &
      n_CC,         HRZAREA,           LAKEMAXH,           &
      WEIRH,        WEIRC,             WEIRL,     DAML,    &
      ORIFICEC,     ORIFICEA,          ORIFICEE,           &
-     LATLAKE,      LONLAKE,                               &
+     persistence,  reservoir_type,    LATLAKE,   LONLAKE, &
      ELEVLAKE,     dist,              ZELEV,     LAKENODE,&
      CH_NETLNK,    CHANXI,            CHANYJ,    CHLAT,   &
      CHLON,        channel_option,    LATVAL,    LONVAL,  &
@@ -8725,6 +8737,7 @@ if (NLAKES > 0) then
    call mpp_land_bcast_real(NLAKES,LATLAKE)
    call mpp_land_bcast_real(NLAKES,LONLAKE)
    call mpp_land_bcast_real(NLAKES,ELEVLAKE)
+   call mpp_land_bcast_int(NLAKES, reservoir_type)
 endif
 
 link_location = CH_NETLNK
@@ -8779,7 +8792,7 @@ end subroutine MPP_READ_CHROUTING_new
            do i = 1, rt_domain(did)%gnlinks
               if(STRMFRXSTPTS(i) .gt. 0) then
                    write(75,114) nlst(did)%olddate(1:4),nlst(did)%olddate(6:7),nlst(did)%olddate(9:10), nlst(did)%olddate(12:13), &
-                         cnt,chlon(i),chlat(i),g_dayMean(i)
+                         cnt,chlon(i),chlat(i),g_dayMean(i) 
                    cnt = cnt + 1
               endif
            end do
@@ -8949,15 +8962,18 @@ end subroutine read_route_link_netcdf
 !
 subroutine read_route_lake_netcdf(route_lake_file,                         &
                                    HRZAREA,  LAKEMAXH, WEIRH,  WEIRC,    WEIRL, DAML,   &
-                                   ORIFICEC, ORIFICEA,  ORIFICEE, LAKEIDM, &
-                                   lakelat, lakelon, ELEVLAKE)
+                                   ORIFICEC, ORIFICEA,  ORIFICEE,  persistence, &
+                                   reservoir_type, LAKEIDM, lakelat, lakelon, ELEVLAKE)
 
     implicit none
     character(len=*),        intent(in)  :: route_lake_file
+    logical,                 intent(in)  :: persistence
     integer, dimension(:),   intent(out) :: LAKEIDM
     real,    dimension(:),   intent(out) :: HRZAREA,  LAKEMAXH, WEIRC,    WEIRL, WEIRH, DAML
     real,    dimension(:),   intent(out) :: ORIFICEC, ORIFICEA, ORIFICEE, lakelat, lakelon
     real,    dimension(:),   intent(out) :: ELEVLAKE
+    integer, dimension(:),   intent(out) :: reservoir_type
+
 
     integer :: iRet, ncid, ii, varid
     logical :: fatal_if_error
@@ -8985,6 +9001,9 @@ subroutine read_route_lake_netcdf(route_lake_file,                         &
     call get_1d_netcdf_real(ncid, 'OrificeC', ORIFICEC,  'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'OrificeA', ORIFICEA,  'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'OrificeE', ORIFICEE,  'read_route_lake_netcdf', .TRUE.)
+    if (persistence) then
+       call get_1d_netcdf_int(ncid, 'reservoir_type', reservoir_type, 'read_route_lake_netcdf', .TRUE.)
+    end if
     call get_1d_netcdf_real(ncid, 'lat', lakelat,        'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'lon', lakelon,        'read_route_lake_netcdf', .TRUE.)
     !remove the alt var. and add initial fractional depth var. LKR/DY
@@ -9937,7 +9956,7 @@ end subroutine output_chrt2
                allocate(g_basnsInd(rt_domain(did)%gnlinksl))
                gnbasns = rt_domain(did)%gnlinksl
           endif
-       endif
+       endif 
 
        if(nlst(did)%channel_option .ne. 3) then
           call ReachLS_write_io(rt_domain(did)%qin_gwsubbas,g_qin_gwsubbas)
@@ -10052,7 +10071,7 @@ end subroutine output_chrt2
                   //startdate(12:13)//':'//startdate(15:16)//':00'
 
      seconds_since = int(nlst(1)%out_dt*60*(rt_domain(1)%out_counts-1))
-
+     
      sec_valid_date = 'seconds since '//nlst(1)%startdate(1:4)//'-'//nlst(1)%startdate(6:7)//'-'//nlst(1)%startdate(9:10) &
                       //' '//nlst(1)%startdate(12:13)//':'//nlst(1)%startdate(15:16)//' UTC'
 
@@ -11067,7 +11086,7 @@ if(my_id .eq. io_id) then
    !if( (nlst_rt(did)%channel_only .eq. 0 .and. nlst_rt(did)%channelBucket_only .eq. 0) .and. &
    !    (channel_only_in .eq. 1 .or.  channelBucket_only_in .eq. 1)        ) &
    !    call hydro_stop('Channel Only: Forcing files in consistent with forcing type.')
-   !! Second row:
+   !! Second row: 
    if(nlst(did)%channel_only .eq. 1 .and. channelBucket_only_in .eq. 1) &
         write(6,*) "Warning: channelBucket_only output forcing channel_only run"
 
@@ -11124,7 +11143,7 @@ if(.FALSE.) then
 
    !! Calculate the current
    if(len .gt. 0) then  !! would the length be zero on some images?
-      rt_domain(did)%qout_gwsubbas = &
+      rt_domain(did)%qout_gwsubbas = & 
            real( (accBucket_in - rt_domain(did)%accBucket)/nlst(did)%DT )
       rt_domain(did)%QLateral      = &
            real( rt_domain(did)%qout_gwsubbas +     &

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -727,7 +727,7 @@ subroutine LandRT_ini(did)
              rt_domain(did)%ORIFICEC,     rt_domain(did)%ORIFICEA, &
              rt_domain(did)%ORIFICEE,                           &
              nlst(did)%reservoir_persistence, rt_domain(did)%reservoir_type, &
-             nlst(did)%reservoir_persistence_parameter_file,    &
+             nlst(did)%reservoir_parameter_file,    &
              rt_domain(did)%LATLAKE,      rt_domain(did)%LONLAKE, &
              rt_domain(did)%ELEVLAKE,     rt_domain(did)%overland%properties%distance_to_neighbor, &
              rt_domain(did)%ZELEV,        rt_domain(did)%LAKENODE,        &
@@ -772,7 +772,7 @@ subroutine LandRT_ini(did)
            rt_domain(did)%ORIFICEE,                                 &
            nlst(did)%reservoir_persistence,                         &
            rt_domain(did)%reservoir_type,                           &
-           nlst(did)%reservoir_persistence_parameter_file,          &
+           nlst(did)%reservoir_parameter_file,          &
            rt_domain(did)%LATLAKE,                                  &
            rt_domain(did)%LONLAKE,       rt_domain(did)%ELEVLAKE,   &
            rt_domain(did)%LAKEIDM,       rt_domain(did)%LAKEIDX,    &
@@ -833,7 +833,7 @@ subroutine LandRT_ini(did)
                     rt_domain(did)%LAKEMAXH(lake_index),               &
                     rt_domain(did)%ELEVLAKE(lake_index),               &
                     rt_domain(did)%LAKEIDM(lake_index),                &
-                    nlst(did)%reservoir_persistence_parameter_file, &
+                    nlst(did)%reservoir_parameter_file, &
                     nlst(did)%startdate(1:19),                      &
                     nlst(did)%reservoir_timeslice_path,             &
                     nlst(did)%reservoir_observation_lookback_hours, &

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -794,7 +794,7 @@ subroutine LandRT_ini(did)
    ! For loop to cycle array of pointers to reservoirs
    do lake_index = 1, NLAKES_total
 
-       if (rt_domain(did)%reservoir_type(lake_index) == 1) then
+       if (rt_domain(did)%reservoir_type(lake_index) == 1 .or. rt_domain(did)%reservoir_type(lake_index) == 3 .or. rt_domain(did)%reservoir_type(lake_index) == 4) then
            allocate( levelpool :: rt_domain(did)%reservoirs(lake_index)%ptr)
 
        else if (rt_domain(did)%reservoir_type(lake_index) == 2) then

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -679,7 +679,7 @@ subroutine LandRT_ini(did)
 !DJG   activated
 
   if(nlst(did)%rtFlag .eq. 0) return
-  
+
   if (nlst(did)%SUBRTSWCRT  .eq.1 .or. &
        nlst(did)%OVRTSWCRT   .eq.1 .or. &
        nlst(did)%GWBASESWCRT .ne. 0) then
@@ -727,6 +727,7 @@ subroutine LandRT_ini(did)
              rt_domain(did)%ORIFICEC,     rt_domain(did)%ORIFICEA, &
              rt_domain(did)%ORIFICEE,                           &
              nlst(did)%reservoir_persistence, rt_domain(did)%reservoir_type, &
+             nlst(did)%reservoir_persistence_parameter_file,    &
              rt_domain(did)%LATLAKE,      rt_domain(did)%LONLAKE, &
              rt_domain(did)%ELEVLAKE,     rt_domain(did)%overland%properties%distance_to_neighbor, &
              rt_domain(did)%ZELEV,        rt_domain(did)%LAKENODE,        &
@@ -769,8 +770,9 @@ subroutine LandRT_ini(did)
            rt_domain(did)%DAML,                                     &
            rt_domain(did)%ORIFICEC,      rt_domain(did)%ORIFICEA,   &
            rt_domain(did)%ORIFICEE,                                 &
-           nlst(did)%reservoir_persistence,                      &
-           rt_domain(did)%reservoir_type,                                   &
+           nlst(did)%reservoir_persistence,                         &
+           rt_domain(did)%reservoir_type,                           &
+           nlst(did)%reservoir_persistence_parameter_file,          &
            rt_domain(did)%LATLAKE,                                  &
            rt_domain(did)%LONLAKE,       rt_domain(did)%ELEVLAKE,   &
            rt_domain(did)%LAKEIDM,       rt_domain(did)%LAKEIDX,    &
@@ -847,7 +849,7 @@ subroutine LandRT_ini(did)
         call output_lake_types( rt_domain(did)%GNLINKSL, rt_domain(did)%LINKID, rt_domain(did)%TYPEL )
      endif
 #endif
-     
+
 #ifdef OUTPUT_CHAN_CONN
 #ifdef MPP_LAND
      connCalcTimeEnd = MPI_Wtime()
@@ -867,19 +869,19 @@ subroutine LandRT_ini(did)
              rt_domain(did)%LAKENODE   &   !! Lake indexing
              )
      end if
-     
+
      !if(my_id .eq. io_id) &
      print '("Time to calculate channel connectivity= ",f6.3," seconds.")', &
           connCalcTimeEnd-connCalcTimeStart
      call exit(17)  !! bail if you're just calculating output connectivity.
 #endif
      ! end OUTPUT_CHAN_CONN
-     
-     
+
+
      ! The UDMP_ini effectively sets the nhd gw bucket area (that field is not used from the file)
      !   this may be the only dependence of the nhd_routing on the UDMAPING in channelBucket_only
      if(nlst(did)%channel_only .eq. 0) then
-        
+
         if(nlst(did)%UDMP_OPT .eq. 1) then
            ! get NHDPLUS mapping function.
            !          call UDMP_ini(rt_domain(did)%GNLINKSL,rt_domain(did)%ixrt,rt_domain(did)%jxrt,rt_domain(did)%CH_LNKRT , &
@@ -892,13 +894,13 @@ subroutine LandRT_ini(did)
            call flush(6)
 #endif
         endif
-        
+
      end if ! end not channel_only
-     
+
      if ( (nlst(did)%CHANRTSWCRT .eq. 1) .and. &
           (nlst(did)%channel_option .eq. 1 .or. nlst(did)%channel_option .eq. 2) ) then
 #ifdef MPP_LAND
-        
+
         if(nlst(did)%UDMP_OPT .eq. 1) then
            ! NHDPLUS
            rt_domain(did)%LNLINKSL = LNUMRSL
@@ -906,9 +908,9 @@ subroutine LandRT_ini(did)
            do k = 1,LNUMRSL
               rt_domain(did)%LLINKID(k) = LUDRSL(k)%myid
            end do
-           
+
         else
-           
+
            allocate (buf(rt_domain(did)%GNLINKS) )
            buf = -99
            do j = 1, rt_domain(did)%jxrt
@@ -922,21 +924,21 @@ subroutine LandRT_ini(did)
                  endif
               end do
            end do
-           
+
            rt_domain(did)%LNLINKSL = 0
            do k = 1, rt_domain(did)%GNLINKS
               if(buf(k) .gt. 0) then
                  rt_domain(did)%LNLINKSL = rt_domain(did)%LNLINKSL + 1
               endif
            end do
-           
+
 #ifdef HYDRO_D
            write(6,*) "LNLINKSL, NLINKS, GNLINKS =",rt_domain(did)%LNLINKSL,rt_domain(did)%NLINKSL,rt_domain(did)%GNLINKSL
            call flush(6)
 #endif
-           
+
            allocate(rt_domain(did)%LLINKID(rt_domain(did)%LNLINKSL))
-           
+
            k = 0
            do i = 1, rt_domain(did)%GNLINKS
               if(buf(i) .gt. 0) then
@@ -944,19 +946,19 @@ subroutine LandRT_ini(did)
                  rt_domain(did)%LLINKID(k) = buf(i)
               endif
            end do
-           
+
            if(allocated(buf)) deallocate(buf)
-           
+
         endif  ! end if block for UDMP_OPT
-        
+
         new_start_i = 0; new_start_j = 1
         new_end_i = rt_domain(did)%ixrt; new_end_j = rt_domain(did)%jxrt
-        
+
         if(left_id .ge. 0) new_start_i = 1
         if(right_id .ge. 0) new_end_i = rt_domain(did)%ixrt - 1
         if(down_id .ge. 0) new_start_j = 2
         if(up_id .ge. 0) new_end_j = rt_domain(did)%jxrt - 1
-        
+
         cache_block = 256
         num_blocks = ceiling((new_end_i - new_start_i)/real(cache_block))
         !$omp parallel do private(cache_idx,cache_block_begin_i,cache_block_end_i,cache_idx_k,i,k) &
@@ -979,9 +981,9 @@ subroutine LandRT_ini(did)
            end do
         end do
         !$omp end parallel do
-        
+
         call getLocalIndx(rt_domain(did)%gnlinksl,rt_domain(did)%LINKID, rt_domain(did)%LLINKID)
-        
+
         call getToInd(rt_domain(did)%LINKID,rt_domain(did)%to_node,rt_domain(did)%toNodeInd,rt_domain(did)%nToInd,rt_domain(did)%gtoNode)
 #else
         do k = 1, rt_domain(did)%NLINKSL
@@ -1006,7 +1008,7 @@ subroutine LandRT_ini(did)
 !!$        end do
 
      endif ! end of if (nlst_rt(did)%channel_option .eq. 1 .or. nlst_rt(did)%channel_option .eq. 2)
-     
+
   end if ! end of if (nlst_rt(did)%SUBRTSWCRT  .eq.1 .or. &    nlst_rt(did)%OVRTSWCRT   .eq.1 .or. &
 !            nlst_rt(did)%GWBASESWCRT .ne. 0) then
 
@@ -1018,19 +1020,19 @@ subroutine LandRT_ini(did)
 
   if(nlst(did)%channel_only       .eq. 0 .and. &
        nlst(did)%channelBucket_only .eq. 0        ) then
-     
+
      !DJG Temporary hardwire of RETDEPRT,RETDEP_CHAN
      !DJG    will later make this a function of SOLTYP and VEGTYP
      !            OVROUGHRT(i,j) = 0.01
-     
+
      rt_domain(did)%overland%properties%retention_depth = 0.001   ! units (mm)
      rt_domain(did)%RETDEP_CHAN = 0.001
-     
-     
+
+
      !DJG Need to insert call for acquiring routing fields here...
      !DJG     include as a subroutine in module module_Noahlsm_wrfcode_input.F
      !DJG  Calculate terrain slopes 'SOXRT,SOYRT' from subgrid elevation 'ELRT'
-     
+
      rt_domain(did)%overland%properties%surface_slope = -999
      Vmax = 0.0
      do j=2,rt_domain(did)%JXRT-1
@@ -1044,7 +1046,7 @@ subroutine LandRT_ini(did)
               else
                  Vmax=rt_domain(did)%overland%properties%surface_slope_y(i,j)
               end if
-              
+
               if (Vmax.gt.0.1) then
                  rt_domain(did)%overland%properties%retention_depth(i,j)=0.
               else
@@ -1053,14 +1055,14 @@ subroutine LandRT_ini(did)
                  if (rt_domain(did)%overland%properties%retention_depth(i,j).lt.0.) rt_domain(did)%overland%properties%retention_depth(i,j)=0.
               end if
            end if
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,1) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i,j+1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,1)
            rt_domain(did)%overland%properties%max_surface_slope_index(i,j,1) = i
            rt_domain(did)%overland%properties%max_surface_slope_index(i,j,2) = j + 1
            rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 1
            Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,1)
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,2) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i+1,j+1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,2)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,2) .gt. Vmax ) then
@@ -1069,7 +1071,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 2
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,2)
            end if
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,3) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i+1,j))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,3)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,3) .gt. Vmax ) then
@@ -1078,7 +1080,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 3
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,3)
            end if
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,4) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i+1,j-1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,4)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,4) .gt. Vmax ) then
@@ -1087,7 +1089,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 4
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,4)
            end if
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,5) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i,j-1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,5)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,5) .gt. Vmax ) then
@@ -1096,7 +1098,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 5
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,5)
            end if
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,6) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i-1,j-1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,6)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,6) .gt. Vmax ) then
@@ -1105,7 +1107,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 6
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,6)
            end if
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,7) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i-1,j))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,7)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,7) .gt. Vmax ) then
@@ -1114,7 +1116,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 7
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,7)
            end if
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,8) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i-1,j+1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,8)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,8) .gt. Vmax ) then
@@ -1123,7 +1125,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 8
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,8)
            end if
-           
+
            !DJG Introduce reduction in retention depth as a linear function of terrain slope
            if (nlst(did)%RT_OPTION.eq.1) then
               if (Vmax.gt.0.75) then
@@ -1141,7 +1143,7 @@ subroutine LandRT_ini(did)
      !Apply calibration scaling factors to sfc roughness and retention depth here...
      rt_domain(did)%overland%properties%retention_depth = rt_domain(did)%overland%properties%retention_depth * rt_domain(did)%RETDEPRTFAC
      rt_domain(did)%overland%properties%roughness = rt_domain(did)%overland%properties%roughness * rt_domain(did)%OVROUGHRTFAC
-     
+
    !ADCHANGE: Moved this channel cell setting from OV_RTNG so it is outside
    !of overland routine (frequently called) and time loop.
    !Force channel retention depth to be 5mm.
@@ -1165,7 +1167,7 @@ subroutine LandRT_ini(did)
      rt_domain(did)%overland%properties%surface_slope_y(:,rt_domain(did)%JXRT)=rt_domain(did)%overland%properties%surface_slope_y(:,rt_domain(did)%JXRT-1)
      rt_domain(did)%overland%properties%surface_slope_y(:,1)=rt_domain(did)%overland%properties%surface_slope_y(:,2)
 #endif
-     
+
 #ifdef MPP_LAND
    ! communicate the value to
      call MPP_LAND_COM_REAL(rt_domain(did)%overland%properties%retention_depth,rt_domain(did)%IXRT,rt_domain(did)%JXRT,99)
@@ -1189,10 +1191,10 @@ subroutine LandRT_ini(did)
      if (nlst(did)%GWBASESWCRT.ge.1) then
         rt_domain(did)%numbasns = rt_domain(did)%NLINKSL
         RT_DOMAIN(did)%gnumbasns = rt_domain(did)%gNLINKSL
-        
+
         allocate (rt_domain(did)%z_gwsubbas (rt_domain(did)%numbasns  ))
         allocate (rt_domain(did)%nhdBuckMask(rt_domain(did)%numbasns  ))  ! default is -999
-        
+
         allocate (rt_domain(did)%qin_gwsubbas (rt_domain(did)%numbasns))
         allocate (rt_domain(did)%gwbas_pix_ct (rt_domain(did)%numbasns))
         allocate (rt_domain(did)%ct2_bas (rt_domain(did)%numbasns))
@@ -1202,32 +1204,32 @@ subroutine LandRT_ini(did)
         allocate (rt_domain(did)%gw_buck_exp(rt_domain(did)%numbasns))
         allocate (rt_domain(did)%z_max (rt_domain(did)%numbasns))
         allocate (rt_domain(did)%basns_area (rt_domain(did)%numbasns))
-        
+
         if(nlst(did)%bucket_loss .eq. 1) then
            allocate(rt_domain(did)%qloss_gwsubbas(rt_domain(did)%numbasns))
            allocate(rt_domain(did)%gw_buck_loss(rt_domain(did)%numbasns))
-           
+
            rt_domain(did)%qloss_gwsubbas = 0
            rt_domain(did)%gw_buck_loss = 0
         endif
-        
+
         rt_domain(did)%qin_gwsubbas = 0
         rt_domain(did)%z_gwsubbas = 0
         rt_domain(did)%gwbas_pix_ct = 0
         rt_domain(did)%bas_pcp = 0
-        
+
         rt_domain(did)%gw_buck_coeff = 0.04
         rt_domain(did)%gw_buck_exp  = 0.2
         rt_domain(did)%z_max = 0.1
-        
+
         !Temporary hardwire...
         rt_domain(did)%z_gwsubbas = 0.05   ! This gets updated with spun-up GW level in GWBUCKPARM.TBL
-        
+
         call readBucket_nhd(trim(nlst(did)%GWBUCKPARM_file), rt_domain(did)%numbasns, &
              rt_domain(did)%gw_buck_coeff, rt_domain(did)%gw_buck_exp, rt_domain(did)%gw_buck_loss, &
              rt_domain(did)%z_max, rt_domain(did)%z_gwsubbas, rt_domain(did)%LINKID(1:rt_domain(did)%numbasns),  &
              rt_domain(did)%nhdBuckMask )
-        
+
       !ADCHANGE: Added in read for z_init from GWBUCKPARM. Units coming in are mm but z_gwsubbas is in m
       !for UDMP=1 so we convert units.
         rt_domain(did)%z_gwsubbas = rt_domain(did)%z_gwsubbas/1000.
@@ -1237,7 +1239,7 @@ subroutine LandRT_ini(did)
         call flush(6)
 #endif
      endif
-     
+
   else
 
    !---------------------------------------------------------------------
@@ -1256,22 +1258,22 @@ subroutine LandRT_ini(did)
                 rt_domain(did)%IX,rt_domain(did)%JX,rt_domain(did)%IXRT,&
                 rt_domain(did)%JXRT,rt_domain(did)%GWSUBBASMSK,nlst(did)%gwbasmskfil,&
                 rt_domain(did)%gw_strm_msk,rt_domain(did)%numbasns,rt_domain(did)%overland%streams_and_lakes%ch_netrt,nlst(did)%AGGFACTRT)
-           
-           
+
+
            call SIMP_GW_IND(rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%GWSUBBASMSK,  &
                 rt_domain(did)%numbasns,rt_domain(did)%gnumbasns,rt_domain(did)%basnsInd)
-           
+
 #ifdef HYDRO_D
            write(6,*) "rt_domain(did)%gnumbasns, rt_domain(did)%numbasns, ", rt_domain(did)%gnumbasns , rt_domain(did)%numbasns
-           
+
 #endif
 #ifdef MPP_LAND
            call collectSizeInd(rt_domain(did)%numbasns)
 #endif
-           
+
            call get_gw_strm_msk_lind (rt_domain(did)%IXRT, rt_domain(did)%JXRT, rt_domain(did)%gw_strm_msk,&
                 rt_domain(did)%numbasns,rt_domain(did)%basnsInd,rt_domain(did)%gw_strm_msk_lind)
-           
+
            allocate (rt_domain(did)%qout_gwsubbas (rt_domain(did)%numbasns))
            allocate (rt_domain(did)%qin_gwsubbas (rt_domain(did)%numbasns))
            allocate (rt_domain(did)%z_gwsubbas (rt_domain(did)%numbasns))
@@ -1283,15 +1285,15 @@ subroutine LandRT_ini(did)
            allocate (rt_domain(did)%gw_buck_exp(rt_domain(did)%numbasns))
            allocate (rt_domain(did)%z_max (rt_domain(did)%numbasns))
            allocate (rt_domain(did)%basns_area (rt_domain(did)%numbasns))
-           
+
 #ifdef HYDRO_D
            write(6,*)  "end Simple GW-Bucket ..."
            print *, "Simple GW-Bucket Scheme selected, retrieving files..."
 #endif
-           
+
            !Temporary hardwire...
            rt_domain(did)%z_gwsubbas = 1.     ! This gets updated with spun-up GW level in GWBUCKPARM.TBL
-           
+
            call read_GWBUCKPARM(trim(nlst(did)%GWBUCKPARM_file),rt_domain(did)%numbasns,   &
                 rt_domain(did)%gnumbasns, rt_domain(did)%basnsInd, &
                 rt_domain(did)%gw_buck_coeff, rt_domain(did)%gw_buck_exp, rt_domain(did)%gw_buck_loss, &
@@ -1329,11 +1331,11 @@ subroutine LandRT_ini(did)
                 gw2d(did)%hycond, gw2d(did)%ho, &
                 gw2d(did)%bot, gw2d(did)%poros, &
                 gw2d(did)%ltype, nlst(did)%gwIhShift)
-           
+
            gw2d(did)%elev = rt_domain(did)%elrt
 
         end if ! end if (nlst_rt(did)%GWBASESWCRT.eq.1.or.nlst_rt(did)%GWBASESWCRT.eq.2)
-        
+
      end if ! end if (nlst_rt(did)%GWBASESWCRT.ge.1)
 
 !---------------------------------------------------------------------
@@ -1385,7 +1387,7 @@ subroutine LandRT_ini(did)
 
      else       !-- parameterize according to order of diffusion scheme, or if read from hi res file, use its value
                 !--  put condition within the if/then structure, which will assign a value if something is missing in hi res
-        
+
         do j=1,rt_domain(did)%NLINKS
 
            if (rt_domain(did)%ORDER(j) .eq. 1) then    !-- smallest stream reach
@@ -1530,11 +1532,11 @@ subroutine LandRT_ini(did)
               rt_domain(did)%HLINK(j) = HLINK_INIT(rt_domain(did)%ORDER(j))
            else   !-- the outlets won't have orders since there's no nodes, so
               !-- assign the order 5 values
-              
+
               if(rt_domain(did)%Bw(j) .eq. 0.0) then
                  rt_domain(did)%Bw(j) = BOTWID(5)
               endif
-              
+
               if(rt_domain(did)%Tw(j) .eq. 0.0) then
                  rt_domain(did)%Tw(j) = TOPWID(5)
               endif
@@ -1552,22 +1554,22 @@ subroutine LandRT_ini(did)
               endif
               rt_domain(did)%HLINK(j) = HLINK_INIT(5)
            endif
-           
+
            rt_domain(did)%CVOL(j) = (rt_domain(did)%Bw(j)+ 1/rt_domain(did)%ChSSLP(j)*rt_domain(did)%HLINK(j))*rt_domain(did)%HLINK(j)*rt_domain(did)%CHANLEN(j) !-- initalize channel volume
         end do
-        
+
      endif  !End if channel option eq 3; else;
-     
-     
+
+
      ! Initialize Lake Elevations for Gridded and NWM routing.
      do j=1,rt_domain(did)%NLAKES
         rt_domain(did)%RESHT(j) = rt_domain(did)%ORIFICEE(j) + &
              ((rt_domain(did)%LAKEMAXH(j) - rt_domain(did)%ORIFICEE(j) )* rt_domain(did)%ELEVLAKE(j))
      end do
-     
+
   end if     ! Endif for channel routing setup
 !-----------------------------------------------------------------------
-  
+
   if(nlst(did)%channel_only       .eq. 0 .and. &
        nlst(did)%channelBucket_only .eq. 0        ) then
 

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -38,7 +38,6 @@ MODULE module_Routing
    use module_UDMAP, only: LNUMRSL, LUDRSL, UDMP_ini
    use module_levelpool, only: levelpool
    use module_persistence_levelpool_hybrid, only: persistence_levelpool_hybrid
-   use module_reservoir_utilities, only: read_reservoir_type
 
    IMPLICIT NONE
 
@@ -680,7 +679,7 @@ subroutine LandRT_ini(did)
 !DJG   activated
 
   if(nlst(did)%rtFlag .eq. 0) return
-
+  
   if (nlst(did)%SUBRTSWCRT  .eq.1 .or. &
        nlst(did)%OVRTSWCRT   .eq.1 .or. &
        nlst(did)%GWBASESWCRT .ne. 0) then
@@ -727,6 +726,7 @@ subroutine LandRT_ini(did)
              rt_domain(did)%WEIRL,        rt_domain(did)%DAML, &
              rt_domain(did)%ORIFICEC,     rt_domain(did)%ORIFICEA, &
              rt_domain(did)%ORIFICEE,                           &
+             nlst(did)%reservoir_persistence, rt_domain(did)%reservoir_type, &
              rt_domain(did)%LATLAKE,      rt_domain(did)%LONLAKE, &
              rt_domain(did)%ELEVLAKE,     rt_domain(did)%overland%properties%distance_to_neighbor, &
              rt_domain(did)%ZELEV,        rt_domain(did)%LAKENODE,        &
@@ -769,6 +769,8 @@ subroutine LandRT_ini(did)
            rt_domain(did)%DAML,                                     &
            rt_domain(did)%ORIFICEC,      rt_domain(did)%ORIFICEA,   &
            rt_domain(did)%ORIFICEE,                                 &
+           nlst(did)%reservoir_persistence,                      &
+           rt_domain(did)%reservoir_type,                                   &
            rt_domain(did)%LATLAKE,                                  &
            rt_domain(did)%LONLAKE,       rt_domain(did)%ELEVLAKE,   &
            rt_domain(did)%LAKEIDM,       rt_domain(did)%LAKEIDX,    &
@@ -786,14 +788,6 @@ subroutine LandRT_ini(did)
      nullify(rt_domain(did)%reservoirs(lake_index)%ptr)
 
    end do
-
-   ! If reservoir_persistence is set to true, then call function to read reservoir_type
-   ! from the reservoir parameter file
-   if (nlst(did)%reservoir_persistence) then
-       call read_reservoir_type(nlst(did)%reservoir_persistence_parameter_file, &
-                           rt_domain(did)%LAKEIDM, NLAKES_total, &
-                           rt_domain(did)%reservoir_type)
-   end if
 
    ! For loop to cycle array of pointers to reservoirs
    do lake_index = 1, NLAKES_total
@@ -853,7 +847,7 @@ subroutine LandRT_ini(did)
         call output_lake_types( rt_domain(did)%GNLINKSL, rt_domain(did)%LINKID, rt_domain(did)%TYPEL )
      endif
 #endif
-
+     
 #ifdef OUTPUT_CHAN_CONN
 #ifdef MPP_LAND
      connCalcTimeEnd = MPI_Wtime()
@@ -873,19 +867,19 @@ subroutine LandRT_ini(did)
              rt_domain(did)%LAKENODE   &   !! Lake indexing
              )
      end if
-
+     
      !if(my_id .eq. io_id) &
      print '("Time to calculate channel connectivity= ",f6.3," seconds.")', &
           connCalcTimeEnd-connCalcTimeStart
      call exit(17)  !! bail if you're just calculating output connectivity.
 #endif
      ! end OUTPUT_CHAN_CONN
-
-
+     
+     
      ! The UDMP_ini effectively sets the nhd gw bucket area (that field is not used from the file)
      !   this may be the only dependence of the nhd_routing on the UDMAPING in channelBucket_only
      if(nlst(did)%channel_only .eq. 0) then
-
+        
         if(nlst(did)%UDMP_OPT .eq. 1) then
            ! get NHDPLUS mapping function.
            !          call UDMP_ini(rt_domain(did)%GNLINKSL,rt_domain(did)%ixrt,rt_domain(did)%jxrt,rt_domain(did)%CH_LNKRT , &
@@ -898,13 +892,13 @@ subroutine LandRT_ini(did)
            call flush(6)
 #endif
         endif
-
+        
      end if ! end not channel_only
-
+     
      if ( (nlst(did)%CHANRTSWCRT .eq. 1) .and. &
           (nlst(did)%channel_option .eq. 1 .or. nlst(did)%channel_option .eq. 2) ) then
 #ifdef MPP_LAND
-
+        
         if(nlst(did)%UDMP_OPT .eq. 1) then
            ! NHDPLUS
            rt_domain(did)%LNLINKSL = LNUMRSL
@@ -912,9 +906,9 @@ subroutine LandRT_ini(did)
            do k = 1,LNUMRSL
               rt_domain(did)%LLINKID(k) = LUDRSL(k)%myid
            end do
-
+           
         else
-
+           
            allocate (buf(rt_domain(did)%GNLINKS) )
            buf = -99
            do j = 1, rt_domain(did)%jxrt
@@ -928,21 +922,21 @@ subroutine LandRT_ini(did)
                  endif
               end do
            end do
-
+           
            rt_domain(did)%LNLINKSL = 0
            do k = 1, rt_domain(did)%GNLINKS
               if(buf(k) .gt. 0) then
                  rt_domain(did)%LNLINKSL = rt_domain(did)%LNLINKSL + 1
               endif
            end do
-
+           
 #ifdef HYDRO_D
            write(6,*) "LNLINKSL, NLINKS, GNLINKS =",rt_domain(did)%LNLINKSL,rt_domain(did)%NLINKSL,rt_domain(did)%GNLINKSL
            call flush(6)
 #endif
-
+           
            allocate(rt_domain(did)%LLINKID(rt_domain(did)%LNLINKSL))
-
+           
            k = 0
            do i = 1, rt_domain(did)%GNLINKS
               if(buf(i) .gt. 0) then
@@ -950,19 +944,19 @@ subroutine LandRT_ini(did)
                  rt_domain(did)%LLINKID(k) = buf(i)
               endif
            end do
-
+           
            if(allocated(buf)) deallocate(buf)
-
+           
         endif  ! end if block for UDMP_OPT
-
+        
         new_start_i = 0; new_start_j = 1
         new_end_i = rt_domain(did)%ixrt; new_end_j = rt_domain(did)%jxrt
-
+        
         if(left_id .ge. 0) new_start_i = 1
         if(right_id .ge. 0) new_end_i = rt_domain(did)%ixrt - 1
         if(down_id .ge. 0) new_start_j = 2
         if(up_id .ge. 0) new_end_j = rt_domain(did)%jxrt - 1
-
+        
         cache_block = 256
         num_blocks = ceiling((new_end_i - new_start_i)/real(cache_block))
         !$omp parallel do private(cache_idx,cache_block_begin_i,cache_block_end_i,cache_idx_k,i,k) &
@@ -985,9 +979,9 @@ subroutine LandRT_ini(did)
            end do
         end do
         !$omp end parallel do
-
+        
         call getLocalIndx(rt_domain(did)%gnlinksl,rt_domain(did)%LINKID, rt_domain(did)%LLINKID)
-
+        
         call getToInd(rt_domain(did)%LINKID,rt_domain(did)%to_node,rt_domain(did)%toNodeInd,rt_domain(did)%nToInd,rt_domain(did)%gtoNode)
 #else
         do k = 1, rt_domain(did)%NLINKSL
@@ -1012,7 +1006,7 @@ subroutine LandRT_ini(did)
 !!$        end do
 
      endif ! end of if (nlst_rt(did)%channel_option .eq. 1 .or. nlst_rt(did)%channel_option .eq. 2)
-
+     
   end if ! end of if (nlst_rt(did)%SUBRTSWCRT  .eq.1 .or. &    nlst_rt(did)%OVRTSWCRT   .eq.1 .or. &
 !            nlst_rt(did)%GWBASESWCRT .ne. 0) then
 
@@ -1024,19 +1018,19 @@ subroutine LandRT_ini(did)
 
   if(nlst(did)%channel_only       .eq. 0 .and. &
        nlst(did)%channelBucket_only .eq. 0        ) then
-
+     
      !DJG Temporary hardwire of RETDEPRT,RETDEP_CHAN
      !DJG    will later make this a function of SOLTYP and VEGTYP
      !            OVROUGHRT(i,j) = 0.01
-
+     
      rt_domain(did)%overland%properties%retention_depth = 0.001   ! units (mm)
      rt_domain(did)%RETDEP_CHAN = 0.001
-
-
+     
+     
      !DJG Need to insert call for acquiring routing fields here...
      !DJG     include as a subroutine in module module_Noahlsm_wrfcode_input.F
      !DJG  Calculate terrain slopes 'SOXRT,SOYRT' from subgrid elevation 'ELRT'
-
+     
      rt_domain(did)%overland%properties%surface_slope = -999
      Vmax = 0.0
      do j=2,rt_domain(did)%JXRT-1
@@ -1050,7 +1044,7 @@ subroutine LandRT_ini(did)
               else
                  Vmax=rt_domain(did)%overland%properties%surface_slope_y(i,j)
               end if
-
+              
               if (Vmax.gt.0.1) then
                  rt_domain(did)%overland%properties%retention_depth(i,j)=0.
               else
@@ -1059,14 +1053,14 @@ subroutine LandRT_ini(did)
                  if (rt_domain(did)%overland%properties%retention_depth(i,j).lt.0.) rt_domain(did)%overland%properties%retention_depth(i,j)=0.
               end if
            end if
-
+           
            rt_domain(did)%overland%properties%surface_slope(i,j,1) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i,j+1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,1)
            rt_domain(did)%overland%properties%max_surface_slope_index(i,j,1) = i
            rt_domain(did)%overland%properties%max_surface_slope_index(i,j,2) = j + 1
            rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 1
            Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,1)
-
+           
            rt_domain(did)%overland%properties%surface_slope(i,j,2) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i+1,j+1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,2)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,2) .gt. Vmax ) then
@@ -1075,7 +1069,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 2
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,2)
            end if
-
+           
            rt_domain(did)%overland%properties%surface_slope(i,j,3) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i+1,j))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,3)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,3) .gt. Vmax ) then
@@ -1084,7 +1078,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 3
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,3)
            end if
-
+           
            rt_domain(did)%overland%properties%surface_slope(i,j,4) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i+1,j-1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,4)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,4) .gt. Vmax ) then
@@ -1093,7 +1087,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 4
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,4)
            end if
-
+           
            rt_domain(did)%overland%properties%surface_slope(i,j,5) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i,j-1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,5)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,5) .gt. Vmax ) then
@@ -1102,7 +1096,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 5
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,5)
            end if
-
+           
            rt_domain(did)%overland%properties%surface_slope(i,j,6) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i-1,j-1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,6)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,6) .gt. Vmax ) then
@@ -1111,7 +1105,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 6
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,6)
            end if
-
+           
            rt_domain(did)%overland%properties%surface_slope(i,j,7) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i-1,j))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,7)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,7) .gt. Vmax ) then
@@ -1120,7 +1114,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 7
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,7)
            end if
-
+           
            rt_domain(did)%overland%properties%surface_slope(i,j,8) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i-1,j+1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,8)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,8) .gt. Vmax ) then
@@ -1129,7 +1123,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 8
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,8)
            end if
-
+           
            !DJG Introduce reduction in retention depth as a linear function of terrain slope
            if (nlst(did)%RT_OPTION.eq.1) then
               if (Vmax.gt.0.75) then
@@ -1147,7 +1141,7 @@ subroutine LandRT_ini(did)
      !Apply calibration scaling factors to sfc roughness and retention depth here...
      rt_domain(did)%overland%properties%retention_depth = rt_domain(did)%overland%properties%retention_depth * rt_domain(did)%RETDEPRTFAC
      rt_domain(did)%overland%properties%roughness = rt_domain(did)%overland%properties%roughness * rt_domain(did)%OVROUGHRTFAC
-
+     
    !ADCHANGE: Moved this channel cell setting from OV_RTNG so it is outside
    !of overland routine (frequently called) and time loop.
    !Force channel retention depth to be 5mm.
@@ -1171,7 +1165,7 @@ subroutine LandRT_ini(did)
      rt_domain(did)%overland%properties%surface_slope_y(:,rt_domain(did)%JXRT)=rt_domain(did)%overland%properties%surface_slope_y(:,rt_domain(did)%JXRT-1)
      rt_domain(did)%overland%properties%surface_slope_y(:,1)=rt_domain(did)%overland%properties%surface_slope_y(:,2)
 #endif
-
+     
 #ifdef MPP_LAND
    ! communicate the value to
      call MPP_LAND_COM_REAL(rt_domain(did)%overland%properties%retention_depth,rt_domain(did)%IXRT,rt_domain(did)%JXRT,99)
@@ -1195,10 +1189,10 @@ subroutine LandRT_ini(did)
      if (nlst(did)%GWBASESWCRT.ge.1) then
         rt_domain(did)%numbasns = rt_domain(did)%NLINKSL
         RT_DOMAIN(did)%gnumbasns = rt_domain(did)%gNLINKSL
-
+        
         allocate (rt_domain(did)%z_gwsubbas (rt_domain(did)%numbasns  ))
         allocate (rt_domain(did)%nhdBuckMask(rt_domain(did)%numbasns  ))  ! default is -999
-
+        
         allocate (rt_domain(did)%qin_gwsubbas (rt_domain(did)%numbasns))
         allocate (rt_domain(did)%gwbas_pix_ct (rt_domain(did)%numbasns))
         allocate (rt_domain(did)%ct2_bas (rt_domain(did)%numbasns))
@@ -1208,32 +1202,32 @@ subroutine LandRT_ini(did)
         allocate (rt_domain(did)%gw_buck_exp(rt_domain(did)%numbasns))
         allocate (rt_domain(did)%z_max (rt_domain(did)%numbasns))
         allocate (rt_domain(did)%basns_area (rt_domain(did)%numbasns))
-
+        
         if(nlst(did)%bucket_loss .eq. 1) then
            allocate(rt_domain(did)%qloss_gwsubbas(rt_domain(did)%numbasns))
            allocate(rt_domain(did)%gw_buck_loss(rt_domain(did)%numbasns))
-
+           
            rt_domain(did)%qloss_gwsubbas = 0
            rt_domain(did)%gw_buck_loss = 0
         endif
-
+        
         rt_domain(did)%qin_gwsubbas = 0
         rt_domain(did)%z_gwsubbas = 0
         rt_domain(did)%gwbas_pix_ct = 0
         rt_domain(did)%bas_pcp = 0
-
+        
         rt_domain(did)%gw_buck_coeff = 0.04
         rt_domain(did)%gw_buck_exp  = 0.2
         rt_domain(did)%z_max = 0.1
-
+        
         !Temporary hardwire...
         rt_domain(did)%z_gwsubbas = 0.05   ! This gets updated with spun-up GW level in GWBUCKPARM.TBL
-
+        
         call readBucket_nhd(trim(nlst(did)%GWBUCKPARM_file), rt_domain(did)%numbasns, &
              rt_domain(did)%gw_buck_coeff, rt_domain(did)%gw_buck_exp, rt_domain(did)%gw_buck_loss, &
              rt_domain(did)%z_max, rt_domain(did)%z_gwsubbas, rt_domain(did)%LINKID(1:rt_domain(did)%numbasns),  &
              rt_domain(did)%nhdBuckMask )
-
+        
       !ADCHANGE: Added in read for z_init from GWBUCKPARM. Units coming in are mm but z_gwsubbas is in m
       !for UDMP=1 so we convert units.
         rt_domain(did)%z_gwsubbas = rt_domain(did)%z_gwsubbas/1000.
@@ -1243,7 +1237,7 @@ subroutine LandRT_ini(did)
         call flush(6)
 #endif
      endif
-
+     
   else
 
    !---------------------------------------------------------------------
@@ -1262,22 +1256,22 @@ subroutine LandRT_ini(did)
                 rt_domain(did)%IX,rt_domain(did)%JX,rt_domain(did)%IXRT,&
                 rt_domain(did)%JXRT,rt_domain(did)%GWSUBBASMSK,nlst(did)%gwbasmskfil,&
                 rt_domain(did)%gw_strm_msk,rt_domain(did)%numbasns,rt_domain(did)%overland%streams_and_lakes%ch_netrt,nlst(did)%AGGFACTRT)
-
-
+           
+           
            call SIMP_GW_IND(rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%GWSUBBASMSK,  &
                 rt_domain(did)%numbasns,rt_domain(did)%gnumbasns,rt_domain(did)%basnsInd)
-
+           
 #ifdef HYDRO_D
            write(6,*) "rt_domain(did)%gnumbasns, rt_domain(did)%numbasns, ", rt_domain(did)%gnumbasns , rt_domain(did)%numbasns
-
+           
 #endif
 #ifdef MPP_LAND
            call collectSizeInd(rt_domain(did)%numbasns)
 #endif
-
+           
            call get_gw_strm_msk_lind (rt_domain(did)%IXRT, rt_domain(did)%JXRT, rt_domain(did)%gw_strm_msk,&
                 rt_domain(did)%numbasns,rt_domain(did)%basnsInd,rt_domain(did)%gw_strm_msk_lind)
-
+           
            allocate (rt_domain(did)%qout_gwsubbas (rt_domain(did)%numbasns))
            allocate (rt_domain(did)%qin_gwsubbas (rt_domain(did)%numbasns))
            allocate (rt_domain(did)%z_gwsubbas (rt_domain(did)%numbasns))
@@ -1289,15 +1283,15 @@ subroutine LandRT_ini(did)
            allocate (rt_domain(did)%gw_buck_exp(rt_domain(did)%numbasns))
            allocate (rt_domain(did)%z_max (rt_domain(did)%numbasns))
            allocate (rt_domain(did)%basns_area (rt_domain(did)%numbasns))
-
+           
 #ifdef HYDRO_D
            write(6,*)  "end Simple GW-Bucket ..."
            print *, "Simple GW-Bucket Scheme selected, retrieving files..."
 #endif
-
+           
            !Temporary hardwire...
            rt_domain(did)%z_gwsubbas = 1.     ! This gets updated with spun-up GW level in GWBUCKPARM.TBL
-
+           
            call read_GWBUCKPARM(trim(nlst(did)%GWBUCKPARM_file),rt_domain(did)%numbasns,   &
                 rt_domain(did)%gnumbasns, rt_domain(did)%basnsInd, &
                 rt_domain(did)%gw_buck_coeff, rt_domain(did)%gw_buck_exp, rt_domain(did)%gw_buck_loss, &
@@ -1335,11 +1329,11 @@ subroutine LandRT_ini(did)
                 gw2d(did)%hycond, gw2d(did)%ho, &
                 gw2d(did)%bot, gw2d(did)%poros, &
                 gw2d(did)%ltype, nlst(did)%gwIhShift)
-
+           
            gw2d(did)%elev = rt_domain(did)%elrt
 
         end if ! end if (nlst_rt(did)%GWBASESWCRT.eq.1.or.nlst_rt(did)%GWBASESWCRT.eq.2)
-
+        
      end if ! end if (nlst_rt(did)%GWBASESWCRT.ge.1)
 
 !---------------------------------------------------------------------
@@ -1391,7 +1385,7 @@ subroutine LandRT_ini(did)
 
      else       !-- parameterize according to order of diffusion scheme, or if read from hi res file, use its value
                 !--  put condition within the if/then structure, which will assign a value if something is missing in hi res
-
+        
         do j=1,rt_domain(did)%NLINKS
 
            if (rt_domain(did)%ORDER(j) .eq. 1) then    !-- smallest stream reach
@@ -1536,11 +1530,11 @@ subroutine LandRT_ini(did)
               rt_domain(did)%HLINK(j) = HLINK_INIT(rt_domain(did)%ORDER(j))
            else   !-- the outlets won't have orders since there's no nodes, so
               !-- assign the order 5 values
-
+              
               if(rt_domain(did)%Bw(j) .eq. 0.0) then
                  rt_domain(did)%Bw(j) = BOTWID(5)
               endif
-
+              
               if(rt_domain(did)%Tw(j) .eq. 0.0) then
                  rt_domain(did)%Tw(j) = TOPWID(5)
               endif
@@ -1558,22 +1552,22 @@ subroutine LandRT_ini(did)
               endif
               rt_domain(did)%HLINK(j) = HLINK_INIT(5)
            endif
-
+           
            rt_domain(did)%CVOL(j) = (rt_domain(did)%Bw(j)+ 1/rt_domain(did)%ChSSLP(j)*rt_domain(did)%HLINK(j))*rt_domain(did)%HLINK(j)*rt_domain(did)%CHANLEN(j) !-- initalize channel volume
         end do
-
+        
      endif  !End if channel option eq 3; else;
-
-
+     
+     
      ! Initialize Lake Elevations for Gridded and NWM routing.
      do j=1,rt_domain(did)%NLAKES
         rt_domain(did)%RESHT(j) = rt_domain(did)%ORIFICEE(j) + &
              ((rt_domain(did)%LAKEMAXH(j) - rt_domain(did)%ORIFICEE(j) )* rt_domain(did)%ELEVLAKE(j))
      end do
-
+     
   end if     ! Endif for channel routing setup
 !-----------------------------------------------------------------------
-
+  
   if(nlst(did)%channel_only       .eq. 0 .and. &
        nlst(did)%channelBucket_only .eq. 0        ) then
 

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -38,6 +38,7 @@ MODULE module_Routing
    use module_UDMAP, only: LNUMRSL, LUDRSL, UDMP_ini
    use module_levelpool, only: levelpool
    use module_persistence_levelpool_hybrid, only: persistence_levelpool_hybrid
+   use module_reservoir_utilities, only: read_reservoir_type
 
    IMPLICIT NONE
 
@@ -785,6 +786,14 @@ subroutine LandRT_ini(did)
      nullify(rt_domain(did)%reservoirs(lake_index)%ptr)
 
    end do
+
+   ! If reservoir_persistence is set to true, then call function to read reservoir_type
+   ! from the reservoir parameter file
+   if (nlst(did)%reservoir_persistence) then
+       call read_reservoir_type(nlst(did)%reservoir_persistence_parameter_file, &
+                           rt_domain(did)%LAKEIDM, NLAKES_total, &
+                           rt_domain(did)%reservoir_type)
+   end if
 
    ! For loop to cycle array of pointers to reservoirs
    do lake_index = 1, NLAKES_total

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -679,7 +679,7 @@ subroutine LandRT_ini(did)
 !DJG   activated
 
   if(nlst(did)%rtFlag .eq. 0) return
-  
+
   if (nlst(did)%SUBRTSWCRT  .eq.1 .or. &
        nlst(did)%OVRTSWCRT   .eq.1 .or. &
        nlst(did)%GWBASESWCRT .ne. 0) then
@@ -726,7 +726,6 @@ subroutine LandRT_ini(did)
              rt_domain(did)%WEIRL,        rt_domain(did)%DAML, &
              rt_domain(did)%ORIFICEC,     rt_domain(did)%ORIFICEA, &
              rt_domain(did)%ORIFICEE,                           &
-             nlst(did)%reservoir_persistence, rt_domain(did)%reservoir_type, &
              rt_domain(did)%LATLAKE,      rt_domain(did)%LONLAKE, &
              rt_domain(did)%ELEVLAKE,     rt_domain(did)%overland%properties%distance_to_neighbor, &
              rt_domain(did)%ZELEV,        rt_domain(did)%LAKENODE,        &
@@ -769,8 +768,6 @@ subroutine LandRT_ini(did)
            rt_domain(did)%DAML,                                     &
            rt_domain(did)%ORIFICEC,      rt_domain(did)%ORIFICEA,   &
            rt_domain(did)%ORIFICEE,                                 &
-           nlst(did)%reservoir_persistence,                      &
-           rt_domain(did)%reservoir_type,                                   &
            rt_domain(did)%LATLAKE,                                  &
            rt_domain(did)%LONLAKE,       rt_domain(did)%ELEVLAKE,   &
            rt_domain(did)%LAKEIDM,       rt_domain(did)%LAKEIDX,    &
@@ -847,7 +844,7 @@ subroutine LandRT_ini(did)
         call output_lake_types( rt_domain(did)%GNLINKSL, rt_domain(did)%LINKID, rt_domain(did)%TYPEL )
      endif
 #endif
-     
+
 #ifdef OUTPUT_CHAN_CONN
 #ifdef MPP_LAND
      connCalcTimeEnd = MPI_Wtime()
@@ -867,19 +864,19 @@ subroutine LandRT_ini(did)
              rt_domain(did)%LAKENODE   &   !! Lake indexing
              )
      end if
-     
+
      !if(my_id .eq. io_id) &
      print '("Time to calculate channel connectivity= ",f6.3," seconds.")', &
           connCalcTimeEnd-connCalcTimeStart
      call exit(17)  !! bail if you're just calculating output connectivity.
 #endif
      ! end OUTPUT_CHAN_CONN
-     
-     
+
+
      ! The UDMP_ini effectively sets the nhd gw bucket area (that field is not used from the file)
      !   this may be the only dependence of the nhd_routing on the UDMAPING in channelBucket_only
      if(nlst(did)%channel_only .eq. 0) then
-        
+
         if(nlst(did)%UDMP_OPT .eq. 1) then
            ! get NHDPLUS mapping function.
            !          call UDMP_ini(rt_domain(did)%GNLINKSL,rt_domain(did)%ixrt,rt_domain(did)%jxrt,rt_domain(did)%CH_LNKRT , &
@@ -892,13 +889,13 @@ subroutine LandRT_ini(did)
            call flush(6)
 #endif
         endif
-        
+
      end if ! end not channel_only
-     
+
      if ( (nlst(did)%CHANRTSWCRT .eq. 1) .and. &
           (nlst(did)%channel_option .eq. 1 .or. nlst(did)%channel_option .eq. 2) ) then
 #ifdef MPP_LAND
-        
+
         if(nlst(did)%UDMP_OPT .eq. 1) then
            ! NHDPLUS
            rt_domain(did)%LNLINKSL = LNUMRSL
@@ -906,9 +903,9 @@ subroutine LandRT_ini(did)
            do k = 1,LNUMRSL
               rt_domain(did)%LLINKID(k) = LUDRSL(k)%myid
            end do
-           
+
         else
-           
+
            allocate (buf(rt_domain(did)%GNLINKS) )
            buf = -99
            do j = 1, rt_domain(did)%jxrt
@@ -922,21 +919,21 @@ subroutine LandRT_ini(did)
                  endif
               end do
            end do
-           
+
            rt_domain(did)%LNLINKSL = 0
            do k = 1, rt_domain(did)%GNLINKS
               if(buf(k) .gt. 0) then
                  rt_domain(did)%LNLINKSL = rt_domain(did)%LNLINKSL + 1
               endif
            end do
-           
+
 #ifdef HYDRO_D
            write(6,*) "LNLINKSL, NLINKS, GNLINKS =",rt_domain(did)%LNLINKSL,rt_domain(did)%NLINKSL,rt_domain(did)%GNLINKSL
            call flush(6)
 #endif
-           
+
            allocate(rt_domain(did)%LLINKID(rt_domain(did)%LNLINKSL))
-           
+
            k = 0
            do i = 1, rt_domain(did)%GNLINKS
               if(buf(i) .gt. 0) then
@@ -944,19 +941,19 @@ subroutine LandRT_ini(did)
                  rt_domain(did)%LLINKID(k) = buf(i)
               endif
            end do
-           
+
            if(allocated(buf)) deallocate(buf)
-           
+
         endif  ! end if block for UDMP_OPT
-        
+
         new_start_i = 0; new_start_j = 1
         new_end_i = rt_domain(did)%ixrt; new_end_j = rt_domain(did)%jxrt
-        
+
         if(left_id .ge. 0) new_start_i = 1
         if(right_id .ge. 0) new_end_i = rt_domain(did)%ixrt - 1
         if(down_id .ge. 0) new_start_j = 2
         if(up_id .ge. 0) new_end_j = rt_domain(did)%jxrt - 1
-        
+
         cache_block = 256
         num_blocks = ceiling((new_end_i - new_start_i)/real(cache_block))
         !$omp parallel do private(cache_idx,cache_block_begin_i,cache_block_end_i,cache_idx_k,i,k) &
@@ -979,9 +976,9 @@ subroutine LandRT_ini(did)
            end do
         end do
         !$omp end parallel do
-        
+
         call getLocalIndx(rt_domain(did)%gnlinksl,rt_domain(did)%LINKID, rt_domain(did)%LLINKID)
-        
+
         call getToInd(rt_domain(did)%LINKID,rt_domain(did)%to_node,rt_domain(did)%toNodeInd,rt_domain(did)%nToInd,rt_domain(did)%gtoNode)
 #else
         do k = 1, rt_domain(did)%NLINKSL
@@ -1006,7 +1003,7 @@ subroutine LandRT_ini(did)
 !!$        end do
 
      endif ! end of if (nlst_rt(did)%channel_option .eq. 1 .or. nlst_rt(did)%channel_option .eq. 2)
-     
+
   end if ! end of if (nlst_rt(did)%SUBRTSWCRT  .eq.1 .or. &    nlst_rt(did)%OVRTSWCRT   .eq.1 .or. &
 !            nlst_rt(did)%GWBASESWCRT .ne. 0) then
 
@@ -1018,19 +1015,19 @@ subroutine LandRT_ini(did)
 
   if(nlst(did)%channel_only       .eq. 0 .and. &
        nlst(did)%channelBucket_only .eq. 0        ) then
-     
+
      !DJG Temporary hardwire of RETDEPRT,RETDEP_CHAN
      !DJG    will later make this a function of SOLTYP and VEGTYP
      !            OVROUGHRT(i,j) = 0.01
-     
+
      rt_domain(did)%overland%properties%retention_depth = 0.001   ! units (mm)
      rt_domain(did)%RETDEP_CHAN = 0.001
-     
-     
+
+
      !DJG Need to insert call for acquiring routing fields here...
      !DJG     include as a subroutine in module module_Noahlsm_wrfcode_input.F
      !DJG  Calculate terrain slopes 'SOXRT,SOYRT' from subgrid elevation 'ELRT'
-     
+
      rt_domain(did)%overland%properties%surface_slope = -999
      Vmax = 0.0
      do j=2,rt_domain(did)%JXRT-1
@@ -1044,7 +1041,7 @@ subroutine LandRT_ini(did)
               else
                  Vmax=rt_domain(did)%overland%properties%surface_slope_y(i,j)
               end if
-              
+
               if (Vmax.gt.0.1) then
                  rt_domain(did)%overland%properties%retention_depth(i,j)=0.
               else
@@ -1053,14 +1050,14 @@ subroutine LandRT_ini(did)
                  if (rt_domain(did)%overland%properties%retention_depth(i,j).lt.0.) rt_domain(did)%overland%properties%retention_depth(i,j)=0.
               end if
            end if
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,1) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i,j+1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,1)
            rt_domain(did)%overland%properties%max_surface_slope_index(i,j,1) = i
            rt_domain(did)%overland%properties%max_surface_slope_index(i,j,2) = j + 1
            rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 1
            Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,1)
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,2) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i+1,j+1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,2)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,2) .gt. Vmax ) then
@@ -1069,7 +1066,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 2
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,2)
            end if
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,3) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i+1,j))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,3)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,3) .gt. Vmax ) then
@@ -1078,7 +1075,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 3
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,3)
            end if
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,4) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i+1,j-1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,4)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,4) .gt. Vmax ) then
@@ -1087,7 +1084,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 4
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,4)
            end if
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,5) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i,j-1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,5)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,5) .gt. Vmax ) then
@@ -1096,7 +1093,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 5
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,5)
            end if
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,6) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i-1,j-1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,6)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,6) .gt. Vmax ) then
@@ -1105,7 +1102,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 6
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,6)
            end if
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,7) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i-1,j))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,7)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,7) .gt. Vmax ) then
@@ -1114,7 +1111,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 7
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,7)
            end if
-           
+
            rt_domain(did)%overland%properties%surface_slope(i,j,8) = &
                 (rt_domain(did)%ELRT(i,j)-rt_domain(did)%ELRT(i-1,j+1))/rt_domain(did)%overland%properties%distance_to_neighbor(i,j,8)
            if(rt_domain(did)%overland%properties%surface_slope(i,j,8) .gt. Vmax ) then
@@ -1123,7 +1120,7 @@ subroutine LandRT_ini(did)
               rt_domain(did)%overland%properties%max_surface_slope_index(i,j,3) = 8
               Vmax = rt_domain(did)%overland%properties%surface_slope(i,j,8)
            end if
-           
+
            !DJG Introduce reduction in retention depth as a linear function of terrain slope
            if (nlst(did)%RT_OPTION.eq.1) then
               if (Vmax.gt.0.75) then
@@ -1141,7 +1138,7 @@ subroutine LandRT_ini(did)
      !Apply calibration scaling factors to sfc roughness and retention depth here...
      rt_domain(did)%overland%properties%retention_depth = rt_domain(did)%overland%properties%retention_depth * rt_domain(did)%RETDEPRTFAC
      rt_domain(did)%overland%properties%roughness = rt_domain(did)%overland%properties%roughness * rt_domain(did)%OVROUGHRTFAC
-     
+
    !ADCHANGE: Moved this channel cell setting from OV_RTNG so it is outside
    !of overland routine (frequently called) and time loop.
    !Force channel retention depth to be 5mm.
@@ -1165,7 +1162,7 @@ subroutine LandRT_ini(did)
      rt_domain(did)%overland%properties%surface_slope_y(:,rt_domain(did)%JXRT)=rt_domain(did)%overland%properties%surface_slope_y(:,rt_domain(did)%JXRT-1)
      rt_domain(did)%overland%properties%surface_slope_y(:,1)=rt_domain(did)%overland%properties%surface_slope_y(:,2)
 #endif
-     
+
 #ifdef MPP_LAND
    ! communicate the value to
      call MPP_LAND_COM_REAL(rt_domain(did)%overland%properties%retention_depth,rt_domain(did)%IXRT,rt_domain(did)%JXRT,99)
@@ -1189,10 +1186,10 @@ subroutine LandRT_ini(did)
      if (nlst(did)%GWBASESWCRT.ge.1) then
         rt_domain(did)%numbasns = rt_domain(did)%NLINKSL
         RT_DOMAIN(did)%gnumbasns = rt_domain(did)%gNLINKSL
-        
+
         allocate (rt_domain(did)%z_gwsubbas (rt_domain(did)%numbasns  ))
         allocate (rt_domain(did)%nhdBuckMask(rt_domain(did)%numbasns  ))  ! default is -999
-        
+
         allocate (rt_domain(did)%qin_gwsubbas (rt_domain(did)%numbasns))
         allocate (rt_domain(did)%gwbas_pix_ct (rt_domain(did)%numbasns))
         allocate (rt_domain(did)%ct2_bas (rt_domain(did)%numbasns))
@@ -1202,32 +1199,32 @@ subroutine LandRT_ini(did)
         allocate (rt_domain(did)%gw_buck_exp(rt_domain(did)%numbasns))
         allocate (rt_domain(did)%z_max (rt_domain(did)%numbasns))
         allocate (rt_domain(did)%basns_area (rt_domain(did)%numbasns))
-        
+
         if(nlst(did)%bucket_loss .eq. 1) then
            allocate(rt_domain(did)%qloss_gwsubbas(rt_domain(did)%numbasns))
            allocate(rt_domain(did)%gw_buck_loss(rt_domain(did)%numbasns))
-           
+
            rt_domain(did)%qloss_gwsubbas = 0
            rt_domain(did)%gw_buck_loss = 0
         endif
-        
+
         rt_domain(did)%qin_gwsubbas = 0
         rt_domain(did)%z_gwsubbas = 0
         rt_domain(did)%gwbas_pix_ct = 0
         rt_domain(did)%bas_pcp = 0
-        
+
         rt_domain(did)%gw_buck_coeff = 0.04
         rt_domain(did)%gw_buck_exp  = 0.2
         rt_domain(did)%z_max = 0.1
-        
+
         !Temporary hardwire...
         rt_domain(did)%z_gwsubbas = 0.05   ! This gets updated with spun-up GW level in GWBUCKPARM.TBL
-        
+
         call readBucket_nhd(trim(nlst(did)%GWBUCKPARM_file), rt_domain(did)%numbasns, &
              rt_domain(did)%gw_buck_coeff, rt_domain(did)%gw_buck_exp, rt_domain(did)%gw_buck_loss, &
              rt_domain(did)%z_max, rt_domain(did)%z_gwsubbas, rt_domain(did)%LINKID(1:rt_domain(did)%numbasns),  &
              rt_domain(did)%nhdBuckMask )
-        
+
       !ADCHANGE: Added in read for z_init from GWBUCKPARM. Units coming in are mm but z_gwsubbas is in m
       !for UDMP=1 so we convert units.
         rt_domain(did)%z_gwsubbas = rt_domain(did)%z_gwsubbas/1000.
@@ -1237,7 +1234,7 @@ subroutine LandRT_ini(did)
         call flush(6)
 #endif
      endif
-     
+
   else
 
    !---------------------------------------------------------------------
@@ -1256,22 +1253,22 @@ subroutine LandRT_ini(did)
                 rt_domain(did)%IX,rt_domain(did)%JX,rt_domain(did)%IXRT,&
                 rt_domain(did)%JXRT,rt_domain(did)%GWSUBBASMSK,nlst(did)%gwbasmskfil,&
                 rt_domain(did)%gw_strm_msk,rt_domain(did)%numbasns,rt_domain(did)%overland%streams_and_lakes%ch_netrt,nlst(did)%AGGFACTRT)
-           
-           
+
+
            call SIMP_GW_IND(rt_domain(did)%ix,rt_domain(did)%jx,rt_domain(did)%GWSUBBASMSK,  &
                 rt_domain(did)%numbasns,rt_domain(did)%gnumbasns,rt_domain(did)%basnsInd)
-           
+
 #ifdef HYDRO_D
            write(6,*) "rt_domain(did)%gnumbasns, rt_domain(did)%numbasns, ", rt_domain(did)%gnumbasns , rt_domain(did)%numbasns
-           
+
 #endif
 #ifdef MPP_LAND
            call collectSizeInd(rt_domain(did)%numbasns)
 #endif
-           
+
            call get_gw_strm_msk_lind (rt_domain(did)%IXRT, rt_domain(did)%JXRT, rt_domain(did)%gw_strm_msk,&
                 rt_domain(did)%numbasns,rt_domain(did)%basnsInd,rt_domain(did)%gw_strm_msk_lind)
-           
+
            allocate (rt_domain(did)%qout_gwsubbas (rt_domain(did)%numbasns))
            allocate (rt_domain(did)%qin_gwsubbas (rt_domain(did)%numbasns))
            allocate (rt_domain(did)%z_gwsubbas (rt_domain(did)%numbasns))
@@ -1283,15 +1280,15 @@ subroutine LandRT_ini(did)
            allocate (rt_domain(did)%gw_buck_exp(rt_domain(did)%numbasns))
            allocate (rt_domain(did)%z_max (rt_domain(did)%numbasns))
            allocate (rt_domain(did)%basns_area (rt_domain(did)%numbasns))
-           
+
 #ifdef HYDRO_D
            write(6,*)  "end Simple GW-Bucket ..."
            print *, "Simple GW-Bucket Scheme selected, retrieving files..."
 #endif
-           
+
            !Temporary hardwire...
            rt_domain(did)%z_gwsubbas = 1.     ! This gets updated with spun-up GW level in GWBUCKPARM.TBL
-           
+
            call read_GWBUCKPARM(trim(nlst(did)%GWBUCKPARM_file),rt_domain(did)%numbasns,   &
                 rt_domain(did)%gnumbasns, rt_domain(did)%basnsInd, &
                 rt_domain(did)%gw_buck_coeff, rt_domain(did)%gw_buck_exp, rt_domain(did)%gw_buck_loss, &
@@ -1329,11 +1326,11 @@ subroutine LandRT_ini(did)
                 gw2d(did)%hycond, gw2d(did)%ho, &
                 gw2d(did)%bot, gw2d(did)%poros, &
                 gw2d(did)%ltype, nlst(did)%gwIhShift)
-           
+
            gw2d(did)%elev = rt_domain(did)%elrt
 
         end if ! end if (nlst_rt(did)%GWBASESWCRT.eq.1.or.nlst_rt(did)%GWBASESWCRT.eq.2)
-        
+
      end if ! end if (nlst_rt(did)%GWBASESWCRT.ge.1)
 
 !---------------------------------------------------------------------
@@ -1385,7 +1382,7 @@ subroutine LandRT_ini(did)
 
      else       !-- parameterize according to order of diffusion scheme, or if read from hi res file, use its value
                 !--  put condition within the if/then structure, which will assign a value if something is missing in hi res
-        
+
         do j=1,rt_domain(did)%NLINKS
 
            if (rt_domain(did)%ORDER(j) .eq. 1) then    !-- smallest stream reach
@@ -1530,11 +1527,11 @@ subroutine LandRT_ini(did)
               rt_domain(did)%HLINK(j) = HLINK_INIT(rt_domain(did)%ORDER(j))
            else   !-- the outlets won't have orders since there's no nodes, so
               !-- assign the order 5 values
-              
+
               if(rt_domain(did)%Bw(j) .eq. 0.0) then
                  rt_domain(did)%Bw(j) = BOTWID(5)
               endif
-              
+
               if(rt_domain(did)%Tw(j) .eq. 0.0) then
                  rt_domain(did)%Tw(j) = TOPWID(5)
               endif
@@ -1552,22 +1549,22 @@ subroutine LandRT_ini(did)
               endif
               rt_domain(did)%HLINK(j) = HLINK_INIT(5)
            endif
-           
+
            rt_domain(did)%CVOL(j) = (rt_domain(did)%Bw(j)+ 1/rt_domain(did)%ChSSLP(j)*rt_domain(did)%HLINK(j))*rt_domain(did)%HLINK(j)*rt_domain(did)%CHANLEN(j) !-- initalize channel volume
         end do
-        
+
      endif  !End if channel option eq 3; else;
-     
-     
+
+
      ! Initialize Lake Elevations for Gridded and NWM routing.
      do j=1,rt_domain(did)%NLAKES
         rt_domain(did)%RESHT(j) = rt_domain(did)%ORIFICEE(j) + &
              ((rt_domain(did)%LAKEMAXH(j) - rt_domain(did)%ORIFICEE(j) )* rt_domain(did)%ELEVLAKE(j))
      end do
-     
+
   end if     ! Endif for channel routing setup
 !-----------------------------------------------------------------------
-  
+
   if(nlst(did)%channel_only       .eq. 0 .and. &
        nlst(did)%channelBucket_only .eq. 0        ) then
 

--- a/trunk/NDHMS/template/HYDRO/hydro.namelist
+++ b/trunk/NDHMS/template/HYDRO/hydro.namelist
@@ -155,7 +155,7 @@ route_lake_f = "./DOMAIN/LAKEPARM.nc"
 reservoir_persistence = .FALSE.
 
 ! Specify the Persistence Reservoir parameter file
-reservoir_persistence_parameter_file = "./DOMAIN/persistence_parm.nc"
+reservoir_parameter_file = "./DOMAIN/persistence_parm.nc"
 
 ! Specify the path to the Timeslice files to be used by Reservoirs
 reservoir_timeslice_path = "./Timeslices/"


### PR DESCRIPTION
TYPE: new feature
KEYWORDS: reservoir_type, reservoir parameter file, lake parameter file
SOURCE: David Mattern

DESCRIPTION OF CHANGES: reservoir_type needs to be read from the reservoir parameter file instead of the lake parameter file. module_HYDRO_io.F will call a subroutine from module_reservoir_utilities.F to read this variable. The lake IDs in the lake parameter file will need to match the lake IDs in the reservoir parameter file. hydro_stop will be called if they do not match. reservoir_type is only read when the reservoir_persistence variable in hydro.namelist is set to true.

ISSUE: fixes #391

LIST OF MODIFIED FILES: 
trunk/NDHMS/OrchestratorLayer/config.f90 
trunk/NDHMS/Routing/Reservoirs/module_reservoir_utilities.F
trunk/NDHMS/Routing/module_HYDRO_io.F
trunk/NDHMS/Routing/module_RT.F

TESTS CONDUCTED: Tests conducted to ensure the reservoir_type is properly read from the reservoir parameter file and calls hydro_stop if the Lake IDs from the lake parameter file and the reservoir parameter file do not match. 