### PR TITLE
Add logic to support both KDAY and KHOUR

### DIFF
--- a/trunk/NDHMS/OrchestratorLayer/config.f90
+++ b/trunk/NDHMS/OrchestratorLayer/config.f90
@@ -826,7 +826,7 @@ contains
      integer            :: pedotransfer_option = 0
      integer            :: crop_option = 0
      integer            :: split_output_count = 1
-     integer            :: khour
+     integer            :: khour = -999
      integer            :: kday = -999
      real               :: zlvl
      character(len=256) :: hrldas_setup_file = " "
@@ -958,8 +958,19 @@ contains
     noah_lsm%crop_option = crop_option
 
     noah_lsm%split_output_count = split_output_count
+
+    if (kday > 0) then
+        if (khour > 0) then
+            write(*, '("WARNING: Check Namelist: KHOUR and KDAY both defined, KHOUR will take precedence.")')
+            kday = -999
+        else
+            write(*, '("WARNING: KDAY is deprecated and may be removed in a future version, please use KHOUR.")')
+            khour = -999
+        end if
+    end if
+    noah_lsm%kday = kday
     noah_lsm%khour = khour
-    noah_lsm%kday = -999!kday
+
     noah_lsm%zlvl = zlvl
     noah_lsm%hrldas_setup_file = hrldas_setup_file
     noah_lsm%mmf_runoff_file = " "!mmf_runoff_file


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: noahlsm, lsm, kday, khour

SOURCE: Ryan Cabell, NCAR

DESCRIPTION OF CHANGES: Re-introduce support for `kday` in `namelist.hrldas` but log warning messages indicating that the option is deprecated.

ISSUE:  Closes issue #395 

TESTS CONDUCTED: Tested with Intel and GFortran, for all combinations of `kday`, `khour`, both, and neither specified. All results as expected.


### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [X] Closes issue #395
 - [X] Tests performed
 - [X] Backwards compatible
 - [X] Requires new files? **No**
 - [ ] ~Fully documented~
 - [ ] ~Short description in the Development section of `NEWS.md`~
