### PR TITLE
Add NWM_META compile time option

### DIFF
--- a/trunk/NDHMS/CMakeLists.txt
+++ b/trunk/NDHMS/CMakeLists.txt
@@ -58,6 +58,7 @@ set (WRF_HYDRO_RAPID $ENV{WRF_HYDRO_RAPID} CACHE STRING "WRF-Hydro coupling to R
 set (SPATIAL_SOIL $ENV{SPATIAL_SOIL} CACHE STRING "Spatially distributed soil parameters for NoahMP 0=off 1=on")
 set (WRFIO_NCD_LARGE_FILE_SUPPORT $ENV{WRFIO_NCD_LARGE_FILE_SUPPORT} CACHE STRING "Large netCDF file support 0=off, 1=on")
 set (NCEP_WCOSS $ENV{NCEP_WCOSS} CACHE STRING "WCOSS file units 0=off 1=on")
+set (NWM_META $ENV{NWM_META} CACHE STRING "NWM output metadata 0=off 1=on")
 set (WRF_HYDRO_NUDGING $ENV{WRF_HYDRO_NUDGING} CACHE STRING "Streamflow nudging 0=off 1=on")
 set (OUTPUT_CHAN_CONN $ENV{OUTPUT_CHAN_CONN} CACHE STRING "Output channel connections")
 set (PRECIP_DOUBLE $ENV{PRECIP_DOUBLE} CACHE STRING "Precipitation as double")
@@ -86,6 +87,10 @@ endif (WRFIO_NCD_LARGE_FILE_SUPPORT STREQUAL "")
 if (NCEP_WCOSS STREQUAL "")
 	set (NCEP_WCOSS "0" CACHE STRING "WCOSS file units 0=off, 1=on" FORCE)
 endif (NCEP_WCOSS STREQUAL "")
+
+if (NWM_META STREQUAL "")
+        set (NWM_META "0" CACHE STRING "NWM output metadata 0=off, 1=on" FORCE)
+endif (NWM_META STREQUAL "")
 
 if (WRF_HYDRO_NUDGING STREQUAL "")
 	set (WRF_HYDRO_NUDGING "0" CACHE STRING "Streamflow nudging 0=off, 1=on" FORCE)
@@ -143,6 +148,12 @@ message ("NCEP_WCOSS = " ${NCEP_WCOSS} )
 if (NCEP_WCOSS STREQUAL "1" )
 	add_definitions(-DNCEP_WCOSS)
 endif (NCEP_WCOSS STREQUAL "1") 
+
+#set -DNCEP_WCOSS from env
+message ("NWM_META = " ${NWM_META} )
+if (NWM_META STREQUAL "1" )
+        add_definitions(-DNWM_META)
+endif (NWM_META STREQUAL "1")
 
 #set -DSPATIAL_SOIL from env
 message ("WRF_HYDRO_NUDGING = " ${WRF_HYDRO_NUDGING} )

--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -669,7 +669,7 @@ subroutine output_chrt_NWM(domainId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create conventions attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"code_version",trim(get_code_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create code_version attribute')
-#ifdef NCEP_WCOSS
+#ifdef NWM_META
       iret = nf90_put_att(ftn,NF90_GLOBAL,"NWM_version_number",trim(get_nwm_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create NWM_version_number attribute')
 #endif
@@ -764,7 +764,7 @@ subroutine output_chrt_NWM(domainId)
       iret = nf90_put_att(ftn,featureVarId,'cf_role',trim(fileMeta%cfRole))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place cf_role attribute into feature_id variable')
 
-#ifndef NCEP_WCOSS
+#ifndef NWM_META
       ! Create channel lat/lon variables
       ! NOTE: NWM current operations do not permit the output of latitude and longitude for streamflow.
       iret = nf90_def_var(ftn,"latitude",nf90_float,dimId(1),latVarId)
@@ -812,7 +812,7 @@ subroutine output_chrt_NWM(domainId)
          call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for feature_id.')
          iret = nf90_def_var_deflate(ftn,refTimeId,0,1,2)
          call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for reference_time.')
-#ifndef NCEP_WCOSS
+#ifndef NWM_META
          iret = nf90_def_var_deflate(ftn,latVarId,0,1,2)
          call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for latitude.')
          iret = nf90_def_var_deflate(ftn,lonVarId,0,1,2)
@@ -924,7 +924,7 @@ subroutine output_chrt_NWM(domainId)
       iret = nf90_put_var(ftn,varId,varMetaInt(2,:))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place data into feature_id output variable.')
 
-#ifndef NCEP_WCOSS
+#ifndef NWM_META
       iret = nf90_inq_varid(ftn,'latitude',varId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to locate latitude in NetCDF file.')
       iret = nf90_put_var(ftn,varId,varMetaReal(1,:))
@@ -1264,7 +1264,7 @@ subroutine output_NoahMP_NWM(outDir,iGrid,output_timestep,itime,startdate,date,i
          call nwmCheck(diagFlag,iret,'ERROR: Unable to place CF conventions attribute into LDASOUT file.')
          iret = nf90_put_att(ftnNoahMP,NF90_GLOBAL,"code_version",trim(get_code_version()))
          call nwmCheck(diagFlag,iret,'ERROR: Unable to create code_version attribute')
-#ifdef NCEP_WCOSS
+#ifdef NWM_META
          iret = nf90_put_att(ftnNoahMP,NF90_GLOBAL,"NWM_version_number",trim(get_nwm_version()))
          call nwmCheck(diagFlag,iret,'ERROR: Unable to create NWM_version_number attribute')
 #endif
@@ -1853,7 +1853,7 @@ subroutine output_rt_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place CF conventions attribute into RT_DOMAIN file.')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"code_version",trim(get_code_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create code_version attribute')
-#ifdef NCEP_WCOSS
+#ifdef NWM_META
       iret = nf90_put_att(ftn,NF90_GLOBAL,"NWM_version_number",trim(get_nwm_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create NWM_version_number attribute')
 #endif
@@ -2569,7 +2569,7 @@ subroutine output_lakes_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create conventions attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"code_version",trim(get_code_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create code_version attribute')
-#ifdef NCEP_WCOSS
+#ifdef NWM_META
       iret = nf90_put_att(ftn,NF90_GLOBAL,"NWM_version_number",trim(get_nwm_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create NWM_version_number attribute')
 #endif
@@ -3078,7 +3078,7 @@ subroutine output_chrtout_grd_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place CF conventions attribute into RT_DOMAIN file.')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"code_version",trim(get_code_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create code_version attribute')
-#ifdef NCEP_WCOSS
+#ifdef NWM_META
       iret = nf90_put_att(ftn,NF90_GLOBAL,"NWM_version_number",trim(get_nwm_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create NWM_version_number attribute')
 #endif
@@ -3547,7 +3547,7 @@ subroutine output_lsmOut_NWM(domainId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place CF conventions attribute into LDASOUT file.')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"code_version",trim(get_code_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create code_version attribute')
-#ifdef NCEP_WCOSS
+#ifdef NWM_META
       iret = nf90_put_att(ftn,NF90_GLOBAL,"NWM_version_number",trim(get_nwm_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create NWM_version_number attribute')
 #endif
@@ -4520,7 +4520,7 @@ subroutine output_chanObs_NWM(domainId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create conventions attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"code_version",trim(get_code_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create code_version attribute')
-#ifdef NCEP_WCOSS
+#ifdef NWM_META
       iret = nf90_put_att(ftn,NF90_GLOBAL,"NWM_version_number",trim(get_nwm_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create NWM_version_number attribute')
 #endif
@@ -5151,7 +5151,7 @@ subroutine output_gw_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create conventions attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"code_version",trim(get_code_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create code_version attribute')
-#ifdef NCEP_WCOSS
+#ifdef NWM_META
       iret = nf90_put_att(ftn,NF90_GLOBAL,"NWM_version_number",trim(get_nwm_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create NWM_version_number attribute')
 #endif

--- a/trunk/NDHMS/arc/macros.mpp.gfort
+++ b/trunk/NDHMS/arc/macros.mpp.gfort
@@ -34,6 +34,12 @@ else
 WRFIO_NCD_LARGE_FILE_SUPPORT =
 endif
 
+ifeq ($(NWM_META),1)
+NWM_META = -DNWM_META
+else
+NWM_META =
+endif
+
 ifeq ($(WRF_HYDRO_NUDGING),1)
 WRF_HYDRO_NUDGING = -DWRF_HYDRO_NUDGING
 else
@@ -59,7 +65,7 @@ F90FLAGS  =       -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian
 MODFLAG	=	-I"./" -I"../../MPP" -I"../MPP" -I"../mod"
 LDFLAGS	=	
 CPPINVOKE	=   -cpp
-CPPFLAGS	=   -DMPP_LAND -I"../Data_Rec" $(HYDRO_D) $(SPATIAL_SOIL) $(WRFIO_NCD_LARGE_FILE_SUPPORT)  $(WRF_HYDRO_NUDGING) $(OUTPUT_CHAN_CONN) $(PRECIP_DOUBLE)
+CPPFLAGS	=   -DMPP_LAND -I"../Data_Rec" $(HYDRO_D) $(SPATIAL_SOIL) $(WRFIO_NCD_LARGE_FILE_SUPPORT) $(NWM_META) $(WRF_HYDRO_NUDGING) $(OUTPUT_CHAN_CONN) $(PRECIP_DOUBLE)
 
 LIBS 	=	
 NETCDFINC       =       $(NETCDF_INC)

--- a/trunk/NDHMS/arc/macros.mpp.ifort
+++ b/trunk/NDHMS/arc/macros.mpp.ifort
@@ -52,6 +52,12 @@ else
 PRECIP_DOUBLE = 
 endif
 
+ifeq ($(NWM_META),1)
+NWM_META = -DNWM_META
+else
+NWM_META =
+endif
+
 ifeq ($(NCEP_WCOSS),1)
 NCEP_WCOSS = -DNCEP_WCOSS
 else
@@ -66,7 +72,7 @@ F90FLAGS    = -O2 -g -w -c -ftz -align all -fno-alias -fp-model precise $(FORMAT
 MODFLAG	    = -I./ -I ../../MPP -I ../MPP -I ../mod
 LDFLAGS	    =
 CPPINVOKE   = -fpp
-CPPFLAGS    = -DMPP_LAND -I ../Data_Rec $(HYDRO_D) $(SPATIAL_SOIL) $(WRFIO_NCD_LARGE_FILE_SUPPORT) $(WRF_HYDRO_NUDGING) $(OUTPUT_CHAN_CONN) $(PRECIP_DOUBLE) $(NCEP_WCOSS)
+CPPFLAGS    = -DMPP_LAND -I ../Data_Rec $(HYDRO_D) $(SPATIAL_SOIL) $(WRFIO_NCD_LARGE_FILE_SUPPORT) $(NWM_META) $(WRF_HYDRO_NUDGING) $(OUTPUT_CHAN_CONN) $(PRECIP_DOUBLE) $(NCEP_WCOSS)
 LIBS 	    =	
 NETCDFINC   = $(NETCDF_INC)
 NETCDFLIB   = -L$(NETCDF_LIB) -lnetcdff -lnetcdf

--- a/trunk/NDHMS/arc/macros.mpp.ifort.luna
+++ b/trunk/NDHMS/arc/macros.mpp.ifort.luna
@@ -87,6 +87,11 @@ else
 NCEP_WCOSS =
 endif
 
+ifeq ($(NWM_META),1)
+NWM_META = -DNWM_META
+else
+NWM_META =
+endif
 
 RMD	    = rm -f
 COMPILER90  = ftn
@@ -96,7 +101,7 @@ F90FLAGS    = -w -c -ftz -align all -fno-alias -fp-model precise $(FORMAT_FREE) 
 MODFLAG	    = -I./ -I ../../MPP -I ../MPP -I ../mod
 LDFLAGS	    = $(HDF5_LDFLAGS)
 CPPINVOKE	= -fpp
-CPPFLAGS    = -DMPP_LAND -I ../Data_Rec $(HYDRO_D) $(SPATIAL_SOIL) $(WRFIO_NCD_LARGE_FILE_SUPPORT) $(WRF_HYDRO_NUDGING) $(OUTPUT_CHAN_CONN) $(PRECIP_DOUBLE) $(NCEP_WCOSS)
+CPPFLAGS    = -DMPP_LAND -I ../Data_Rec $(HYDRO_D) $(SPATIAL_SOIL) $(WRFIO_NCD_LARGE_FILE_SUPPORT) $(NWM_META) $(WRF_HYDRO_NUDGING) $(OUTPUT_CHAN_CONN) $(PRECIP_DOUBLE) $(NCEP_WCOSS)
 LIBS 	    =$(Z_LIB)	
 NETCDFINC   = $(NETCDF_INC)
 NETCDFLIB   = -L$(NETCDF_LIB) -lnetcdff -lnetcdf

--- a/trunk/NDHMS/arc/macros.mpp.ifort.omp
+++ b/trunk/NDHMS/arc/macros.mpp.ifort.omp
@@ -58,6 +58,12 @@ else
 NCEP_WCOSS =
 endif
 
+ifeq ($(NWM_META),1)
+NWM_META = -DNWM_META
+else
+NWM_META =
+endif
+
 RMD	    = rm -f
 COMPILER90  = mpif90
 FORMAT_FREE = -FR
@@ -66,7 +72,7 @@ F90FLAGS    = -xHost -qopenmp -g -w -c -ftz -align all -fno-alias -fp-model stri
 MODFLAG	    = -I./ -I ../../MPP -I ../MPP -I ../mod
 LDFLAGS	    = -qopenmp
 CPPINVOKE   = -fpp
-CPPFLAGS    = -DMPP_LAND -I ../Data_Rec $(HYDRO_D) $(SPATIAL_SOIL) $(WRFIO_NCD_LARGE_FILE_SUPPORT) $(WRF_HYDRO_NUDGING) $(OUTPUT_CHAN_CONN) $(PRECIP_DOUBLE) $(NCEP_WCOSS)
+CPPFLAGS    = -DMPP_LAND -I ../Data_Rec $(HYDRO_D) $(SPATIAL_SOIL) $(WRFIO_NCD_LARGE_FILE_SUPPORT) $(NWM_META) $(WRF_HYDRO_NUDGING) $(OUTPUT_CHAN_CONN) $(PRECIP_DOUBLE) $(NCEP_WCOSS)
 LIBS 	    = -qopenmp
 NETCDFINC   = $(NETCDF_INC)
 NETCDFLIB   = -L$(NETCDF_LIB) -lnetcdff -lnetcdf

--- a/trunk/NDHMS/arc/macros.mpp.ifort.summit_has
+++ b/trunk/NDHMS/arc/macros.mpp.ifort.summit_has
@@ -58,6 +58,12 @@ else
 NCEP_WCOSS =
 endif
 
+ifeq ($(NWM_META),1)
+NWM_META = -DNWM_META
+else
+NWM_META =
+endif
+
 RMD	    = rm -f
 COMPILER90  = mpiifort
 FORMAT_FREE = -FR
@@ -66,7 +72,7 @@ F90FLAGS    = -O2 -g -w -c -ftz -align all -fno-alias -fp-model precise $(FORMAT
 MODFLAG	    = -I./ -I ../../MPP -I ../MPP -I ../mod
 LDFLAGS	    =
 CPPINVOKE	= -fpp
-CPPFLAGS    = -DMPP_LAND -I ../Data_Rec $(HYDRO_D) $(SPATIAL_SOIL) $(WRFIO_NCD_LARGE_FILE_SUPPORT) $(WRF_HYDRO_NUDGING) $(OUTPUT_CHAN_CONN) $(PRECIP_DOUBLE) $(NCEP_WCOSS)
+CPPFLAGS    = -DMPP_LAND -I ../Data_Rec $(HYDRO_D) $(SPATIAL_SOIL) $(WRFIO_NCD_LARGE_FILE_SUPPORT) $(NWM_META) $(WRF_HYDRO_NUDGING) $(OUTPUT_CHAN_CONN) $(PRECIP_DOUBLE) $(NCEP_WCOSS)
 LIBS 	    =	
 NETCDFINC   = $(NETCDF_INC)
 NETCDFLIB   = -L$(NETCDF_LIB) -lnetcdff -lnetcdf

--- a/trunk/NDHMS/compile_offline_NoahMP.sh
+++ b/trunk/NDHMS/compile_offline_NoahMP.sh
@@ -22,6 +22,7 @@ if [[ ! -z $env_file ]]; then
     unset WRF_HYDRO_RAPID
     unset WRFIO_NCD_LARGE_FILE_SUPPORT
     unset NCEP_WCOSS
+    unset NWM_META
     unset WRF_HYDRO_NUDGING
 
     echo "configure: Sourcing $env_file for the compile options."

--- a/trunk/NDHMS/template/setEnvar.sh
+++ b/trunk/NDHMS/template/setEnvar.sh
@@ -20,5 +20,8 @@ export WRFIO_NCD_LARGE_FILE_SUPPORT=1
 # WCOSS file units: 0=Off, 1=On.
 export NCEP_WCOSS=0
 
+# NWM output metadata: 0=Off, 1=On.
+export NWM_META=0
+
 # Streamflow nudging: 0=Off, 1=On.
 export WRF_HYDRO_NUDGING=0

--- a/trunk/NDHMS/utils/module_version.F
+++ b/trunk/NDHMS/utils/module_version.F
@@ -13,7 +13,7 @@ contains
 function get_model_version()
 character (len=512) :: get_model_version
 
-#ifdef NCEP_WCOSS
+#ifdef NWM_META
    get_model_version="NWM " // NWM_VERSION
 #else
    get_model_version="WRF-Hydro " // WRF_HYDRO_VERSION


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: compile option, NWM, metadata

SOURCE: Katelyn (NCAR)

DESCRIPTION OF CHANGES: 
* Adds a new compile time option NWM_META to control NWM specific metadata rather than using NCEP_WCOSS for this in addition to its other functionality

ISSUE:
```
Fixes #418
```

TESTS CONDUCTED: 
Local test suite passes

NOTES: 
Open to other ideas for how to address this issue.  I just needed something for the time being and this worked.  
