### PR TITLE
Bug fix: update water class value in output subroutine (v5.1.x)

### DIFF
--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -1,11 +1,7 @@
 ! Module for handling National Water Model streamflow, land surface,
 ! gridded routing, lake, and groundwater output.
 
-! Logan Karsten
-! National Center for Atmospheric Research
-! Research Applications Laboratory
-! karsten@ucar.edu
-! 303-497-2693
+! Logan Karsten, NCAR, RAL
 
 module module_NWM_io
 
@@ -1116,7 +1112,7 @@ subroutine output_NoahMP_NWM(outDir,iGrid,output_timestep,itime,startdate,date,i
 
    ! Initialize water type to 16.
    ! NOTE THIS MAY CHANGE IN THE FUTURE!!!!!
-   waterVal = 16
+   waterVal = rt_domain(1)%iswater
 
    ! Initialize NWM dictionary derived type containing all the necessary
    ! metadata for the output file.


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: IO, water, land cover / use classes

SOURCE: Katelyn, NCAR

DESCRIPTION OF CHANGES: Set water class value for output masking to appropriate water class instead of hard coding.

Same as PR#456, but applied to v5.1.x

ISSUE: Addresses issue #455 

TESTS CONDUCTED: Tested w/ coupled domain in Docker