### PR TITLE
CHANOBS output to a single file under NWM IO

### DIFF
--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -311,7 +311,7 @@ subroutine output_chrt_NWM(domainId)
       allocate(velocityLocal(RT_DOMAIN(domainId)%NLINKS))
       strFlowLocal = RT_DOMAIN(domainId)%QLINK(:,1)
       velocityLocal = RT_DOMAIN(domainId)%velocity
-      ! TML: Add qloss allocation and compute variable, only for channel 
+      ! TML: Add qloss allocation and compute variable, only for channel
       ! option #2, where qloss is active (muskingum-cunge).
       if(nlst(domainId)%channel_option == 2 .and. nlst(domainId)%channel_loss_option > 0) then
          allocate(qlossLocal(RT_DOMAIN(domainId)%NLINKS))
@@ -1170,7 +1170,7 @@ subroutine output_NoahMP_NWM(outDir,iGrid,output_timestep,itime,startdate,date,i
 
    ! Initialize overland routing flag for SFCRNOFF outputs
    sfcflag = 1
-   if (nlst(1)%OVRTSWCRT > 0) then 
+   if (nlst(1)%OVRTSWCRT > 0) then
      sfcflag = 0
    endif
 
@@ -4382,10 +4382,12 @@ subroutine output_chanObs_NWM(domainId)
    type(chObsMeta) :: fileMeta
 
    ! Local variables
+   logical :: single_output_file, single_output_file_exists
    integer :: nudgeFlag, mppFlag, diagFlag
    integer :: minSinceSim ! Number of minutes since beginning of simulation.
    integer :: minSinceEpoch1 ! Number of minutes from EPOCH to the beginning of the model simulation.
    integer :: minSinceEpoch ! Number of minutes from EPOCH to the current model valid time.
+   integer, dimension(1) :: minSinceEpochVect
    character(len=16) :: epochDate ! EPOCH represented as a string.
    character(len=16) :: startDate ! Start of model simulation, represented as a string.
    character(len=256) :: output_flnm ! CHRTOUT_DOMAIN filename
@@ -4396,6 +4398,7 @@ subroutine output_chanObs_NWM(domainId)
    integer :: dimId(3) ! Dimension ID values created during NetCDF created.
    integer :: varId ! Variable ID value created as NetCDF variables are created and populated.
    integer :: timeId ! Dimension ID for the time dimension.
+   integer :: tmpDimId, n_times, n_feature_ids
    integer :: refTimeId ! Dimension ID for the reference time dimension.
    integer :: coordVarId ! Variable to hold crs
    integer :: featureVarId, elevVarId, orderVarId ! Misc NetCDF variable id values
@@ -4461,7 +4464,7 @@ subroutine output_chanObs_NWM(domainId)
 
    ! Initialize NWM dictionary derived type containing all the necessary metadat
    ! for the output file.
-   call initChanObsDict(fileMeta,diagFlag,myId)
+   call initChanObsDict(fileMeta, diagFlag, myId)
 
    ! For now, keep all output variables on, regardless of IOC flag
    fileMeta%outFlag(:) = [1]
@@ -4483,6 +4486,7 @@ subroutine output_chanObs_NWM(domainId)
    ! Fourth, calculate the total number of minutes from EPOCH to the current
    ! model time step.
    minSinceEpoch = minSinceEpoch1 + minSinceSim
+   minSinceEpochVect(1) = minSinceEpoch
    ! Fifth, compose global attribute time strings that will be used.
    validTime = trim(nlst(domainId)%olddate(1:4)//'-'//&
                     nlst(domainId)%olddate(6:7)//'-'//&
@@ -4508,11 +4512,16 @@ subroutine output_chanObs_NWM(domainId)
    fileMeta%totalValidTime = int(nlst(1)%khour * 60 / nlst(1)%out_dt)  ! # number of valid time (#of output files)
 
    ! Compose output file name.
-   write(output_flnm,'(A12,".CHANOBS_DOMAIN",I1)')nlst(domainId)%olddate(1:4)//&
-         nlst(domainId)%olddate(6:7)//nlst(domainId)%olddate(9:10)//&
-         nlst(domainId)%olddate(12:13)//nlst(domainId)%olddate(15:16),&
-         nlst(domainId)%igrid
-
+   ! 0 means do not split = single output file
+   single_output_file = nlst(domainId)%split_output_count .eq. 0
+   if(single_output_file) then
+      write(output_flnm,'("CHANOBS_DOMAIN",I1,".nc")'), nlst(domainId)%igrid
+   else
+      write(output_flnm,'(A12,".CHANOBS_DOMAIN",I1)')nlst(domainId)%olddate(1:4)//&
+           nlst(domainId)%olddate(6:7)//nlst(domainId)%olddate(9:10)//&
+           nlst(domainId)%olddate(12:13)//nlst(domainId)%olddate(15:16),&
+           nlst(domainId)%igrid
+   endif
 
    ! First step is to allocate a global array of index values. This "index"
    ! array will be used to subset after collection has taken place. Also,
@@ -4645,8 +4654,7 @@ subroutine output_chanObs_NWM(domainId)
 
       if(nlst(domainId)%channel_option .ne. 3) then
          ! Check to see if we have any gages that need to be added for
-         ! reach-based
-         ! routing.
+         ! reach-based routing.
          call checkRouteGages(diagFlag,gSize,g_outInd)
       endif
 
@@ -4655,7 +4663,7 @@ subroutine output_chanObs_NWM(domainId)
       where(g_qlink(:,1) .le. -9999) g_outInd = 0
 
       ! Allocate output arrays based on size of number of forecast points.
-      numPtsOut = SUM(g_outInd)
+      numPtsOut = sum(g_outInd)
 
       if(numPtsOut .eq. 0) then
          ! Write warning message to user showing there are NO forecast points to
@@ -4675,15 +4683,15 @@ subroutine output_chanObs_NWM(domainId)
       allocate(g_zelevOut(numPtsOut))
 
       ! Subset global arrays for forecast points.
-      g_STRMFRXSTPTSOut = PACK(g_STRMFRXSTPTS,g_outInd == 1)
-      g_chlonOut = PACK(g_chlon,g_outInd == 1)
-      g_chlatOut = PACK(g_chlat,g_outInd == 1)
-      g_hlinkOut = PACK(g_hlink,g_outInd == 1)
-      g_qlinkOut(:,1) = PACK(g_qlink(:,1),g_outInd == 1)
-      g_qlinkOut(:,2) = PACK(g_qlink(:,2),g_outInd == 1)
-      g_linkidOut = PACK(g_linkid,g_outInd == 1)
-      g_orderOut = PACK(g_order,g_outInd == 1)
-      g_zelevOut = PACK(g_zelev,g_outInd == 1)
+      g_STRMFRXSTPTSOut = pack(g_STRMFRXSTPTS,g_outInd == 1)
+      g_chlonOut = pack(g_chlon,g_outInd == 1)
+      g_chlatOut = pack(g_chlat,g_outInd == 1)
+      g_hlinkOut = pack(g_hlink,g_outInd == 1)
+      g_qlinkOut(:,1) = pack(g_qlink(:,1),g_outInd == 1)
+      g_qlinkOut(:,2) = pack(g_qlink(:,2),g_outInd == 1)
+      g_linkidOut = pack(g_linkid,g_outInd == 1)
+      g_orderOut = pack(g_order,g_outInd == 1)
+      g_zelevOut = pack(g_zelev,g_outInd == 1)
 
       allocate(varOutReal(fileMeta%numVars,numPtsOut))
       allocate(varOutInt(numPtsOut))
@@ -4693,268 +4701,299 @@ subroutine output_chanObs_NWM(domainId)
       ! Mask out missing values
       where ( varOutReal == fileMeta%modelNdv ) varOutReal = -9999.0
 
-     ! call the GetModelConfigType function
-     modelConfigType = GetModelConfigType(nlst(1)%io_config_outputs)
+      ! call the GetModelConfigType function
+      modelConfigType = GetModelConfigType(nlst(1)%io_config_outputs)
 
-      ! Create NetCDF for output.
-      iret = nf90_create(trim(output_flnm),cmode=NF90_NETCDF4,ncid = ftn)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create CHANOBS NetCDF file.')
+      ! Create NetCDF for output?
+
+      if(single_output_file) then
+         iret = nf90_create(trim(output_flnm), cmode=ior(nf90_noclobber,nf90_netcdf4), ncid=ftn)
+         single_output_file_exists = iret == nf90_eexist
+      endif
+
+      if((.not. single_output_file) .or. (.not. single_output_file_exists)) then
+
+         iret = nf90_create(trim(output_flnm), cmode=nf90_netcdf4, ncid=ftn)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create CHANOBS NetCDF file.')
 
       ! Write global attributes.
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"TITLE",trim(fileMeta%title))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create TITLE attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"featureType",trim(fileMeta%fType))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create featureType attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"proj4",trim(fileMeta%proj4))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create proj4 attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"model_initialization_time",trim(fileMeta%initTime))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create model init attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"station_dimension",trim(fileMeta%stDim))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create st. dimension attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"model_output_valid_time",trim(fileMeta%validTime))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create model valid attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"model_total_valid_times",fileMeta%totalValidTime)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create model total valid times attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"stream_order_output",fileMeta%stOrder)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create order attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"cdm_datatype",trim(fileMeta%cdm))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create CDM attribute')
-      !iret = nf90_put_att(ftn,NF90_GLOBAL,"esri_pe_string",trim(fileMeta%esri))
-      !call nwmCheck(diagFlag,iret,'ERROR: Unable to create ESRI attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"Conventions",trim(fileMeta%conventions))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create conventions attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"code_version",trim(get_code_version()))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create code_version attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"TITLE",trim(fileMeta%title))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create TITLE attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"featureType",trim(fileMeta%fType))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create featureType attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"proj4",trim(fileMeta%proj4))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create proj4 attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"model_initialization_time",trim(fileMeta%initTime))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create model init attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"station_dimension",trim(fileMeta%stDim))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create st. dimension attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"model_output_valid_time",trim(fileMeta%validTime))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create model valid attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"model_total_valid_times",fileMeta%totalValidTime)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create model total valid times attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"stream_order_output",fileMeta%stOrder)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create order attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"cdm_datatype",trim(fileMeta%cdm))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create CDM attribute')
+         !iret = nf90_put_att(ftn,NF90_GLOBAL,"esri_pe_string",trim(fileMeta%esri))
+         !call nwmCheck(diagFlag,iret,'ERROR: Unable to create ESRI attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"Conventions",trim(fileMeta%conventions))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create conventions attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"code_version",trim(get_code_version()))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create code_version attribute')
 #ifdef NWM_META
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"NWM_version_number",trim(get_nwm_version()))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create NWM_version_number attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"NWM_version_number",trim(get_nwm_version()))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create NWM_version_number attribute')
 #endif
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"model_output_type",trim(fileMeta%modelOutputType))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create model_output_type attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"model_configuration",modelConfigType)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create model_configuration attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"model_output_type",trim(fileMeta%modelOutputType))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create model_output_type attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"model_configuration",modelConfigType)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create model_configuration attribute')
 
