### PR TITLE
Update two CMakeLists.txt files

### DIFF
--- a/trunk/NDHMS/OrchestratorLayer/CMakeLists.txt
+++ b/trunk/NDHMS/OrchestratorLayer/CMakeLists.txt
@@ -7,4 +7,6 @@ add_library(hydro_orchestrator STATIC
         orchestrator.f90
         )
 
+add_dependencies(hydro_orchestrator hydro_utils)
+
 target_link_libraries(hydro_orchestrator PUBLIC hydro_netcdf_layer)

--- a/trunk/NDHMS/OrchestratorLayer/CMakeLists.txt
+++ b/trunk/NDHMS/OrchestratorLayer/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(hydro_orchestrator STATIC
         orchestrator.f90
         )
 
+add_dependencies(hydro_orchestrator hydro_netcdf_layer)
 add_dependencies(hydro_orchestrator hydro_utils)
 
 target_link_libraries(hydro_orchestrator PUBLIC hydro_netcdf_layer)
+target_link_libraries(hydro_orchestrator PUBLIC hydro_utils)

--- a/trunk/NDHMS/Routing/Reservoirs/RFC_Forecasts/CMakeLists.txt
+++ b/trunk/NDHMS/Routing/Reservoirs/RFC_Forecasts/CMakeLists.txt
@@ -6,5 +6,5 @@ add_library(hydro_routing_reservoirs_rfc STATIC
 	module_rfc_forecasts_properties.F
 )
 
-add_dependencies(hydro_routing_reservoirs_levelpool hydro_routing_reservoirs)
+add_dependencies(hydro_routing_reservoirs_rfc hydro_routing_reservoirs)
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: CMake

SOURCE: Ryan Cabell, NCAR

DESCRIPTION OF CHANGES: 

* Fix typo with wrong library name in RFC_Forecasts/CMakeLists.txt
* Add missing dependency on `hydro_utils` in OrchestratorLayer/CMakeLists.txt

ISSUE:  Fixes #407 

TESTS CONDUCTED:

Builds with `-j`, `-j 2`, `-j 4`, and `-j 16` all correctly build the code now.

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [X] Closes issue #407 (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [-] ~Tests added (unit tests and/or regression/integration tests)~
 - [X] Backwards compatible
 - [X] Requires new files? **No**
 - [-] ~Fully documented~
 - [-] ~Short description in the Development section of `NEWS.md`~
