### PR TITLE
Fix crashes with newer versions of netCDF (v5.1.x backport)

### DIFF
--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -53,14 +53,14 @@ type chrtMeta
    character (len=64), dimension(numChVars) :: longName  ! Long names for each variable.
    character (len=64), dimension(numChVars) :: units ! Units for each variable.
    character (len=64), dimension(numChVars) :: coordNames ! Coordinate names for each variable. 
-   integer*8, dimension(numChVars) :: validMinComp ! Valid min (after conversion to integer)
-   integer*8, dimension(numChVars) :: validMaxComp ! Valid max (after conversion to integer)
+   integer(kind=4), dimension(numChVars) :: validMinComp ! Valid min (after conversion to integer)
+   integer(kind=4), dimension(numChVars) :: validMaxComp ! Valid max (after conversion to integer)
    real*8, dimension(numChVars) :: validMinDbl ! Valid minimum (before conversion to integer)
    real*8, dimension(numChVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
-   integer*8, dimension(numChVars) :: missingComp ! Missing value attribute (after conversion to integer)
+   integer(kind=4), dimension(numChVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numChVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numChVars) :: fillReal ! Fill value (before conversion to integer)
-   integer*8, dimension(numChVars) :: fillComp ! Fill value (after conversion to integer)
+   integer(kind=4), dimension(numChVars) :: fillComp ! Fill value (after conversion to integer)
    integer, dimension(numChVars) :: outFlag ! 0/1 flag to turn outputting off/on 
    integer, dimension(numChVars) :: timeZeroFlag ! 0/1 flag to either set variable to all NDV values or output 
                                                  ! the actual data. This was done because time 0 
@@ -129,14 +129,14 @@ type ldasMeta
    character (len=128), dimension(numLdasVars) :: longName  ! Long names for each variable.
    character (len=64), dimension(numLdasVars) :: units ! Units for each variable.
    integer, dimension(numLdasVars) :: numLev ! Number of levels for each variable.
-   integer*8, dimension(numLdasVars) :: validMinComp ! Valid min (after conversion to integer)
-   integer*8, dimension(numLdasVars) :: validMaxComp ! Valid max (after conversion to integer)
+   integer(kind=4), dimension(numLdasVars) :: validMinComp ! Valid min (after conversion to integer)
+   integer(kind=4), dimension(numLdasVars) :: validMaxComp ! Valid max (after conversion to integer)
    real*8, dimension(numLdasVars) :: validMinDbl ! Valid minimum (before conversion to integer)
    real*8, dimension(numLdasVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
-   integer*8, dimension(numLdasVars) :: missingComp ! Missing value attribute (after conversion to integer)
+   integer(kind=4), dimension(numLdasVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numLdasVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numLdasVars) :: fillReal ! Fill value (before conversion to integer)
-   integer*8, dimension(numLdasVars) :: fillComp ! Fill value (after conversion to integer)
+   integer(kind=4), dimension(numLdasVars) :: fillComp ! Fill value (after conversion to integer)
    integer, dimension(numLdasVars) :: outFlag ! 0/1 flag to turn outputting off/on 
    integer, dimension(numLdasVars) :: timeZeroFlag ! 0/1 flag to either set variable to all NDV values or output 
                                                    ! the actual data. This was done because time 0 
@@ -202,14 +202,14 @@ type rtDomainMeta
    character (len=64), dimension(numRtDomainVars) :: longName  ! Long names for each variable.
    character (len=64), dimension(numRtDomainVars) :: units ! Units for each variable.
    character (len=64), dimension(numRtDomainVars) :: coordNames ! Coordinate names for each variable. 
-   integer*8, dimension(numRtDomainVars) :: validMinComp ! Valid min (after conversion to integer)
-   integer*8, dimension(numRtDomainVars) :: validMaxComp ! Valid max (after conversion to integer)
+   integer(kind=4), dimension(numRtDomainVars) :: validMinComp ! Valid min (after conversion to integer)
+   integer(kind=4), dimension(numRtDomainVars) :: validMaxComp ! Valid max (after conversion to integer)
    real*8, dimension(numRtDomainVars) :: validMinDbl ! Valid minimum (before conversion to integer)
    real*8, dimension(numRtDomainVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
-   integer*8, dimension(numRtDomainVars) :: missingComp ! Missing value attribute (after conversion to integer)
+   integer(kind=4), dimension(numRtDomainVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numRtDomainVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numRtDomainVars) :: fillReal ! Fill value (before conversion to integer)
-   integer*8, dimension(numRtDomainVars) :: fillComp ! Fill value (after conversion to integer)
+   integer(kind=4), dimension(numRtDomainVars) :: fillComp ! Fill value (after conversion to integer)
    integer, dimension(numRtDomainVars) :: outFlag ! 0/1 flag to turn outputting off/on 
    integer, dimension(numRtDomainVars) :: timeZeroFlag ! 0/1 flag to either set variable to all NDV values or output 
                                                        ! the actual data. This was done because time 0 
@@ -272,14 +272,14 @@ type lakeMeta
    character (len=64), dimension(numLakeVars) :: longName  ! Long names for each variable.
    character (len=64), dimension(numLakeVars) :: units ! Units for each variable.
    character (len=64), dimension(numLakeVars) :: coordNames ! Coordinate names for each variable. 
-   integer*8, dimension(numLakeVars) :: validMinComp ! Valid min (after conversion to integer)
-   integer*8, dimension(numLakeVars) :: validMaxComp ! Valid max (after conversion to integer)
+   integer(kind=4), dimension(numLakeVars) :: validMinComp ! Valid min (after conversion to integer)
+   integer(kind=4), dimension(numLakeVars) :: validMaxComp ! Valid max (after conversion to integer)
    real*8, dimension(numLakeVars) :: validMinDbl ! Valid minimum (before conversion to integer)
    real*8, dimension(numLakeVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
-   integer*8, dimension(numLakeVars) :: missingComp ! Missing value attribute (after conversion to integer)
+   integer(kind=4), dimension(numLakeVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numLakeVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numLakeVars) :: fillReal ! Fill value (before conversion to integer)
-   integer*8, dimension(numLakeVars) :: fillComp ! Fill value (after conversion to integer)
+   integer(kind=4), dimension(numLakeVars) :: fillComp ! Fill value (after conversion to integer)
    integer, dimension(numLakeVars) :: outFlag ! 0/1 flag to turn outputting off/on 
    integer, dimension(numLakeVars) :: timeZeroFlag ! 0/1 flag to either set variable to all NDV values or output 
                                                    ! the actual data. This was done because time 0 
@@ -342,14 +342,14 @@ type chrtGrdMeta
    character (len=64), dimension(numChGrdVars) :: longName ! longname for each variable
    character (len=64), dimension(numChGrdVars) :: units ! Units for each variable.
    character (len=64), dimension(numChGrdVars) :: coordNames ! Coordinate names for each variable. 
-   integer*8, dimension(numChGrdVars) :: validMinComp ! Valid min (after conversion to integer)
-   integer*8, dimension(numChGrdVars) :: validMaxComp ! Valid max (after conversion to integer)
+   integer(kind=4), dimension(numChGrdVars) :: validMinComp ! Valid min (after conversion to integer)
+   integer(kind=4), dimension(numChGrdVars) :: validMaxComp ! Valid max (after conversion to integer)
    real*8, dimension(numChGrdVars) :: validMinDbl ! Valid minimum (before conversion to integer)
    real*8, dimension(numChGrdVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
-   integer*8, dimension(numChGrdVars) :: missingComp ! Missing value attribute (after conversion to integer)
+   integer(kind=4), dimension(numChGrdVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numChGrdVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numChGrdVars) :: fillReal ! Fill value (before conversion to integer)
-   integer*8, dimension(numChGrdVars) :: fillComp ! Fill value (after conversion to integer)
+   integer(kind=4), dimension(numChGrdVars) :: fillComp ! Fill value (after conversion to integer)
    integer, dimension(numChGrdVars) :: outFlag ! 0/1 flag to turn outputting off/on 
    integer, dimension(numChGrdVars) :: timeZeroFlag ! 0/1 flag to either set variable to all NDV values or output 
                                                        ! the actual data. This
@@ -416,14 +416,14 @@ type lsmMeta
    character (len=64), dimension(numLsmVars) :: longName  ! Long names for each variable.
    character (len=64), dimension(numLsmVars) :: units ! Units for each variable.
    integer, dimension(numLsmVars) :: numLev ! Number of levels for each variable.
-   integer*8, dimension(numLsmVars) :: validMinComp ! Valid min (after conversion to integer)
-   integer*8, dimension(numLsmVars) :: validMaxComp ! Valid max (after conversion to integer)
+   integer(kind=4), dimension(numLsmVars) :: validMinComp ! Valid min (after conversion to integer)
+   integer(kind=4), dimension(numLsmVars) :: validMaxComp ! Valid max (after conversion to integer)
    real*8, dimension(numLsmVars) :: validMinDbl ! Valid minimum (before conversion to integer)
    real*8, dimension(numLsmVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
-   integer*8, dimension(numLsmVars) :: missingComp ! Missing value attribute (after conversion to integer)
+   integer(kind=4), dimension(numLsmVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numLsmVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numLsmVars) :: fillReal ! Fill value (before conversion to integer)
-   integer*8, dimension(numLsmVars) :: fillComp ! Fill value (after conversion to integer)
+   integer(kind=4), dimension(numLsmVars) :: fillComp ! Fill value (after conversion to integer)
    integer, dimension(numLsmVars) :: outFlag ! 0/1 flag to turn outputting off/on 
    integer, dimension(numLsmVars) :: timeZeroFlag ! 0/1 flag to either set variable to all NDV values or output 
                                                    ! the actual data. This was
@@ -487,14 +487,14 @@ type chObsMeta
    character (len=64), dimension(numChObsVars) :: longName  ! Long names for each variable.
    character (len=64), dimension(numChObsVars) :: units ! Units for each variable.
    character (len=64), dimension(numChObsVars) :: coordNames ! Coordinate names for each variable. 
-   integer*8, dimension(numChObsVars) :: validMinComp ! Valid min (after conversion to integer)
-   integer*8, dimension(numChObsVars) :: validMaxComp ! Valid max (after conversion to integer)
+   integer(kind=4), dimension(numChObsVars) :: validMinComp ! Valid min (after conversion to integer)
+   integer(kind=4), dimension(numChObsVars) :: validMaxComp ! Valid max (after conversion to integer)
    real*8, dimension(numChObsVars) :: validMinDbl ! Valid minimum (before conversion to integer)
    real*8, dimension(numChObsVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
-   integer*8, dimension(numChObsVars) :: missingComp ! Missing value attribute (after conversion to integer)
+   integer(kind=4), dimension(numChObsVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numChObsVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numChObsVars) :: fillReal ! Fill value (before conversion to integer)
-   integer*8, dimension(numChObsVars) :: fillComp ! Fill value (after conversion to integer)
+   integer(kind=4), dimension(numChObsVars) :: fillComp ! Fill value (after conversion to integer)
    integer, dimension(numChObsVars) :: outFlag ! 0/1 flag to turn outputting off/on 
    integer, dimension(numChObsVars) :: timeZeroFlag ! 0/1 flag to either set variable to all NDV values or output 
                                                  ! the actual data. This was
@@ -560,14 +560,14 @@ type gwMeta
    character (len=64), dimension(numGwVars) :: longName  ! Long names for each variable.
    character (len=64), dimension(numGwVars) :: units ! Units for each variable.
    !character (len=64), dimension(numGwVars) :: coordNames ! Coordinate names for each variable. 
-   integer*8, dimension(numGwVars) :: validMinComp ! Valid min (after conversion to integer)
-   integer*8, dimension(numGwVars) :: validMaxComp ! Valid max (after conversion to integer)
+   integer(kind=4), dimension(numGwVars) :: validMinComp ! Valid min (after conversion to integer)
+   integer(kind=4), dimension(numGwVars) :: validMaxComp ! Valid max (after conversion to integer)
    real*8, dimension(numGwVars) :: validMinDbl ! Valid minimum (before conversion to integer)
    real*8, dimension(numGwVars) :: validMaxDbl ! Valid maximum (before converstion to integer)
-   integer*8, dimension(numGwVars) :: missingComp ! Missing value attribute (after conversion to integer)
+   integer(kind=4), dimension(numGwVars) :: missingComp ! Missing value attribute (after conversion to integer)
    real, dimension(numGwVars) :: missingReal ! Missing value attribute (before conversion to integer)
    real, dimension(numGwVars) :: fillReal ! Fill value (before conversion to integer)
-   integer*8, dimension(numGwVars) :: fillComp ! Fill value (after conversion to integer)
+   integer(kind=4), dimension(numGwVars) :: fillComp ! Fill value (after conversion to integer)
    integer, dimension(numGwVars) :: outFlag ! 0/1 flag to turn outputting off/on 
    integer, dimension(numGwVars) :: timeZeroFlag ! 0/1 flag to either set variable to all NDV values or output 
                                                    ! the actual data. This was


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: netCDF

SOURCE: internal (Ryan @ NCAR)

DESCRIPTION OF CHANGES: netCDF file metadata for scale/offset output types specified 32-bit integers (`nf90_int`) but the IO code was using `integer(kind=8)` values. Older versions of netCDF allowed an implicit cast from a 64 bit integer to a 32 bit integer, but starting somewhere around 4.6.x it's now an error. This fix changes the data type components in `module_NWM_io_dict.F` to be `integer(kind=4)` to explicitly match what the netCDF variable.

ISSUE: 
```
Closes  #382 
```

TESTS CONDUCTED: Croton tests were performed with `io_form_outputs` set to 1,2,3, and 4 and output is consistent.
