### PR TITLE
bug fix - domain decomposition

### DIFF
--- a/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
+++ b/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
@@ -1369,9 +1369,6 @@ integer:: ix0,jx0
 integer, dimension(ix0,jx0),optional :: vegtyp, soltyp
 integer            :: iret, ncid, ascIndId
 
-#ifdef MPP_LAND
-call  MPP_LAND_INIT()
-#endif
 
 
 ! read the namelist

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -411,8 +411,10 @@ module module_NoahMP_hrldas_driver
 
     ! initilization for stand alone parallel code.
     integer, optional, intent(in) :: wrfits,wrfite,wrfjts,wrfjte
+
 #ifdef MPP_LAND
-    call  MPP_LAND_INIT()
+    call read_dim(noah_lsm%hrldas_setup_file,ix_tmp,jx_tmp)
+    call MPP_LAND_INIT(ix_tmp,jx_tmp)
 #endif
 
 #ifdef WRF_HYDRO

--- a/trunk/NDHMS/MPP/mpp_land.F
+++ b/trunk/NDHMS/MPP/mpp_land.F
@@ -140,13 +140,17 @@ MODULE MODULE_MPP_LAND
 
 
   !old subroutine MPP_LAND_INIT(flag, ew_numprocs, sn_numprocs)
-  subroutine MPP_LAND_INIT()
-!    ### initialize the land model logically based on the two D method.
+  subroutine MPP_LAND_INIT(in_global_nx,in_global_ny)
+!    ### initialize the land model logically based on the two D method. 
 !    ### Call this function directly if it is nested with WRF.
     implicit none
+    integer in_global_nx, in_global_ny
     integer :: ierr, provided
     integer :: ew_numprocs, sn_numprocs  ! input the processors in x and y direction.
     logical mpi_inited
+
+    global_nx = in_global_nx
+    global_ny = in_global_ny 
 
     ! left_right_np = ew_numprocs
     ! up_down_np  = sn_numprocs
@@ -1357,18 +1361,28 @@ MODULE MODULE_MPP_LAND
       return
   end subroutine decompose_RT_int
 
-  subroutine getNX_NY(nprocs, nx,ny)
+  subroutine getNX_NY(nprocs,nx,ny)
   ! calculate the nx and ny based on the total nprocs.
-    integer nprocs, nx, ny
-    integer i,j, max
+    integer nprocs, nx, ny, n
+    integer i, j, max
+
+    n = global_nx * global_ny
+    if( nprocs .ge. n ) then
+       call fatal_error_stop("Error: number of processes greater than number of cells in the land grid")
+    end if
+
     max = nprocs
     do j = 1, nprocs
        if( mod(nprocs,j) .eq. 0 ) then
            i = nprocs/j
-           if( abs(i-j) .lt. max) then
-               max = abs(i-j)
-               nx = i
-               ny = j
+           if( i .le. global_nx ) then
+               if( abs(i-j) .lt. max) then
+                   if( j .le. global_ny ) then
+                       max = abs(i-j)
+                       nx = i
+                       ny = j
+                   end if
+               end if
            end if
        end if
     end do


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: MPI, domain decomposition

SOURCE: Katelyn, NCAR

DESCRIPTION OF CHANGES: 
Determination of nx and ny for MPI processes should be informed by grid dimensions.  This was not the case previously and is problematic for very small and/or vectorized domains.  

The grid dimensions of the land surface model were added to MPP_LAND_INIT() as arguments, additional logic added to the grid decomposition, and call(s) adjusted accordingly.

Open to other ideas for how to address this.  I'm not super familiar w/ these parts of the code and we just needed something to get this working for a project.

ISSUE: Fixes #444

TESTS CONDUCTED: Test runs on a 1D test domain.  

NOTES: 
* Only implemented for NoahMP (Noah implementation would require moving more things around in the initialization and we should probably implement the orchestrator at the same time).  
* Should be checked to make sure it doesn't interfere w/ coupled parallelization.
* May want to add additional error checking.