-      ! Create global attributes specific to running output through the
-      ! channel-only configuration of the model.
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"dev_OVRTSWCRT",nlst(domainId)%OVRTSWCRT)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create dev_OVRTSWCRT attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"dev_NOAH_TIMESTEP",int(nlst(domainId)%dt))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create dev_NOAH_TIMESTEP attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"dev_channel_only",nlst(domainId)%channel_only)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create dev_channel_only attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,"dev_channelBucket_only",nlst(domainId)%channelBucket_only)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create dev_channelBucket_only attribute')
-      iret = nf90_put_att(ftn,NF90_GLOBAL,'dev','dev_ prefix indicates development/internal meta data')
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create dev attribute')
+         ! Create global attributes specific to running output through the
+         ! channel-only configuration of the model.
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"dev_OVRTSWCRT",nlst(domainId)%OVRTSWCRT)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create dev_OVRTSWCRT attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"dev_NOAH_TIMESTEP",int(nlst(domainId)%dt))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create dev_NOAH_TIMESTEP attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"dev_channel_only",nlst(domainId)%channel_only)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create dev_channel_only attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"dev_channelBucket_only",nlst(domainId)%channelBucket_only)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create dev_channelBucket_only attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,'dev','dev_ prefix indicates development/internal meta data')
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create dev attribute')
 
