### PR TITLE
Update CMakeLists.txt to include preprocessor flags (Take 2)

### DIFF
--- a/trunk/NDHMS/CMakeLists.txt
+++ b/trunk/NDHMS/CMakeLists.txt
@@ -169,11 +169,11 @@ message("=============================================================")
 if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU.*")
     # set compile flags for gfortran
     message ( "-- Using gfortran")
-    set (CMAKE_Fortran_FLAGS "-fpp -O2 -g -w -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4")
+    set (CMAKE_Fortran_FLAGS "-cpp -O2 -g -w -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4")
 elseif (CMAKE_Fortran_COMPILER_ID MATCHES "Intel.*")
     # set compile flags for ifort
     message ( "Using ifort")
-    set (CMAKE_Fortran_FLAGS "-cpp -O2 -g -w -ftz -align all -fno-alias -fp-model precise -FR -convert big_endian")
+    set (CMAKE_Fortran_FLAGS "-fpp -O2 -g -w -ftz -align all -fno-alias -fp-model precise -FR -convert big_endian")
 else (CMAKE_Fortran_COMPILER_ID MATCHES "GNU.*")
     message ("CMAKE_Fortran_COMPILER full path: " ${CMAKE_Fortran_COMPILER})
     message ("Fortran compiler: " ${Fortran_COMPILER_NAME})


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: CMake

SOURCE: Ryan Cabell, NCAR

DESCRIPTION OF CHANGES: Adds explicit `-fpp` and `-cpp` preprocessor flags to `CMAKE_Fortran_FLAGS` set statements

**This update corrects inverted gfortran/Intel flags 😳**

ISSUE: Closes issue #409 

TESTS CONDUCTED: Croton case with CMake-based build (not currently in CI)

ADDITIONAL NOTES: Also adds some explicit dependencies to improve build reliability 

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [X] Closes issue 409  
 - [-] ~Tests added (unit tests and/or regression/integration tests)~
 - [X] Backwards compatible
 - [X] Requires new files? _NO_
 - [X] Fully documented
 - [-] ~Short description in the Development section of `NEWS.md`~