-      ! Create dimensions
-      iret = nf90_def_dim(ftn,"feature_id",numPtsOut,dimId(1))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create feature_id dimension')
-      iret = nf90_def_dim(ftn,"time",NF90_UNLIMITED,dimId(2))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create time dimension')
-      iret = nf90_def_dim(ftn,"reference_time",1,dimId(3))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create reference_time dimension')
+         ! Create dimensions
+         iret = nf90_def_dim(ftn,"feature_id",numPtsOut,dimId(1))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create feature_id dimension')
+         iret = nf90_def_dim(ftn,"time",NF90_UNLIMITED,dimId(2))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create time dimension')
+         iret = nf90_def_dim(ftn,"reference_time",1,dimId(3))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create reference_time dimension')
 
-      ! Create and populate reference_time and time variables.
-      iret = nf90_def_var(ftn,"time",nf90_int,dimId(2),timeId)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create time variable')
-      iret = nf90_put_att(ftn,timeId,'long_name',trim(fileMeta%timeLName))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place long_name attribute into time variable')
-      iret = nf90_put_att(ftn,timeId,'standard_name',trim(fileMeta%timeStName))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place standard_name attribute into time variable')
-      iret = nf90_put_att(ftn,timeId,'units',trim(fileMeta%timeUnits))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into time variable')
-      iret = nf90_put_att(ftn,timeId,'valid_min',fileMeta%timeValidMin)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_min attribute into time variable')
-      iret = nf90_put_att(ftn,timeId,'valid_max',fileMeta%timeValidMax)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_max attribute into time variable')
-      iret = nf90_def_var(ftn,"reference_time",nf90_int,dimId(3),refTimeId)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create reference_time variable')
-      iret = nf90_put_att(ftn,refTimeId,'long_name',trim(fileMeta%rTimeLName))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place long_name attribute into reference_time variable')
-      iret = nf90_put_att(ftn,refTimeId,'standard_name',trim(fileMeta%rTimeStName))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place standard_name attribute into reference_time variable')
-      iret = nf90_put_att(ftn,refTimeId,'units',trim(fileMeta%rTimeUnits))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into reference_time variable')
-
-      ! Create a crs variable.
-      ! NOTE - For now, we are hard-coding in for lat/lon points. However, this
-      ! may be more flexible in future iterations.
-      iret = nf90_def_var(ftn,'crs',nf90_char,varid=coordVarId)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create crs variable.')
-      iret = nf90_put_att(ftn,coordVarId,'transform_name','latitude longitude')
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place transform_name attribute into crs variable.')
-      iret = nf90_put_att(ftn,coordVarId,'grid_mapping_name','latitude longitude')
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place grid_mapping_name attribute into crs variable.')
-      iret = nf90_put_att(ftn,coordVarId,'esri_pe_string','GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",&
-                                          &SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",&
-                                          &0.0174532925199433]];-400 -400 1000000000;&
-                                          &-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision')
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place esri_pe_string into crs variable.')
-      iret = nf90_put_att(ftn,coordVarId,'spatial_ref','GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",&
-                                          &SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",&
-                                          &0.0174532925199433]];-400 -400 1000000000;&
-                                          &-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision')
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place spatial_ref into crs variable.')
-      iret = nf90_put_att(ftn,coordVarId,'long_name','CRS definition')
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place long_name into crs variable.')
-      iret = nf90_put_att(ftn,coordVarId,'longitude_of_prime_meridian',0.0)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place longitude_of_prime_meridian into crs variable.')
-      iret = nf90_put_att(ftn,coordVarId,'_CoordinateAxes','latitude longitude')
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place _CoordinateAxes into crs variable.')
-      iret = nf90_put_att(ftn,coordVarId,'semi_major_axis',6378137.0)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place semi_major_axis into crs variable.')
-      iret = nf90_put_att(ftn,coordVarId,'semi_minor_axis',6356752.31424518)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place semi_minor_axis into crs variable.')
-      iret = nf90_put_att(ftn,coordVarId,'inverse_flattening',298.257223563)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place inverse_flattening into crs variable.')
-
-      ! Create feature_id variable
-      iret = nf90_def_var(ftn,"feature_id",nf90_int,dimId(1),featureVarId)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create feature_id variable.')
-      ! Specify these attributes based on channel routing methods specified by
-      ! user.
-      if(nlst(domainId)%channel_option .eq. 3) then
-         iret = nf90_put_att(ftn,featureVarId,'long_name','User Specified Forecast Points')
-         call nwmCheck(diagFlag,iret,'ERROR: Uanble to place long_name attribute into feature_id variable')
-         iret = nf90_put_att(ftn,featureVarId,'comment','Forecast Points Specified in Fulldom file')
-         call nwmCheck(diagFlag,iret,'ERROR: Unable to place comment attribute into feature_id variable')
-      else
-         iret = nf90_put_att(ftn,featureVarId,'long_name',trim(fileMeta%featureIdLName))
-         call nwmCheck(diagFlag,iret,'ERROR: Uanble to place long_name attribute into feature_id variable')
-         iret = nf90_put_att(ftn,featureVarId,'comment',trim(fileMeta%featureIdComment))
-         call nwmCheck(diagFlag,iret,'ERROR: Unable to place comment attribute into feature_id variable')
-      endif
-      iret = nf90_put_att(ftn,featureVarId,'cf_role',trim(fileMeta%cfRole))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place cf_role attribute into feature_id variable')
-
-      ! Create channel lat/lon variables
-      iret = nf90_def_var(ftn,"latitude",nf90_float,dimId(1),latVarId)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create latitude variable.')
-      iret = nf90_put_att(ftn,latVarId,'long_name',trim(fileMeta%latLName))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place long_name attribute into latitude variable')
-      iret = nf90_put_att(ftn,latVarId,'standard_name',trim(fileMeta%latStName))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place stndard_name attribute into latitude variable')
-      iret = nf90_put_att(ftn,latVarId,'units',trim(fileMeta%latUnits))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into latitude variable')
-      iret = nf90_def_var(ftn,"longitude",nf90_float,dimId(1),lonVarId)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create longitude variable.')
-      iret = nf90_put_att(ftn,lonVarId,'long_name',trim(fileMeta%lonLName))
-      call nwmCheck(diagFlag,iret,'ERROR: Uanble to place long_name attribute into longitude variable')
-      iret = nf90_put_att(ftn,lonVarId,'standard_name',trim(fileMeta%lonStName))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place stndard_name attribute into longitude variable')
-      iret = nf90_put_att(ftn,lonVarId,'units',trim(fileMeta%lonUnits))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into longitude variable')
-
-      ! Create channel order variable
-      iret = nf90_def_var(ftn,"order",nf90_int,dimId(1),orderVarId)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create order variable.')
-      iret = nf90_put_att(ftn,orderVarId,'long_name',trim(fileMeta%orderLName))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place long_name attribute into order variable')
-      iret = nf90_put_att(ftn,orderVarId,'standard_name',trim(fileMeta%orderStName))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place stndard_name attribute into order variable')
-
-      ! Create channel elevation variable
-      iret = nf90_def_var(ftn,"elevation",nf90_float,dimId(1),elevVarId)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to create elevation variable.')
-      iret = nf90_put_att(ftn,elevVarId,'long_name',trim(fileMeta%elevLName))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place long_name attribute into elevation variable')
-      iret = nf90_put_att(ftn,elevVarId,'standard_name',trim(fileMeta%elevStName))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place stndard_name attribute into elevation variable')
-
-
-      ! Define deflation levels for these meta-variables. For now, we are going
-      ! to
-      ! default to a compression level of 2. Only compress if io_form_outputs is set to 1.
-      if((nlst(1)%io_form_outputs .eq. 1) .or. (nlst(1)%io_form_outputs .eq. 3)) then
-         iret = nf90_def_var_deflate(ftn,timeId,0,1,2)
-         call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for time.')
-         iret = nf90_def_var_deflate(ftn,featureVarId,0,1,2)
-         call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for feature_id.')
-         iret = nf90_def_var_deflate(ftn,refTimeId,0,1,2)
-         call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for reference_time.')
-         iret = nf90_def_var_deflate(ftn,latVarId,0,1,2)
-         call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for latitude.')
-         iret = nf90_def_var_deflate(ftn,lonVarId,0,1,2)
-         call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for longitude.')
-         iret = nf90_def_var_deflate(ftn,orderVarId,0,1,2)
-         call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for order.')
-         iret = nf90_def_var_deflate(ftn,elevVarId,0,1,2)
-         call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for elevation.')
-      endif
-      ! Allocate memory for the output variables, then place the real output
-      ! variables into a single array. This array will be accessed throughout
-      ! the
-      ! output looping below for conversion to compressed integer values.
-      ! Loop through and create each output variable, create variable
-      ! attributes,
-      ! and insert data.
-      do iTmp=1,fileMeta%numVars
-         if(fileMeta%outFlag(iTmp) .eq. 1) then
-            ! First create variable
-            if((nlst(1)%io_form_outputs .eq. 1) .or. (nlst(1)%io_form_outputs .eq. 2)) then
-               iret = nf90_def_var(ftn,trim(fileMeta%varNames(iTmp)),nf90_int,dimId(1),varId)
-            else
-               iret = nf90_def_var(ftn,trim(fileMeta%varNames(iTmp)),nf90_float,dimId(1),varId)
-            endif
-            call nwmCheck(diagFlag,iret,'ERROR: Unable to create variable:'//trim(fileMeta%varNames(iTmp)))
-
-            ! Extract valid range into a 1D array for placement.
-            varRange(1) = fileMeta%validMinComp(iTmp)
-            varRange(2) = fileMeta%validMaxComp(iTmp)
-            varRangeReal(1) = real(fileMeta%validMinDbl(iTmp))
-            varRangeReal(2) = real(fileMeta%validMaxDbl(iTmp))
-
-            ! Establish a compression level for the variables. For now we are
-            ! using a
-            ! compression level of 2. In addition, we are choosing to turn the
-            ! shuffle
-            ! filter off for now. Kelley Eicher did some testing with this and
-            ! determined that the benefit wasn't worth the extra time spent
-            ! writing
-            ! output. Only compress if io_form_outputs is set to 1.
-            if((nlst(1)%io_form_outputs .eq. 1) .or. (nlst(1)%io_form_outputs .eq. 3)) then
-               iret = nf90_def_var_deflate(ftn,varId,0,1,2)
-               call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression for: '//trim(fileMeta%varNames(iTmp)))
-            endif
-
-            ! Create variable attributes
-            iret = nf90_put_att(ftn,varId,'long_name',trim(fileMeta%longName(iTmp)))
-            call nwmCheck(diagFlag,iret,'ERROR: Unable to place long_name attribute into variable '//trim(fileMeta%varNames(iTmp)))
-            iret = nf90_put_att(ftn,varId,'units',trim(fileMeta%units(iTmp)))
-            call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into variable '//trim(fileMeta%varNames(iTmp)))
-            iret = nf90_put_att(ftn,varId,'coordinates',trim(fileMeta%coordNames(iTmp)))
-            call nwmCheck(diagFlag,iret,'ERROR: Unable to place coordinates attribute into variable '//trim(fileMeta%varNames(iTmp)))
-            iret = nf90_put_att(ftn,varId,'grid_mapping','crs')
-            call nwmCheck(diagFlag,iret,'ERROR: Unable to place grid_mapping attribute into variable '//trim(fileMeta%varNames(iTmp)))
-            if((nlst(1)%io_form_outputs .eq. 1) .or. (nlst(1)%io_form_outputs .eq. 2)) then
-               iret = nf90_put_att(ftn,varId,'_FillValue',fileMeta%fillComp(iTmp))
-               call nwmCheck(diagFlag,iret,'ERROR: Unable to place Fill value attribute into variable '//trim(fileMeta%varNames(iTmp)))
-               iret = nf90_put_att(ftn,varId,'missing_value',fileMeta%missingComp(iTmp))
-               call nwmCheck(diagFlag,iret,'ERROR: Unable to place missing value attribute into variable '//trim(fileMeta%varNames(iTmp)))
-               iret = nf90_put_att(ftn,varId,'scale_factor',fileMeta%scaleFactor(iTmp))
-               call nwmCheck(diagFlag,iret,'ERROR: Unable to place scale_factor attribute into variable '//trim(fileMeta%varNames(iTmp)))
-               iret = nf90_put_att(ftn,varId,'add_offset',fileMeta%addOffset(iTmp))
-               call nwmCheck(diagFlag,iret,'ERROR: Unable to place add_offset attribute into variable '//trim(fileMeta%varNames(iTmp)))
-               iret = nf90_put_att(ftn,varId,'valid_range',varRange)
-               call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_range attribute into variable '//trim(fileMeta%varNames(iTmp)))
-            else
-               iret = nf90_put_att(ftn,varId,'_FillValue',fileMeta%fillReal(iTmp))
-               call nwmCheck(diagFlag,iret,'ERROR: Unable to place Fill value attribute into variable '//trim(fileMeta%varNames(iTmp)))
-               iret = nf90_put_att(ftn,varId,'missing_value',fileMeta%missingReal(iTmp))
-               call nwmCheck(diagFlag,iret,'ERROR: Unable to place missing value attribute into variable '//trim(fileMeta%varNames(iTmp)))
-               iret = nf90_put_att(ftn,varId,'valid_range',varRangeReal)
-               call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_range attribute into variable '//trim(fileMeta%varNames(iTmp)))
-            endif
+         ! Create and populate reference_time and time variables.
+         iret = nf90_def_var(ftn,"time",nf90_int,dimId(2),timeId)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create time variable')
+         iret = nf90_put_att(ftn,timeId,'long_name',trim(fileMeta%timeLName))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place long_name attribute into time variable')
+         iret = nf90_put_att(ftn,timeId,'standard_name',trim(fileMeta%timeStName))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place standard_name attribute into time variable')
+         iret = nf90_put_att(ftn,timeId,'units',trim(fileMeta%timeUnits))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into time variable')
+         if(.not. single_output_file) then
+            iret = nf90_put_att(ftn,timeId,'valid_min',fileMeta%timeValidMin)
+            call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_min attribute into time variable')
+            iret = nf90_put_att(ftn,timeId,'valid_max',fileMeta%timeValidMax)
+            call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_max attribute into time variable')
          endif
-      end do
 
-      ! Remove NetCDF file from definition mode.
-      iret = nf90_enddef(ftn)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to take CHRTOUT file out of definition mode')
+         iret = nf90_def_var(ftn,"reference_time",nf90_int,dimId(3),refTimeId)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create reference_time variable')
+         iret = nf90_put_att(ftn,refTimeId,'long_name',trim(fileMeta%rTimeLName))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place long_name attribute into reference_time variable')
+         iret = nf90_put_att(ftn,refTimeId,'standard_name',trim(fileMeta%rTimeStName))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place standard_name attribute into reference_time variable')
+         iret = nf90_put_att(ftn,refTimeId,'units',trim(fileMeta%rTimeUnits))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into reference_time variable')
 
-      ! Loop through all possible output variables, and convert floating
-      ! points
+         ! Create a crs variable.
+         ! NOTE - For now, we are hard-coding in for lat/lon points. However, this
+         ! may be more flexible in future iterations.
+         iret = nf90_def_var(ftn,'crs',nf90_char,varid=coordVarId)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create crs variable.')
+         iret = nf90_put_att(ftn,coordVarId,'transform_name','latitude longitude')
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place transform_name attribute into crs variable.')
+         iret = nf90_put_att(ftn,coordVarId,'grid_mapping_name','latitude longitude')
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place grid_mapping_name attribute into crs variable.')
+         iret = nf90_put_att(ftn,coordVarId,'esri_pe_string','GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",&
+              &SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",&
+              &0.0174532925199433]];-400 -400 1000000000;&
+              &-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision')
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place esri_pe_string into crs variable.')
+         iret = nf90_put_att(ftn,coordVarId,'spatial_ref','GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",&
+              &SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",&
+              &0.0174532925199433]];-400 -400 1000000000;&
+              &-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision')
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place spatial_ref into crs variable.')
+         iret = nf90_put_att(ftn,coordVarId,'long_name','CRS definition')
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place long_name into crs variable.')
+         iret = nf90_put_att(ftn,coordVarId,'longitude_of_prime_meridian',0.0)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place longitude_of_prime_meridian into crs variable.')
+         iret = nf90_put_att(ftn,coordVarId,'_CoordinateAxes','latitude longitude')
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place _CoordinateAxes into crs variable.')
+         iret = nf90_put_att(ftn,coordVarId,'semi_major_axis',6378137.0)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place semi_major_axis into crs variable.')
+         iret = nf90_put_att(ftn,coordVarId,'semi_minor_axis',6356752.31424518)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place semi_minor_axis into crs variable.')
+         iret = nf90_put_att(ftn,coordVarId,'inverse_flattening',298.257223563)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place inverse_flattening into crs variable.')
+
+         ! Create feature_id variable
+         iret = nf90_def_var(ftn,"feature_id",nf90_int,dimId(1),featureVarId)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create feature_id variable.')
+         ! Specify these attributes based on channel routing methods specified by
+         ! user.
+         if(nlst(domainId)%channel_option .eq. 3) then
+            iret = nf90_put_att(ftn,featureVarId,'long_name','User Specified Forecast Points')
+            call nwmCheck(diagFlag,iret,'ERROR: Uanble to place long_name attribute into feature_id variable')
+            iret = nf90_put_att(ftn,featureVarId,'comment','Forecast Points Specified in Fulldom file')
+            call nwmCheck(diagFlag,iret,'ERROR: Unable to place comment attribute into feature_id variable')
+         else
+            iret = nf90_put_att(ftn,featureVarId,'long_name',trim(fileMeta%featureIdLName))
+            call nwmCheck(diagFlag,iret,'ERROR: Uanble to place long_name attribute into feature_id variable')
+            iret = nf90_put_att(ftn,featureVarId,'comment',trim(fileMeta%featureIdComment))
+            call nwmCheck(diagFlag,iret,'ERROR: Unable to place comment attribute into feature_id variable')
+         endif
+         iret = nf90_put_att(ftn,featureVarId,'cf_role',trim(fileMeta%cfRole))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place cf_role attribute into feature_id variable')
+
+         ! Create channel lat/lon variables
+         iret = nf90_def_var(ftn,"latitude",nf90_float,dimId(1),latVarId)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create latitude variable.')
+         iret = nf90_put_att(ftn,latVarId,'long_name',trim(fileMeta%latLName))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place long_name attribute into latitude variable')
+         iret = nf90_put_att(ftn,latVarId,'standard_name',trim(fileMeta%latStName))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place stndard_name attribute into latitude variable')
+         iret = nf90_put_att(ftn,latVarId,'units',trim(fileMeta%latUnits))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into latitude variable')
+         iret = nf90_def_var(ftn,"longitude",nf90_float,dimId(1),lonVarId)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create longitude variable.')
+         iret = nf90_put_att(ftn,lonVarId,'long_name',trim(fileMeta%lonLName))
+         call nwmCheck(diagFlag,iret,'ERROR: Uanble to place long_name attribute into longitude variable')
+         iret = nf90_put_att(ftn,lonVarId,'standard_name',trim(fileMeta%lonStName))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place stndard_name attribute into longitude variable')
+         iret = nf90_put_att(ftn,lonVarId,'units',trim(fileMeta%lonUnits))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into longitude variable')
+
+         ! Create channel order variable
+         iret = nf90_def_var(ftn,"order",nf90_int,dimId(1),orderVarId)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create order variable.')
+         iret = nf90_put_att(ftn,orderVarId,'long_name',trim(fileMeta%orderLName))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place long_name attribute into order variable')
+         iret = nf90_put_att(ftn,orderVarId,'standard_name',trim(fileMeta%orderStName))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place stndard_name attribute into order variable')
+
+         ! Create channel elevation variable
+         iret = nf90_def_var(ftn,"elevation",nf90_float,dimId(1),elevVarId)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create elevation variable.')
+         iret = nf90_put_att(ftn,elevVarId,'long_name',trim(fileMeta%elevLName))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place long_name attribute into elevation variable')
+         iret = nf90_put_att(ftn,elevVarId,'standard_name',trim(fileMeta%elevStName))
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place stndard_name attribute into elevation variable')
+
+         ! Define deflation levels for these meta-variables. For now, we are going
+         ! to default to a compression level of 2. Only compress if io_form_outputs is set to 1.
+         if((nlst(1)%io_form_outputs .eq. 1) .or. (nlst(1)%io_form_outputs .eq. 3)) then
+            iret = nf90_def_var_deflate(ftn,timeId,0,1,2)
+            call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for time.')
+            iret = nf90_def_var_deflate(ftn,featureVarId,0,1,2)
+            call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for feature_id.')
+            iret = nf90_def_var_deflate(ftn,refTimeId,0,1,2)
+            call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for reference_time.')
+            iret = nf90_def_var_deflate(ftn,latVarId,0,1,2)
+            call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for latitude.')
+            iret = nf90_def_var_deflate(ftn,lonVarId,0,1,2)
+            call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for longitude.')
+            iret = nf90_def_var_deflate(ftn,orderVarId,0,1,2)
+            call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for order.')
+            iret = nf90_def_var_deflate(ftn,elevVarId,0,1,2)
+            call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression level for elevation.')
+         endif
+
+         ! Allocate memory for the output variables, then place the real output
+         ! variables into a single array. This array will be accessed throughout
+         ! the output looping below for conversion to compressed integer values.
+         ! Loop through and create each output variable, create variable
+         ! attributes, and insert data.
+         do iTmp=1,fileMeta%numVars
+            if(fileMeta%outFlag(iTmp) .eq. 1) then
+               if((nlst(1)%io_form_outputs .eq. 1) .or. (nlst(1)%io_form_outputs .eq. 2)) then
+                  iret = nf90_def_var( &
+                       ftn, trim(fileMeta%varNames(iTmp)), nf90_int, &
+                       (/ dimId(1), dimId(2) /), varId)
+               else
+                  iret = nf90_def_var( &
+                       ftn, trim(fileMeta%varNames(iTmp)), nf90_float, &
+                       (/ dimId(1), dimId(2) /), varId)
+               endif
+               call nwmCheck(diagFlag,iret,'ERROR: Unable to create variable:'//trim(fileMeta%varNames(iTmp)))
+
+               ! Extract valid range into a 1D array for placement.
+               varRange(1) = fileMeta%validMinComp(iTmp)
+               varRange(2) = fileMeta%validMaxComp(iTmp)
+               varRangeReal(1) = real(fileMeta%validMinDbl(iTmp))
+               varRangeReal(2) = real(fileMeta%validMaxDbl(iTmp))
+
+               ! Establish a compression level for the variables. For now we are
+               ! using a compression level of 2. In addition, we are choosing to turn the
+               ! shuffle filter off for now. Kelley Eicher did some testing with this and
+               ! determined that the benefit wasn't worth the extra time spent
+               ! writing output. Only compress if io_form_outputs is set to 1.
+               if((nlst(1)%io_form_outputs .eq. 1) .or. (nlst(1)%io_form_outputs .eq. 3)) then
+                  iret = nf90_def_var_deflate(ftn,varId,0,1,2)
+                  call nwmCheck(diagFlag,iret,'ERROR: Unable to define compression for: '//trim(fileMeta%varNames(iTmp)))
+               endif
+
+               ! Create variable attributes
+               iret = nf90_put_att(ftn,varId,'long_name',trim(fileMeta%longName(iTmp)))
+               call nwmCheck(diagFlag,iret,'ERROR: Unable to place long_name attribute into variable '//trim(fileMeta%varNames(iTmp)))
+               iret = nf90_put_att(ftn,varId,'units',trim(fileMeta%units(iTmp)))
+               call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into variable '//trim(fileMeta%varNames(iTmp)))
+               iret = nf90_put_att(ftn,varId,'coordinates',trim(fileMeta%coordNames(iTmp)))
+               call nwmCheck(diagFlag,iret,'ERROR: Unable to place coordinates attribute into variable '//trim(fileMeta%varNames(iTmp)))
+               iret = nf90_put_att(ftn,varId,'grid_mapping','crs')
+               call nwmCheck(diagFlag,iret,'ERROR: Unable to place grid_mapping attribute into variable '//trim(fileMeta%varNames(iTmp)))
+               if((nlst(1)%io_form_outputs .eq. 1) .or. (nlst(1)%io_form_outputs .eq. 2)) then
+                  iret = nf90_put_att(ftn,varId,'_FillValue',fileMeta%fillComp(iTmp))
+                  call nwmCheck(diagFlag,iret,'ERROR: Unable to place Fill value attribute into variable '//trim(fileMeta%varNames(iTmp)))
+                  iret = nf90_put_att(ftn,varId,'missing_value',fileMeta%missingComp(iTmp))
+                  call nwmCheck(diagFlag,iret,'ERROR: Unable to place missing value attribute into variable '//trim(fileMeta%varNames(iTmp)))
+                  iret = nf90_put_att(ftn,varId,'scale_factor',fileMeta%scaleFactor(iTmp))
+                  call nwmCheck(diagFlag,iret,'ERROR: Unable to place scale_factor attribute into variable '//trim(fileMeta%varNames(iTmp)))
+                  iret = nf90_put_att(ftn,varId,'add_offset',fileMeta%addOffset(iTmp))
+                  call nwmCheck(diagFlag,iret,'ERROR: Unable to place add_offset attribute into variable '//trim(fileMeta%varNames(iTmp)))
+                  iret = nf90_put_att(ftn,varId,'valid_range',varRange)
+                  call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_range attribute into variable '//trim(fileMeta%varNames(iTmp)))
+               else
+                  iret = nf90_put_att(ftn,varId,'_FillValue',fileMeta%fillReal(iTmp))
+                  call nwmCheck(diagFlag,iret,'ERROR: Unable to place Fill value attribute into variable '//trim(fileMeta%varNames(iTmp)))
+                  iret = nf90_put_att(ftn,varId,'missing_value',fileMeta%missingReal(iTmp))
+                  call nwmCheck(diagFlag,iret,'ERROR: Unable to place missing value attribute into variable '//trim(fileMeta%varNames(iTmp)))
+                  iret = nf90_put_att(ftn,varId,'valid_range',varRangeReal)
+                  call nwmCheck(diagFlag,iret,'ERROR: Unable to place valid_range attribute into variable '//trim(fileMeta%varNames(iTmp)))
+               endif
+            endif
+         end do
+
+         ! Remove NetCDF file from definition mode.
+         iret = nf90_enddef(ftn)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to take CHANOBS file out of definition mode')
+
+      else
+
+         iret = nf90_open(trim(output_flnm), nf90_write, ftn)
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to open CHANOBS_DOMAIN.nc file.')
+
+      endif ! if((.not. single_output_file) .or. (.not. single_output_file_exists)) then
+
+      ! Time: length and write
+      iret =  nf90_inq_dimid(ftn, 'time', tmpDimId)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to locate time dimension.')
+      iret = nf90_inquire_dimension(ftn, tmpDimId, len=n_times)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to to get length of time dimension.')
+
+      iret = nf90_inq_varid(ftn, 'time', varId)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to locate time variable')
+      iret = nf90_put_var(ftn, varId, minSinceEpochVect, start=(/n_times+1/), count = (/1/))
+      call nwmCheck(diagFlag,iret,'ERROR: Failure to place data into time variable')
+
+      ! Feature_id: just length
+      iret =  nf90_inq_dimid(ftn, 'feature_id', tmpDimId)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to locate time dimension.')
+      iret = nf90_inquire_dimension(ftn, tmpDimId, len=n_feature_ids)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to to get length of time dimension.')
+
+      ! Loop through all possible output variables, and convert floating points
       ! to integers via prescribed scale_factor/add_offset, then write to the
       ! NetCDF variable.
       do iTmp=1,fileMeta%numVars
@@ -4974,9 +5013,14 @@ subroutine output_chanObs_NWM(domainId)
 
             ! Put data into NetCDF file
             if((nlst(1)%io_form_outputs .eq. 1) .or. (nlst(1)%io_form_outputs .eq. 2)) then
-               iret = nf90_put_var(ftn,varId,varOutInt)
+               iret = nf90_put_var(ftn, varId, &
+                    reshape(varOutInt, (/n_feature_ids, 1/)), &
+                    start=(/1, n_times+1/), count=(/n_feature_ids, 1/))
             else
-               iret = nf90_put_var(ftn,varId,varOutReal(iTmp,:))
+               iret = nf90_put_var( &
+                    ftn, varId, &
+                    reshape(varOutReal(iTmp,:), (/n_feature_ids, 1/)), &
+                    start=(/1, n_times+1/), count=(/n_feature_ids, 1/))
             endif
             call nwmCheck(diagFlag,iret,'ERROR: Unable to place data into output variable: '//trim(fileMeta%varNames(iTmp)))
          endif
@@ -5015,11 +5059,7 @@ subroutine output_chanObs_NWM(domainId)
       iret = nf90_put_var(ftn,varId,g_zelevOut)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place data into elevation output variable.')
 
-      ! Place time values into time variables.
-      iret = nf90_inq_varid(ftn,'time',varId)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to locate time variable')
-      iret = nf90_put_var(ftn,varId,minSinceEpoch)
-      call nwmCheck(diagFlag,iret,'ERROR: Failure to place data into time variable')
+      ! Place reference time value
       iret = nf90_inq_varid(ftn,'reference_time',varId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to locate reference_time variable')
       iret = nf90_put_var(ftn,varId,minSinceEpoch1)
@@ -5031,7 +5071,9 @@ subroutine output_chanObs_NWM(domainId)
 
       deallocate(varOutReal)
       deallocate(varOutInt)
+
    else
+
       allocate(g_STRMFRXSTPTSOut(1))
       allocate(g_chlonOut(1))
       allocate(g_chlatOut(1))
@@ -5040,6 +5082,7 @@ subroutine output_chanObs_NWM(domainId)
       allocate(g_linkidOut(1))
       allocate(g_zelevOut(1))
       allocate(g_orderOut(1))
+
    endif
 
    ! Deallocate memory
@@ -5060,7 +5103,6 @@ subroutine output_chanObs_NWM(domainId)
    deallocate(g_linkid)
    deallocate(g_zelev)
    deallocate(g_order)
-
 
 end subroutine output_chanObs_NWM
 


### PR DESCRIPTION

TYPE: enhancement

KEYWORDS: output, chanobs

SOURCE: j foo, n-kizzidy-car, yo

DESCRIPTION OF CHANGES: tweaks to NWM_IO output of chanobs to concatenate all time into a single file when the `split_output_count` option is set to zero. I tested a fairly limited impact of using this namelist option. 

ISSUE: I can create one. But this might raise more issues than it solves, at least for now.

TESTS CONDUCTED: 
I'm submitting this because I'm too lazy to test locally right now. But I did run the following (on cheyenne) which was satisfactory: 

```
import datetime
import deepdiff
import os
import pathlib
import pickle
import shlex
import shutil
import subprocess
import time
import wrfhydropy
import xarray as xr

config = 'nwm_ana'
domain_path = pathlib.Path('/glade/work/jamesmcc/domains/public/croton_NY')
repo_path = '/glade/u/home/jamesmcc/WRF_Hydro/wrf_hydro_nwm_public/trunk/NDHMS'
exp_path = pathlib.Path('/glade/scratch/jamesmcc/tmp_croton_reduce_output')
if not exp_path.exists():
    os.mkdir(exp_path)


run_dict = {
    'master': {'branch': 'master', 'split_output': 1},
    'single_1': {'branch': 'reduce_output', 'split_output': 1},
    'single_0': {'branch': 'reduce_output', 'split_output': 0} }

    
def run_branch_split_output(branch, split_output):

    ret = subprocess.run(shlex.split('git checkout ' + branch), cwd=repo_path)
    if ret.returncode != 0:
        raise ValueError('branch checkout failed')
    
    comp_path = exp_path / ('compile_' + branch)

    # for a fresh compile, remove comp_path from disk.
    if not comp_path.exists():
        model = wrfhydropy.Model(
            repo_path,
            model_config=config,
            compiler='ifort'
        )
        model.compile(comp_path)
    else:
        model = pickle.load((comp_path / 'WrfHydroModel.pkl').open('rb'))

    model.hydro_namelists['hydro_nlist']['split_output_count'] = split_output

    domain = wrfhydropy.Domain(
        domain_top_dir=domain_path,
        domain_config=config
    )

    model_start_time = datetime.datetime(2011, 8, 26)
    model_end_time = model_start_time + datetime.timedelta(hours=24)

    job = wrfhydropy.Job(
        exe_cmd='mpirun -np 2 ./wrf_hydro.exe',
        job_id='reduce_output',
        restart=True,
        model_start_time= model_start_time,
        model_end_time=model_end_time
    )

    sim = wrfhydropy.Simulation()
    sim.add(model)
    sim.add(domain)
    sim.add(job)

    sim_dir = exp_path / ('simulation_' + branch + '_' + str(split_output))
    if sim_dir.exists():
        shutil.rmtree(str(sim_dir))
    os.mkdir(sim_dir)
    os.chdir(sim_dir)
    sim.compose()
    sim.run()


for key, this_run_dict in run_dict.items():
    run_branch_split_output(**this_run_dict)

master_files = sorted(exp_path.glob("simulation_master_1/*CHANOBS*"))
master_ds = xr.open_mfdataset(master_files)

reduce_1_files = sorted(exp_path.glob("simulation_reduce_output_1/*CHANOBS*"))
reduce_1_ds = xr.open_mfdataset(reduce_1_files)

reduce_0_ds = xr.open_dataset(exp_path.joinpath(
    "simulation_reduce_output_0/CHANOBS_DOMAIN1.nc"))

assert (master_ds.streamflow.values == reduce_1_ds.streamflow.values).all()
assert (master_ds.streamflow.values == reduce_0_ds.streamflow.values).all()

```

NOTES: There are probably a variety of things to think about before merging this. This is very preliminary.

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [ ] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
 - [ ] Short description in the Development section of `NEWS.md`
