### PR TITLE
Reservoir Assimilated Value and Source File Added in Lake Out Files

### DIFF
--- a/trunk/NDHMS/Data_Rec/rt_include.inc
+++ b/trunk/NDHMS/Data_Rec/rt_include.inc
@@ -8,6 +8,8 @@
    class (reservoir_container), allocatable, dimension(:) :: reservoirs
    integer, allocatable, dimension(:) :: reservoir_type ! specifying type of reservoir
    integer, allocatable, dimension(:) :: final_reservoir_type   ! resolved reservoir type (since it can change)
+   real, allocatable, dimension(:) :: reservoir_assimilated_value ! observation or forecast assimilated to reservoir discharge
+   character(len=256), allocatable, dimension(:) :: reservoir_assimilated_source_file ! source file of assimilated value
 
    INTEGER :: IX, JX
    logical :: initialized

--- a/trunk/NDHMS/MPP/mpp_land.F
+++ b/trunk/NDHMS/MPP/mpp_land.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !#### This is a module for parallel Land model.
@@ -23,7 +23,7 @@ MODULE MODULE_MPP_LAND
 
   use MODULE_CPL_LAND
   use mpi
-  
+
   IMPLICIT NONE
   !integer, public :: HYDRO_COMM_WORLD ! communicator for WRF-Hydro - moved to MODULE_CPL_LAND
   integer, public :: left_id,right_id,up_id,down_id,my_id
@@ -60,26 +60,26 @@ MODULE MODULE_MPP_LAND
      module procedure mpp_land_bcast_real8_1d
      module procedure mpp_land_bcast_real1
      module procedure mpp_land_bcast_real1_double
-     module procedure mpp_land_bcast_char1d 
+     module procedure mpp_land_bcast_char1d
      module procedure mpp_land_bcast_char1
-     module procedure mpp_land_bcast_int1 
-     module procedure mpp_land_bcast_int1d 
-     module procedure mpp_land_bcast_int2d 
+     module procedure mpp_land_bcast_int1
+     module procedure mpp_land_bcast_int1d
+     module procedure mpp_land_bcast_int2d
      module procedure mpp_land_bcast_logical
-     
+
   end interface
- 
+
   contains
 
   subroutine LOG_MAP2d()
     implicit none
     integer :: ndim, ierr
     integer, dimension(0:1) :: dims, coords
-    
+
     logical cyclic(0:1), reorder
     data cyclic/.false.,.false./  ! not cyclic
     data reorder/.false./
-    
+
       call MPI_COMM_RANK( HYDRO_COMM_WORLD, my_id, ierr )
       call MPI_COMM_SIZE( HYDRO_COMM_WORLD, numprocs, ierr )
 
@@ -101,15 +101,15 @@ MODULE MODULE_MPP_LAND
 
 !   ### get the neighbors.  -1 means no neighbor.
         down_id = my_id - left_right_np
-        up_id =   my_id + left_right_np 
+        up_id =   my_id + left_right_np
         if( up_down_p .eq. 0) down_id = -1
         if( up_down_p .eq. (up_down_np-1) ) up_id = -1
 
-        left_id = my_id - 1 
-        right_id = my_id + 1 
+        left_id = my_id - 1
+        right_id = my_id + 1
         if( left_right_p .eq. 0) left_id = -1
         if( left_right_p .eq. (left_right_np-1) ) right_id =-1
-    
+
 !    ### the IO node is the last processor.
 !yw        IO_id = numprocs - 1
          IO_id = 0
@@ -124,24 +124,24 @@ MODULE MODULE_MPP_LAND
 !
      call MPI_Cart_create(HYDRO_COMM_WORLD, ndim, dims, &
                           cyclic, reorder, cartGridComm, ierr)
-     
+
      call MPI_CART_GET(cartGridComm, 2, dims, cyclic, coords, ierr)
-     
+
      p_up_down = coords(0)
      p_left_right = coords(1)
-     np_up_down = up_down_np 
+     np_up_down = up_down_np
      np_left_right = left_right_np
- 
-     
+
+
      call mpp_land_sync()
 
-  return 
+  return
   end  subroutine log_map2d
 
 
   !old subroutine MPP_LAND_INIT(flag, ew_numprocs, sn_numprocs)
   subroutine MPP_LAND_INIT()
-!    ### initialize the land model logically based on the two D method. 
+!    ### initialize the land model logically based on the two D method.
 !    ### Call this function directly if it is nested with WRF.
     implicit none
     integer :: ierr, provided
@@ -177,17 +177,17 @@ MODULE MODULE_MPP_LAND
         integer :: i
 
         global_nx = in_global_nx
-        global_ny = in_global_ny 
+        global_ny = in_global_ny
         rt_AGGFACTRT = AGGFACTRT
         global_rt_nx = in_global_nx*AGGFACTRT
         global_rt_ny = in_global_ny *AGGFACTRT
         !overlap_n = 1
-!ywold        local_nx = global_nx / left_right_np 
+!ywold        local_nx = global_nx / left_right_np
 !ywold        if(left_right_p .eq. (left_right_np-1) ) then
 !ywold              local_nx = global_nx   &
 !ywold                    -int(global_nx/left_right_np)*(left_right_np-1)
 !ywold        end if
-!ywold        local_ny = global_ny / up_down_np 
+!ywold        local_ny = global_ny / up_down_np
 !ywold        if(  up_down_p .eq. (up_down_np-1) ) then
 !ywold           local_ny = global_ny  &
 !ywold                 -int(global_ny/up_down_np)*(up_down_np -1)
@@ -212,7 +212,7 @@ MODULE MODULE_MPP_LAND
                  end if
             end do
         end if
-        
+
         local_rt_nx=local_nx*AGGFACTRT+2
         local_rt_ny=local_ny*AGGFACTRT+2
         if(left_id.lt.0) local_rt_nx = local_rt_nx -1
@@ -222,7 +222,7 @@ MODULE MODULE_MPP_LAND
 
         call get_local_size(local_nx, local_ny,local_rt_nx,local_rt_ny)
         call calculate_start_p()
-        
+
         in_global_nx = local_nx
         in_global_ny = local_ny
 #ifdef HYDRO_D
@@ -231,7 +231,7 @@ MODULE MODULE_MPP_LAND
         write(6,*) "my_id=",my_id,"global_nx=",global_nx
         write(6,*) "my_id=",my_id,"global_nx=",global_ny
 #endif
-        return 
+        return
         end  subroutine MPP_LAND_PAR_INI
 
   subroutine MPP_LAND_LR_COM(in_out_data,NX,NY,flag)
@@ -241,9 +241,9 @@ MODULE MODULE_MPP_LAND
     integer count,size,tag,  ierr
     integer flag   ! 99 replace the boundary, else get the sum.
 
-    if(flag .eq. 99) then ! replace the data  
+    if(flag .eq. 99) then ! replace the data
        if(right_id .ge. 0) then  !   ### send to right first.
-           tag = 11 
+           tag = 11
            size = ny
            call mpi_send(in_out_data(nx-1,:),size,MPI_REAL,   &
              right_id,tag,HYDRO_COMM_WORLD,ierr)
@@ -253,17 +253,17 @@ MODULE MODULE_MPP_LAND
            size = ny
            call mpi_recv(in_out_data(1,:),size,MPI_REAL,  &
               left_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
-       endif 
+       endif
 
       if(left_id .ge. 0 ) then !   ### send to left second.
-          size = ny 
+          size = ny
           tag = 21
           call mpi_send(in_out_data(2,:),size,MPI_REAL,   &
              left_id,tag,HYDRO_COMM_WORLD,ierr)
       endif
       if(right_id .ge. 0) then !   receive from  right
           tag = 21
-          size = ny 
+          size = ny
           call mpi_recv(in_out_data(nx,:),size,MPI_REAL,&
              right_id,tag,HYDRO_COMM_WORLD, mpp_status,ierr)
       endif
@@ -272,7 +272,7 @@ MODULE MODULE_MPP_LAND
 
        if(right_id .ge. 0) then !   ### send to right first.
          tag = 11
-         size = 2*ny 
+         size = 2*ny
          call mpi_send(in_out_data(nx-1:nx,:),size,MPI_REAL,   &
              right_id,tag,HYDRO_COMM_WORLD,ierr)
        end if
@@ -283,7 +283,7 @@ MODULE MODULE_MPP_LAND
                HYDRO_COMM_WORLD,mpp_status,ierr)
           in_out_data(1,:) = in_out_data(1,:) + data_r(1,:)
           in_out_data(2,:) = in_out_data(2,:) + data_r(2,:)
-       endif 
+       endif
 
       if(left_id .ge. 0 ) then !   ### send to left second.
           size = 2*ny
@@ -309,9 +309,9 @@ MODULE MODULE_MPP_LAND
     integer count,size,tag,  ierr
     integer flag   ! 99 replace the boundary, else get the sum.
 
-    if(flag .eq. 99) then ! replace the data  
+    if(flag .eq. 99) then ! replace the data
        if(right_id .ge. 0) then  !   ### send to right first.
-           tag = 11 
+           tag = 11
            size = ny
            call mpi_send(in_out_data(nx-1,:),size,MPI_DOUBLE_PRECISION,   &
              right_id,tag,HYDRO_COMM_WORLD,ierr)
@@ -321,17 +321,17 @@ MODULE MODULE_MPP_LAND
            size = ny
            call mpi_recv(in_out_data(1,:),size,MPI_DOUBLE_PRECISION,  &
               left_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
-       endif 
+       endif
 
       if(left_id .ge. 0 ) then !   ### send to left second.
-          size = ny 
+          size = ny
           tag = 21
           call mpi_send(in_out_data(2,:),size,MPI_DOUBLE_PRECISION,   &
              left_id,tag,HYDRO_COMM_WORLD,ierr)
       endif
       if(right_id .ge. 0) then !   receive from  right
           tag = 21
-          size = ny 
+          size = ny
           call mpi_recv(in_out_data(nx,:),size,MPI_DOUBLE_PRECISION,&
              right_id,tag,HYDRO_COMM_WORLD, mpp_status,ierr)
       endif
@@ -340,7 +340,7 @@ MODULE MODULE_MPP_LAND
 
        if(right_id .ge. 0) then !   ### send to right first.
          tag = 11
-         size = 2*ny 
+         size = 2*ny
          call mpi_send(in_out_data(nx-1:nx,:),size,MPI_DOUBLE_PRECISION,   &
              right_id,tag,HYDRO_COMM_WORLD,ierr)
        end if
@@ -351,7 +351,7 @@ MODULE MODULE_MPP_LAND
                HYDRO_COMM_WORLD,mpp_status,ierr)
           in_out_data(1,:) = in_out_data(1,:) + data_r(1,:)
           in_out_data(2,:) = in_out_data(2,:) + data_r(2,:)
-       endif 
+       endif
 
       if(left_id .ge. 0 ) then !   ### send to left second.
           size = 2*ny
@@ -369,31 +369,31 @@ MODULE MODULE_MPP_LAND
 
     return
   end subroutine MPP_LAND_LR_COM8
-  
-  
+
+
   subroutine get_local_size(local_nx, local_ny,rt_nx,rt_ny)
     integer local_nx, local_ny, rt_nx,rt_ny
     integer i,status,ierr, tag
     integer tmp_nx,tmp_ny
-!   ### if it is IO node, get the local_size of the x and y direction 
+!   ### if it is IO node, get the local_size of the x and y direction
 !   ### for all other tasks.
     integer s_r(2)
 
-!   if(my_id .eq. IO_id) then 
-       if(.not. allocated(local_nx_size) ) allocate(local_nx_size(numprocs),stat = status) 
-       if(.not. allocated(local_ny_size) ) allocate(local_ny_size(numprocs),stat = status) 
-       if(.not. allocated(local_rt_nx_size) ) allocate(local_rt_nx_size(numprocs),stat = status) 
-       if(.not. allocated(local_rt_ny_size) ) allocate(local_rt_ny_size(numprocs),stat = status) 
+!   if(my_id .eq. IO_id) then
+       if(.not. allocated(local_nx_size) ) allocate(local_nx_size(numprocs),stat = status)
+       if(.not. allocated(local_ny_size) ) allocate(local_ny_size(numprocs),stat = status)
+       if(.not. allocated(local_rt_nx_size) ) allocate(local_rt_nx_size(numprocs),stat = status)
+       if(.not. allocated(local_rt_ny_size) ) allocate(local_rt_ny_size(numprocs),stat = status)
 !   end if
 
        call mpp_land_sync()
 
        if(my_id .eq. IO_id) then
-           do i = 0, numprocs - 1 
+           do i = 0, numprocs - 1
               if(i .ne. my_id) then
                  !block receive  from other node.
                  tag = 1
-                 call mpi_recv(s_r,2,MPI_INTEGER,i, & 
+                 call mpi_recv(s_r,2,MPI_INTEGER,i, &
                       tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                  local_nx_size(i+1) = s_r(1)
                  local_ny_size(i+1) = s_r(2)
@@ -402,21 +402,21 @@ MODULE MODULE_MPP_LAND
                    local_ny_size(i+1) = local_ny
                end if
            end do
-       else 
-           tag =  1  
+       else
+           tag =  1
            s_r(1) = local_nx
            s_r(2) = local_ny
            call mpi_send(s_r,2,MPI_INTEGER, IO_id,     &
                tag,HYDRO_COMM_WORLD,ierr)
        end if
 
- 
+
        if(my_id .eq. IO_id) then
-           do i = 0, numprocs - 1 
+           do i = 0, numprocs - 1
               if(i .ne. my_id) then
                  !block receive  from other node.
                  tag = 2
-                 call mpi_recv(s_r,2,MPI_INTEGER,i, & 
+                 call mpi_recv(s_r,2,MPI_INTEGER,i, &
                       tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                  local_rt_nx_size(i+1) = s_r(1)
                  local_rt_ny_size(i+1) = s_r(2)
@@ -425,15 +425,15 @@ MODULE MODULE_MPP_LAND
                    local_rt_ny_size(i+1) = rt_ny
                end if
            end do
-       else 
-           tag =  2  
+       else
+           tag =  2
            s_r(1) = rt_nx
            s_r(2) = rt_ny
            call mpi_send(s_r,2,MPI_INTEGER, IO_id,     &
                tag,HYDRO_COMM_WORLD,ierr)
        end if
        call mpp_land_sync()
-       return 
+       return
   end  subroutine get_local_size
 
 
@@ -453,27 +453,27 @@ MODULE MODULE_MPP_LAND
            call mpi_send(in_out_data(:,ny-1),size,MPI_REAL,   &
                up_id,tag,HYDRO_COMM_WORLD,ierr)
        endif
-       if(down_id .ge. 0 ) then !   receive from down 
-           tag = 31 
+       if(down_id .ge. 0 ) then !   receive from down
+           tag = 31
            size = nx
            call mpi_recv(in_out_data(:,1),size,MPI_REAL, &
               down_id,tag,HYDRO_COMM_WORLD, mpp_status,ierr)
        endif
-   
+
        if(down_id .ge. 0 ) then !   send down.
            tag = 41
            size = nx
            call mpi_send(in_out_data(:,2),size,MPI_REAL,      &
                 down_id,tag,HYDRO_COMM_WORLD,ierr)
        endif
-       if(up_id .ge. 0 ) then !   receive from upper 
-           tag = 41 
+       if(up_id .ge. 0 ) then !   receive from upper
+           tag = 41
            size = nx
            call mpi_recv(in_out_data(:,ny),size,MPI_REAL, &
                up_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
        endif
-     
-    else  ! flag = 1 
+
+    else  ! flag = 1
 
        if(up_id .ge. 0 ) then !   ### send to up first.
            tag = 31
@@ -522,27 +522,27 @@ MODULE MODULE_MPP_LAND
            call mpi_send(in_out_data(:,ny-1),size,MPI_DOUBLE_PRECISION,   &
                up_id,tag,HYDRO_COMM_WORLD,ierr)
        endif
-       if(down_id .ge. 0 ) then !   receive from down 
-           tag = 31 
+       if(down_id .ge. 0 ) then !   receive from down
+           tag = 31
            size = nx
            call mpi_recv(in_out_data(:,1),size,MPI_DOUBLE_PRECISION, &
               down_id,tag,HYDRO_COMM_WORLD, mpp_status,ierr)
        endif
-   
+
        if(down_id .ge. 0 ) then !   send down.
            tag = 41
            size = nx
            call mpi_send(in_out_data(:,2),size,MPI_DOUBLE_PRECISION,      &
                 down_id,tag,HYDRO_COMM_WORLD,ierr)
        endif
-       if(up_id .ge. 0 ) then !   receive from upper 
-           tag = 41 
+       if(up_id .ge. 0 ) then !   receive from upper
+           tag = 41
            size = nx
            call mpi_recv(in_out_data(:,ny),size,MPI_DOUBLE_PRECISION, &
                up_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
        endif
-     
-    else  ! flag = 1 
+
+    else  ! flag = 1
 
        if(up_id .ge. 0 ) then !   ### send to up first.
            tag = 31
@@ -574,18 +574,18 @@ MODULE MODULE_MPP_LAND
     endif  ! end of block  flag
     return
   end  subroutine MPP_LAND_UB_COM8
-  
+
   subroutine calculate_start_p()
 ! calculate startx and starty
     integer :: i,status, ierr, tag
     integer :: r_s(2)
     integer ::  t_nx, t_ny
 
-    if(.not. allocated(starty) ) allocate(starty(numprocs),stat = ierr) 
+    if(.not. allocated(starty) ) allocate(starty(numprocs),stat = ierr)
     if(.not. allocated(startx) ) allocate(startx(numprocs),stat = ierr)
 
-    local_startx = int(global_nx/left_right_np) * left_right_p+1 
-    local_starty = int(global_ny/up_down_np) * up_down_p+1 
+    local_startx = int(global_nx/left_right_np) * left_right_p+1
+    local_starty = int(global_ny/up_down_np) * up_down_p+1
 
 !ywold
     t_nx = 0
@@ -674,7 +674,7 @@ MODULE MODULE_MPP_LAND
             iend   = startx(i+1)+local_nx_size(i+1) -1
             jbegin = starty(i+1)
             jend   = starty(i+1)+local_ny_size(i+1) -1
-          
+
             if(my_id .eq. i) then
                out_buff=in_buff(ibegin:iend,jbegin:jend)
             else
@@ -684,7 +684,7 @@ MODULE MODULE_MPP_LAND
                   MPI_REAL, i,tag,HYDRO_COMM_WORLD,ierr)
             end if
          end do
-      else 
+      else
          size = local_nx*local_ny
          call mpi_recv(out_buff,size,MPI_REAL,IO_id, &
                 tag,HYDRO_COMM_WORLD,mpp_status,ierr)
@@ -699,7 +699,7 @@ MODULE MODULE_MPP_LAND
       integer,dimension(:,:) ::  in_buff,out_buff
       integer tag, i, status, ierr,size
       integer ibegin,iend,jbegin,jend
- 
+
       tag = 2
       if(my_id .eq. IO_id) then
          do i = 0, numprocs - 1
@@ -716,7 +716,7 @@ MODULE MODULE_MPP_LAND
                   MPI_INTEGER, i,tag,HYDRO_COMM_WORLD,ierr)
             end if
          end do
-      else 
+      else
          size = local_nx*local_ny
          call mpi_recv(out_buff,size,MPI_INTEGER,IO_id, &
                 tag,HYDRO_COMM_WORLD,mpp_status,ierr)
@@ -741,8 +741,8 @@ MODULE MODULE_MPP_LAND
             jbegin = starty(i+1)
             jend   = starty(i+1)+local_ny_size(i+1) -1
             if(i .eq. IO_id) then
-               out_buff(ibegin:iend,jbegin:jend) = in_buff 
-            else 
+               out_buff(ibegin:iend,jbegin:jend) = in_buff
+            else
                size = local_nx_size(i+1)*local_ny_size(i+1)
                tag = 2
                call mpi_recv(out_buff(ibegin:iend,jbegin:jend),size,&
@@ -755,19 +755,19 @@ MODULE MODULE_MPP_LAND
 
   subroutine write_IO_char_head(in, out, imageHead)
   !! JLM 2015-11-30
-  !! for i is image number (starting from 0), 
-  !! this routine writes 
-  !! in(1:imageHead(i+1)) 
-  !! to 
+  !! for i is image number (starting from 0),
+  !! this routine writes
+  !! in(1:imageHead(i+1))
+  !! to
   !! out( (sum(imageHead(i+1-1))+1) : ((sum(imageHead(i+1-1))+1)+imageHead(i+1)) )
   !! where out is on the IO node.
-      character(len=*), intent(in),  dimension(:) :: in 
+      character(len=*), intent(in),  dimension(:) :: in
       character(len=*), intent(out), dimension(:) :: out
       integer,   intent(in),  dimension(:) :: imageHead
       integer :: tag, i, status, ierr, size
       integer :: ibegin,iend,jbegin,jend
       integer :: lenSize, theStart, theEnd
-      tag = 2 
+      tag = 2
       if(my_id .ne. IO_id) then
          lenSize = imageHead(my_id+1)*len(in(1))  !! some times necessary for character arrays?
          if(lenSize .eq. 0) return
@@ -778,13 +778,13 @@ MODULE MODULE_MPP_LAND
             if(lenSize .eq. 0) cycle
             if(i .eq. 0) then
                theStart = 1
-            else 
+            else
                theStart = sum(imageHead(1:(i+1-1))) +1
             end if
             theEnd   = theStart + imageHead(i+1) -1
             if(i .eq. IO_id) then
                out(theStart:theEnd) = in(1:imageHead(i+1))
-            else 
+            else
                call mpi_recv(out(theStart:theEnd),lenSize,&
                     MPI_CHARACTER,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
             end if
@@ -820,8 +820,8 @@ MODULE MODULE_MPP_LAND
             jbegin = starty(i+1)
             jend   = starty(i+1)+local_ny_size(i+1) -1
             if(i .eq. IO_id) then
-               out_buff(ibegin:iend,jbegin:jend) = in_buff 
-            else 
+               out_buff(ibegin:iend,jbegin:jend) = in_buff
+            else
                size = local_nx_size(i+1)*local_ny_size(i+1)
                tag = 2
                call mpi_recv(out_buff(ibegin:iend,jbegin:jend),size,&
@@ -844,15 +844,15 @@ MODULE MODULE_MPP_LAND
                 tag,HYDRO_COMM_WORLD,ierr)
       else
           do i = 0, numprocs - 1
-            ibegin = startx(i+1)*rt_AGGFACTRT - (rt_AGGFACTRT-1) 
+            ibegin = startx(i+1)*rt_AGGFACTRT - (rt_AGGFACTRT-1)
             if(ibegin.gt.1) ibegin=ibegin - 1
             iend   = ibegin + local_rt_nx_size(i+1) -1
             jbegin = starty(i+1)*rt_AGGFACTRT - (rt_AGGFACTRT-1)
             if(jbegin.gt.1) jbegin=jbegin - 1
             jend   = jbegin + local_rt_ny_size(i+1) -1
             if(i .eq. IO_id) then
-               out_buff(ibegin:iend,jbegin:jend) = in_buff 
-            else 
+               out_buff(ibegin:iend,jbegin:jend) = in_buff
+            else
                size = local_rt_nx_size(i+1)*local_rt_ny_size(i+1)
                tag = 2
                call mpi_recv(out_buff(ibegin:iend,jbegin:jend),size,&
@@ -877,15 +877,15 @@ MODULE MODULE_MPP_LAND
                 tag,HYDRO_COMM_WORLD,ierr)
       else
           do i = 0, numprocs - 1
-            ibegin = startx(i+1)*rt_AGGFACTRT - (rt_AGGFACTRT-1) 
+            ibegin = startx(i+1)*rt_AGGFACTRT - (rt_AGGFACTRT-1)
             if(ibegin.gt.1) ibegin=ibegin - 1
             iend   = ibegin + local_rt_nx_size(i+1) -1
             jbegin = starty(i+1)*rt_AGGFACTRT - (rt_AGGFACTRT-1)
             if(jbegin.gt.1) jbegin=jbegin - 1
             jend   = jbegin + local_rt_ny_size(i+1) -1
             if(i .eq. IO_id) then
-               out_buff(ibegin:iend,jbegin:jend) = in_buff 
-            else 
+               out_buff(ibegin:iend,jbegin:jend) = in_buff
+            else
                size = local_rt_nx_size(i+1)*local_rt_ny_size(i+1)
                tag = 2
                call mpi_recv(out_buff(ibegin:iend,jbegin:jend),size,&
@@ -902,7 +902,7 @@ MODULE MODULE_MPP_LAND
         call mpi_bcast(inout,1,MPI_LOGICAL,   &
             IO_id,HYDRO_COMM_WORLD,ierr)
       call mpp_land_sync()
-    return 
+    return
   end subroutine mpp_land_bcast_log1
 
 
@@ -913,29 +913,29 @@ MODULE MODULE_MPP_LAND
         call mpi_bcast(inout,size,MPI_INTEGER,   &
             IO_id,HYDRO_COMM_WORLD,ierr)
       call mpp_land_sync()
-    return 
+    return
   end subroutine mpp_land_bcast_int
 
   subroutine mpp_land_bcast_int1d(inout)
-      integer len 
+      integer len
       integer inout(:)
      integer ierr
       len = size(inout,1)
         call mpi_bcast(inout,len,MPI_INTEGER,   &
             IO_id,HYDRO_COMM_WORLD,ierr)
       call mpp_land_sync()
-    return 
+    return
   end subroutine mpp_land_bcast_int1d
 
   subroutine mpp_land_bcast_int1d_root(inout, rootId)
-     integer len 
+     integer len
      integer inout(:)
      integer, intent(in) :: rootId
      integer ierr
       len = size(inout,1)
         call mpi_bcast(inout,len,MPI_INTEGER,rootId,HYDRO_COMM_WORLD,ierr)
       call mpp_land_sync()
-    return 
+    return
   end subroutine mpp_land_bcast_int1d_root
 
   subroutine mpp_land_bcast_int1(inout)
@@ -944,7 +944,7 @@ MODULE MODULE_MPP_LAND
         call mpi_bcast(inout,1,MPI_INTEGER,   &
             IO_id,HYDRO_COMM_WORLD,ierr)
       call mpp_land_sync()
-    return 
+    return
   end subroutine mpp_land_bcast_int1
 
   subroutine mpp_land_bcast_int1_root(inout, rootId)
@@ -953,7 +953,7 @@ MODULE MODULE_MPP_LAND
       integer, intent(in) :: rootId
         call mpi_bcast(inout,1,MPI_INTEGER,rootId,HYDRO_COMM_WORLD,ierr)
       call mpp_land_sync()
-    return 
+    return
   end subroutine mpp_land_bcast_int1_root
 
   subroutine mpp_land_bcast_logical(inout)
@@ -962,7 +962,7 @@ MODULE MODULE_MPP_LAND
         call mpi_bcast(inout,1,MPI_LOGICAL,   &
             IO_id,HYDRO_COMM_WORLD,ierr)
       call mpp_land_sync()
-    return 
+    return
   end subroutine mpp_land_bcast_logical
 
   subroutine mpp_land_bcast_logical_root(inout, rootId)
@@ -971,7 +971,7 @@ MODULE MODULE_MPP_LAND
       integer ierr
         call mpi_bcast(inout,1,MPI_LOGICAL,rootId,HYDRO_COMM_WORLD,ierr)
       call mpp_land_sync()
-    return 
+    return
   end subroutine mpp_land_bcast_logical_root
 
 
@@ -981,7 +981,7 @@ MODULE MODULE_MPP_LAND
         call mpi_bcast(inout,1,MPI_REAL,   &
             IO_id,HYDRO_COMM_WORLD,ierr)
       call mpp_land_sync()
-    return 
+    return
   end subroutine mpp_land_bcast_real1
 
   subroutine mpp_land_bcast_real1_double(inout)
@@ -997,7 +997,7 @@ MODULE MODULE_MPP_LAND
       integer len
       real inout(:)
       integer ierr
-      len = size(inout,1) 
+      len = size(inout,1)
         call mpi_bcast(inout,len,MPI_real,   &
             IO_id,HYDRO_COMM_WORLD,ierr)
       call mpp_land_sync()
@@ -1084,7 +1084,7 @@ MODULE MODULE_MPP_LAND
       call mpp_land_sync()
     return
   end subroutine mpp_land_bcast_real3d
-  
+
   subroutine mpp_land_bcast_rd(size,inout)
       integer size
       real*8 inout(size)
@@ -1149,7 +1149,7 @@ MODULE MODULE_MPP_LAND
     return
   end subroutine mpp_land_bcast_char1
 
- 
+
   subroutine MPP_LAND_COM_REAL(in_out_data,NX,NY,flag)
 !   ### Communicate message on left right and up bottom directions.
     integer NX,NY
@@ -1191,7 +1191,7 @@ MODULE MODULE_MPP_LAND
 
     return
   end subroutine MPP_LAND_COM_INTEGER
- 
+
      subroutine read_restart_3(unit,nz,out)
         integer unit,nz,i
         real buf3(global_nx,global_ny,nz),&
@@ -1298,7 +1298,7 @@ MODULE MODULE_MPP_LAND
       tag = 2
       if(my_id .eq. IO_id) then
          do i = 0, numprocs - 1
-            ibegin = startx(i+1)*rt_AGGFACTRT - (rt_AGGFACTRT-1) 
+            ibegin = startx(i+1)*rt_AGGFACTRT - (rt_AGGFACTRT-1)
             if(ibegin.gt.1) ibegin=ibegin - 1
             iend   = ibegin + local_rt_nx_size(i+1) -1
             jbegin = starty(i+1)*rt_AGGFACTRT - (rt_AGGFACTRT-1)
@@ -1369,12 +1369,12 @@ MODULE MODULE_MPP_LAND
            i = nprocs/j
            if( abs(i-j) .lt. max) then
                max = abs(i-j)
-               nx = i 
-               ny = j 
+               nx = i
+               ny = j
            end if
        end if
     end do
-  return 
+  return
   end subroutine getNX_NY
 
      subroutine pack_global_22(in,   &
@@ -1385,7 +1385,7 @@ MODULE MODULE_MPP_LAND
         do i = 1, k
           call write_IO_real(in(:,:,i),out(:,:,i))
         enddo
-     return 
+     return
      end subroutine pack_global_22
 
 
@@ -1400,7 +1400,7 @@ MODULE MODULE_MPP_LAND
       call MPI_COMM_SIZE( HYDRO_COMM_WORLD, numprocs, ierr )
 
       if(numprocs .ne. total_pe) then
-         write(6,*) "FATAL ERROR: In wrf_LAND_set_INIT() - numprocs .ne. total_pe ",numprocs, total_pe 
+         write(6,*) "FATAL ERROR: In wrf_LAND_set_INIT() - numprocs .ne. total_pe ",numprocs, total_pe
          call mpp_land_abort()
       endif
 
@@ -1412,17 +1412,17 @@ MODULE MODULE_MPP_LAND
       down_id = info(5,my_id+1)
       IO_id = 0
 
-       allocate(local_nx_size(numprocs),stat = status) 
-       allocate(local_ny_size(numprocs),stat = status) 
-       allocate(local_rt_nx_size(numprocs),stat = status) 
-       allocate(local_rt_ny_size(numprocs),stat = status) 
-       allocate(starty(numprocs),stat = ierr) 
+       allocate(local_nx_size(numprocs),stat = status)
+       allocate(local_ny_size(numprocs),stat = status)
+       allocate(local_rt_nx_size(numprocs),stat = status)
+       allocate(local_rt_ny_size(numprocs),stat = status)
+       allocate(starty(numprocs),stat = ierr)
        allocate(startx(numprocs),stat = ierr)
 
        i = my_id + 1
        local_nx = info(7,i) - info(6,i) + 1
        local_ny = info(9,i) - info(8,i) + 1
- 
+
        global_nx = 0
        global_ny = 0
        do i = 1, numprocs
@@ -1441,11 +1441,11 @@ MODULE MODULE_MPP_LAND
        global_rt_ny = global_ny*AGGFACTRT
        rt_AGGFACTRT = AGGFACTRT
 
-       do i =1,numprocs 
+       do i =1,numprocs
           local_nx_size(i) = info(7,i) - info(6,i) + 1
           local_ny_size(i) = info(9,i) - info(8,i) + 1
-          startx(i)        = info(6,i) 
-          starty(i)        = info(8,i) 
+          startx(i)        = info(6,i)
+          starty(i)        = info(8,i)
 
           local_rt_nx_size(i) = (info(7,i) - info(6,i) + 1)*AGGFACTRT+2
           local_rt_ny_size(i) = (info(9,i) - info(8,i) + 1 )*AGGFACTRT+2
@@ -1454,7 +1454,7 @@ MODULE MODULE_MPP_LAND
           if(info(4,i).lt.0) local_rt_ny_size(i) = local_rt_ny_size(i) -1
           if(info(5,i).lt.0) local_rt_ny_size(i) = local_rt_ny_size(i) -1
        enddo
-      return 
+      return
       end   subroutine wrf_LAND_set_INIT
 
       subroutine getMy_global_id()
@@ -1473,12 +1473,12 @@ MODULE MODULE_MPP_LAND
 
       tmp_inout = -999
 
-      if(size .eq. 0) then  
+      if(size .eq. 0) then
             tmp_inout = -999
       else
 
          !     map the Link_V data to tmp_inout(ix,jy)
-         do i = 1,ix 
+         do i = 1,ix
             if(Link_location(i,1) .gt. 0) &
                tmp_inout(i,1) = Link_V(Link_location(i,1))
             if(Link_location(i,2) .gt. 0) &
@@ -1488,7 +1488,7 @@ MODULE MODULE_MPP_LAND
             if(Link_location(i,jy) .gt. 0) &
                tmp_inout(i,jy) = Link_V(Link_location(i,jy))
           enddo
-         do j = 1,jy 
+         do j = 1,jy
             if(Link_location(1,j) .gt. 0) &
                tmp_inout(1,j) = Link_V(Link_location(1,j))
             if(Link_location(2,j) .gt. 0) &
@@ -1505,7 +1505,7 @@ MODULE MODULE_MPP_LAND
 
 !map the data back to Link_V
     if(size .eq. 0) return
-      do j = 1,jy 
+      do j = 1,jy
             if( (Link_location(1,j) .gt. 0) .and. (tmp_inout(1,j) .ne. -999) ) &
                Link_V(Link_location(1,j)) = tmp_inout(1,j)
             if((Link_location(2,j) .gt. 0) .and. (tmp_inout(2,j) .ne. -999) ) &
@@ -1515,7 +1515,7 @@ MODULE MODULE_MPP_LAND
             if((Link_location(ix,j) .gt. 0) .and. (tmp_inout(ix,j) .ne. -999) )&
                Link_V(Link_location(ix,j)) = tmp_inout(ix,j)
       enddo
-      do i = 1,ix 
+      do i = 1,ix
             if((Link_location(i,1) .gt. 0) .and. (tmp_inout(i,1) .ne. -999) )&
                Link_V(Link_location(i,1)) = tmp_inout(i,1)
             if( (Link_location(i,2) .gt. 0) .and. (tmp_inout(i,2) .ne. -999) )&
@@ -1538,12 +1538,12 @@ MODULE MODULE_MPP_LAND
 
       tmp_inout = -999
 
-      if(size .eq. 0) then  
+      if(size .eq. 0) then
             tmp_inout = -999
       else
 
          !     map the Link_V data to tmp_inout(ix,jy)
-         do i = 1,ix 
+         do i = 1,ix
             if(Link_location(i,1) .gt. 0) &
                tmp_inout(i,1) = Link_V(Link_location(i,1))
             if(Link_location(i,2) .gt. 0) &
@@ -1553,7 +1553,7 @@ MODULE MODULE_MPP_LAND
             if(Link_location(i,jy) .gt. 0) &
                tmp_inout(i,jy) = Link_V(Link_location(i,jy))
           enddo
-         do j = 1,jy 
+         do j = 1,jy
             if(Link_location(1,j) .gt. 0) &
                tmp_inout(1,j) = Link_V(Link_location(1,j))
             if(Link_location(2,j) .gt. 0) &
@@ -1570,7 +1570,7 @@ MODULE MODULE_MPP_LAND
 
 !map the data back to Link_V
     if(size .eq. 0) return
-      do j = 1,jy 
+      do j = 1,jy
             if( (Link_location(1,j) .gt. 0) .and. (tmp_inout(1,j) .ne. -999) ) &
                Link_V(Link_location(1,j)) = tmp_inout(1,j)
             if((Link_location(2,j) .gt. 0) .and. (tmp_inout(2,j) .ne. -999) ) &
@@ -1580,7 +1580,7 @@ MODULE MODULE_MPP_LAND
             if((Link_location(ix,j) .gt. 0) .and. (tmp_inout(ix,j) .ne. -999) )&
                Link_V(Link_location(ix,j)) = tmp_inout(ix,j)
       enddo
-      do i = 1,ix 
+      do i = 1,ix
             if((Link_location(i,1) .gt. 0) .and. (tmp_inout(i,1) .ne. -999) )&
                Link_V(Link_location(i,1)) = tmp_inout(i,1)
             if( (Link_location(i,2) .gt. 0) .and. (tmp_inout(i,2) .ne. -999) )&
@@ -1600,12 +1600,12 @@ MODULE MODULE_MPP_LAND
       integer i,j, flag
       integer Link_V(size), tmp_inout(ix,jy)
 
-      if(size .eq. 0) then  
+      if(size .eq. 0) then
            tmp_inout = -999
       else
 
          !     map the Link_V data to tmp_inout(ix,jy)
-         do i = 1,ix 
+         do i = 1,ix
             if(Link_location(i,1) .gt. 0) &
                tmp_inout(i,1) = Link_V(Link_location(i,1))
             if(Link_location(i,2) .gt. 0) &
@@ -1615,7 +1615,7 @@ MODULE MODULE_MPP_LAND
             if(Link_location(i,jy) .gt. 0) &
                tmp_inout(i,jy) = Link_V(Link_location(i,jy))
           enddo
-         do j = 1,jy 
+         do j = 1,jy
             if(Link_location(1,j) .gt. 0) &
                tmp_inout(1,j) = Link_V(Link_location(1,j))
             if(Link_location(2,j) .gt. 0) &
@@ -1632,7 +1632,7 @@ MODULE MODULE_MPP_LAND
 
 !map the data back to Link_V
     if(size .eq. 0) return
-      do j = 1,jy 
+      do j = 1,jy
             if( (Link_location(1,j) .gt. 0) .and. (tmp_inout(1,j) .ne. -999) ) &
                Link_V(Link_location(1,j)) = tmp_inout(1,j)
             if((Link_location(2,j) .gt. 0) .and. (tmp_inout(2,j) .ne. -999) ) &
@@ -1642,7 +1642,7 @@ MODULE MODULE_MPP_LAND
             if((Link_location(ix,j) .gt. 0) .and. (tmp_inout(ix,j) .ne. -999) )&
                Link_V(Link_location(ix,j)) = tmp_inout(ix,j)
       enddo
-      do i = 1,ix 
+      do i = 1,ix
             if((Link_location(i,1) .gt. 0) .and. (tmp_inout(i,1) .ne. -999) )&
                Link_V(Link_location(i,1)) = tmp_inout(i,1)
             if( (Link_location(i,2) .gt. 0) .and. (tmp_inout(i,2) .ne. -999) )&
@@ -1684,7 +1684,7 @@ MODULE MODULE_MPP_LAND
                  tag = 101
                  call mpi_recv(r1,1,MPI_INTEGER,i, &
                       tag,HYDRO_COMM_WORLD,mpp_status,ierr)
-                 if(max <= r1) max = r1 
+                 if(max <= r1) max = r1
               end if
            end do
        else
@@ -1696,7 +1696,7 @@ MODULE MODULE_MPP_LAND
        v = max
        return
      end subroutine mpp_land_max_int1
-     
+
      subroutine mpp_land_max_real1(v)
         implicit none
         real v, r1, max
@@ -1709,7 +1709,7 @@ MODULE MODULE_MPP_LAND
                  tag = 101
                  call mpi_recv(r1,1,MPI_REAL,i, &
                       tag,HYDRO_COMM_WORLD,mpp_status,ierr)
-                 if(max <= r1) max = r1 
+                 if(max <= r1) max = r1
               end if
            end do
        else
@@ -1722,7 +1722,7 @@ MODULE MODULE_MPP_LAND
        return
      end subroutine mpp_land_max_real1
 
-     subroutine mpp_same_int1(v)   
+     subroutine mpp_same_int1(v)
         implicit none
         integer v,r1
         integer i, ierr, tag
@@ -1733,7 +1733,7 @@ MODULE MODULE_MPP_LAND
                  tag = 109
                  call mpi_recv(r1,1,MPI_INTEGER,i, &
                       tag,HYDRO_COMM_WORLD,mpp_status,ierr)
-                 if(v .ne. r1) v = -99  
+                 if(v .ne. r1) v = -99
               end if
            end do
        else
@@ -1746,7 +1746,7 @@ MODULE MODULE_MPP_LAND
 
 
 
-     subroutine write_chanel_real(v,map_l2g,gnlinks,nlinks,g_v)   
+     subroutine write_chanel_real(v,map_l2g,gnlinks,nlinks,g_v)
         implicit none
         integer  gnlinks,nlinks, map_l2g(nlinks)
         real recv(nlinks), v(nlinks)
@@ -1785,7 +1785,7 @@ MODULE MODULE_MPP_LAND
                    tag,HYDRO_COMM_WORLD,mpp_status,ierr)
 
                  do k = 1,message_len
-                    node = tmp_map(k) 
+                    node = tmp_map(k)
                     if(node .gt. 0) then
                       g_v(node) = tmp_v(k)
                     else
@@ -1796,17 +1796,17 @@ MODULE MODULE_MPP_LAND
                  enddo
               else
                  do k = 1,nlinks
-                    node = map_l2g(k) 
+                    node = map_l2g(k)
                     if(node .gt. 0) then
                       g_v(node) = v(k)
                     else
 #ifdef HYDRO_D
-                      write(6,*) "local Maping infor k=",k," node=",node 
+                      write(6,*) "local Maping infor k=",k," node=",node
 #endif
                     endif
                  enddo
               end if
-            
+
            end do
         else
            tag =  109
@@ -1821,7 +1821,7 @@ MODULE MODULE_MPP_LAND
            if(allocated(tmp_v)) deallocate(tmp_v)
      end subroutine write_chanel_real
 
-     subroutine write_chanel_int(v,map_l2g,gnlinks,nlinks,g_v)   
+     subroutine write_chanel_int(v,map_l2g,gnlinks,nlinks,g_v)
         implicit none
         integer gnlinks,nlinks, map_l2g(nlinks)
         integer ::  recv(nlinks), v(nlinks)
@@ -1860,9 +1860,9 @@ MODULE MODULE_MPP_LAND
 
                  do k = 1,message_len
                     if(tmp_map(k) .gt. 0) then
-                      node = tmp_map(k) 
+                      node = tmp_map(k)
                       g_v(node) = tmp_v(k)
-                    else 
+                    else
 #ifdef HYDRO_D
                       write(6,*) "Maping infor k=",k," node=",tmp_v(k)
 #endif
@@ -1871,7 +1871,7 @@ MODULE MODULE_MPP_LAND
               else
                  do k = 1,nlinks
                     if(map_l2g(k) .gt. 0) then
-                      node = map_l2g(k) 
+                      node = map_l2g(k)
                       g_v(node) = v(k)
                     else
 #ifdef HYDRO_D
@@ -1880,7 +1880,7 @@ MODULE MODULE_MPP_LAND
                     endif
                  enddo
               end if
-            
+
            end do
         else
            tag =  109
@@ -1895,8 +1895,7 @@ MODULE MODULE_MPP_LAND
      end subroutine write_chanel_int
 
 
-
-     subroutine write_lake_real(v,nodelist_in,nlakes)   
+     subroutine write_lake_real(v,nodelist_in,nlakes)
         implicit none
         real recv(nlakes), v(nlakes)
         integer nodelist(nlakes), nlakes, nodelist_in(nlakes)
@@ -1917,11 +1916,11 @@ MODULE MODULE_MPP_LAND
 
                  do k = 1,nlakes
                     if(nodelist(k) .gt. -99) then
-                       node = nodelist(k) 
+                       node = nodelist(k)
                        v(node) = recv(node)
                     endif
                  enddo
-              end if            
+              end if
            end do
         else
            tag =  129
@@ -1932,6 +1931,47 @@ MODULE MODULE_MPP_LAND
                tag,HYDRO_COMM_WORLD,ierr)
         end if
      end subroutine write_lake_real
+
+
+     subroutine write_lake_char(v,nodelist_in,nlakes)
+        implicit none
+        character(len=256) recv(nlakes), v(nlakes)
+        integer nodelist(nlakes), nlakes, nodelist_in(nlakes)
+        integer i, ierr, tag, k, in_len
+        integer length, node
+
+        in_len = size(v, 1)*len(v)
+
+        nodelist = nodelist_in
+        if(my_id .eq. IO_id) then
+           do i = 0, numprocs - 1
+              if(i .ne. my_id) then
+                 !block receive  from other node.
+                 tag = 129
+                 call mpi_recv(nodelist,nlakes,MPI_INTEGER,i, &
+                      tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+                   tag = 139
+                 call mpi_recv(recv(:),in_len,MPI_CHARACTER,i,  &
+                   tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+
+                 do k = 1,nlakes
+                    if(nodelist(k) .gt. -99) then
+                       node = nodelist(k)
+                       v(node) = recv(node)
+                    endif
+                 enddo
+              end if
+           end do
+        else
+           tag =  129
+           call mpi_send(nodelist,nlakes,MPI_INTEGER, IO_id,     &
+               tag,HYDRO_COMM_WORLD,ierr)
+           tag = 139
+           call mpi_send(v,in_len,MPI_CHARACTER,IO_id,   &
+               tag,HYDRO_COMM_WORLD,ierr)
+        end if
+     end subroutine write_lake_char
+
 
      subroutine read_rst_crt_r(unit,out,size)
          implicit none
@@ -1947,7 +1987,7 @@ MODULE MODULE_MPP_LAND
         call mpi_bcast(out,size,MPI_REAL,   &
             IO_id,HYDRO_COMM_WORLD,ierr)
      return
-     end subroutine read_rst_crt_r  
+     end subroutine read_rst_crt_r
 
          subroutine write_rst_crt_r(unit,cd,map_l2g,gnlinks,nlinks)
          integer :: unit,gnlinks,nlinks,map_l2g(nlinks)
@@ -1976,7 +2016,7 @@ MODULE MODULE_MPP_LAND
              call mpi_send(vin,nsize,MPI_INTEGER,IO_id,   &
                   tag,HYDRO_COMM_WORLD,ierr)
        endif
-       call mpp_land_bcast_int1d(vin) 
+       call mpp_land_bcast_int1d(vin)
        return
     end subroutine sum_int1d
 
@@ -2013,7 +2053,7 @@ MODULE MODULE_MPP_LAND
        real,dimension(nsize) :: vin
        real*8,dimension(nsize) :: vin8
        vin8=vin
-       call sum_real8(vin8,nsize) 
+       call sum_real8(vin8,nsize)
        vin=vin8
     end subroutine sum_real1d
 
@@ -2021,7 +2061,7 @@ MODULE MODULE_MPP_LAND
        implicit none
        integer nsize,i,j,tag,ierr
        real*8, dimension(nsize):: vin,recv
-       real, dimension(nsize):: v 
+       real, dimension(nsize):: v
        tag = 319
        if(my_id .eq. IO_id) then
           do i = 0, numprocs - 1
@@ -2036,7 +2076,7 @@ MODULE MODULE_MPP_LAND
              call mpi_send(vin,nsize,MPI_DOUBLE_PRECISION,IO_id,   &
                   tag,HYDRO_COMM_WORLD,ierr)
        endif
-       call mpp_land_bcast_real(nsize,v) 
+       call mpp_land_bcast_real(nsize,v)
        vin = v
        return
     end subroutine sum_real8
@@ -2068,41 +2108,41 @@ MODULE MODULE_MPP_LAND
     s = s_in
     e = e_in
 
-    if(my_id .eq. IO_id) then 
+    if(my_id .eq. IO_id) then
         vg(s:e) = vl
     end if
 
      index_s(1) = s
      index_s(2) = e
-     size = e - s + 1 
+     size = e - s + 1
 
     if(my_id .eq. IO_id) then
-         do i = 0, numprocs - 1 
+         do i = 0, numprocs - 1
               if(i .ne. my_id) then
                  !block receive  from other node.
                  tag = 202
-                 call mpi_recv(index_s,2,MPI_INTEGER,i, & 
+                 call mpi_recv(index_s,2,MPI_INTEGER,i, &
                       tag,HYDRO_COMM_WORLD,mpp_status,ierr)
 
                  tag = 203
                  e = index_s(2)
                  s = index_s(1)
-                 size = e - s + 1 
+                 size = e - s + 1
                  call mpi_recv(vg(s:e),size,MPI_REAL,  &
                     i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
               endif
          end do
-     else 
+     else
            tag =  202
            call mpi_send(index_s,2,MPI_INTEGER, IO_id,     &
                tag,HYDRO_COMM_WORLD,ierr)
 
-           tag =  203  
+           tag =  203
            call mpi_send(vl,size,MPI_REAL,IO_id,   &
                tag,HYDRO_COMM_WORLD,ierr)
      end if
 
-     return 
+     return
   end  subroutine gather_1d_real_tmp
 
   subroutine sum_real1(inout)
@@ -2111,7 +2151,7 @@ MODULE MODULE_MPP_LAND
       integer :: ierr
       send = inout
       CALL MPI_ALLREDUCE(send,inout,1,MPI_REAL,MPI_SUM,HYDRO_COMM_WORLD,ierr)
-  end subroutine sum_real1 
+  end subroutine sum_real1
 
   subroutine sum_double(inout)
       implicit none
@@ -2127,7 +2167,7 @@ MODULE MODULE_MPP_LAND
        implicit none
        integer :: nlinks
        integer :: i, ierr, status, tag
-       allocate(mpp_nlinks(numprocs),stat = status) 
+       allocate(mpp_nlinks(numprocs),stat = status)
                  tag = 138
        mpp_nlinks = 0
        if(my_id .eq. IO_id) then
@@ -2144,7 +2184,7 @@ MODULE MODULE_MPP_LAND
                tag,HYDRO_COMM_WORLD,ierr)
        endif
 
-     
+
   end subroutine mpp_chrt_nlinks_collect
 
      subroutine  getLocalXY(ix,jx,startx,starty,endx,endy)
@@ -2181,9 +2221,9 @@ MODULE MODULE_MPP_LAND
         integer :: unit
         real :: inVar(:,:)
         real :: g_var(global_nx,global_ny)
-        call write_io_real(inVar,g_var) 
+        call write_io_real(inVar,g_var)
         if(my_id .eq. IO_id) then
-           write(unit,*) g_var 
+           write(unit,*) g_var
            call flush(unit)
         endif
      end subroutine check_landreal2d
@@ -2195,7 +2235,7 @@ MODULE MODULE_MPP_LAND
         real :: g_var(global_nx,global_ny)
         klevel = size(inVar,2)
         do k = 1, klevel
-           call write_io_real(inVar(:,k,:),g_var) 
+           call write_io_real(inVar(:,k,:),g_var)
            if(my_id .eq. IO_id) then
               write(unit,*) g_var
               call flush(unit)
@@ -2226,7 +2266,7 @@ MODULE MODULE_MPP_LAND
        endif
        call mpp_land_sync()
        call mpp_land_bcast_int1d(vinout)
-    
+
   end subroutine mpp_collect_1d_int
 
   subroutine mpp_collect_1d_int_mem(nlinks,vinout)
@@ -2260,14 +2300,14 @@ MODULE MODULE_MPP_LAND
             end if
           end do
           if(allocated(tmpBuf)) deallocate(tmpBuf)
-       else 
+       else
            lsize = 0
            do k = 1, nlinks
                if(vinout(k) .gt. 0) then
                   lsize = lsize + 1
-                  tmpIn(lsize) = k        
+                  tmpIn(lsize) = k
                end if
-           end do 
+           end do
            tag = 120
            call mpi_send(lsize,1,MPI_INTEGER, IO_id,     &
                  tag,HYDRO_COMM_WORLD,ierr)
@@ -2279,7 +2319,7 @@ MODULE MODULE_MPP_LAND
        endif
        call mpp_land_sync()
        call mpp_land_bcast_int1d(vinout)
-   
+
   end subroutine mpp_collect_1d_int_mem
 
      subroutine updateLake_seqInt(in,nsize,in0)
@@ -2300,14 +2340,14 @@ MODULE MODULE_MPP_LAND
             if(i .ne. IO_id) then
                call mpi_recv(tmp,nsize,&
                    MPI_INTEGER,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
-               do k = 1, nsize 
+               do k = 1, nsize
                   if(in0(k) .ne. tmp(k)) in(k) = tmp(k)
                end do
             end if
           end do
        end if
        call mpp_land_bcast_int1d(in)
-     
+
      end subroutine updateLake_seqInt
 
      subroutine updateLake_seq(in,nsize,in0)
@@ -2328,15 +2368,47 @@ MODULE MODULE_MPP_LAND
             if(i .ne. IO_id) then
                call mpi_recv(tmp,nsize,&
                    MPI_REAL,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
-               do k = 1, nsize 
+               do k = 1, nsize
                   if(in0(k) .ne. tmp(k)) in(k) = tmp(k)
                end do
             end if
           end do
        end if
        call mpp_land_bcast_real_1d(in)
-     
+
      end subroutine updateLake_seq
+
+
+     subroutine updateLake_seq_char(in,nsize,in0)
+       implicit none
+       integer :: nsize
+       character(len=256), dimension(nsize) :: in
+       character(len=256), dimension(nsize) :: tmp
+       character(len=256), dimension(:) :: in0
+       integer tag, i, status, ierr, k, in_len
+       if(nsize .le. 0) return
+
+       in_len = size(in, 1)*len(in)
+
+       tag = 29
+       if(my_id .ne. IO_id) then
+          call mpi_send(in,in_len,MPI_CHARACTER, IO_id,     &
+                tag,HYDRO_COMM_WORLD,ierr)
+       else
+          do i = 0, numprocs - 1
+            if(i .ne. IO_id) then
+               call mpi_recv(tmp,in_len,&
+                   MPI_CHARACTER,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+               do k = 1, nsize
+                  if(in0(k) .ne. tmp(k)) in(k) = tmp(k)
+               end do
+            end if
+          end do
+       end if
+       call mpp_land_bcast_char1d(in)
+
+     end subroutine updateLake_seq_char
+
 
      subroutine updateLake_grid(in,nsize,lake_index)
        implicit none
@@ -2363,14 +2435,14 @@ MODULE MODULE_MPP_LAND
                tag = 30
                call mpi_recv(lake_index,nsize,&
                    MPI_INTEGER,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
-               do k = 1, nsize 
+               do k = 1, nsize
                   if(lake_index(k) .gt. 0) in(k) = tmp(k)
                end do
             end if
           end do
        end if
        call mpp_land_bcast_real_1d(in)
-     
+
      end subroutine updateLake_grid
 
 
@@ -2388,14 +2460,14 @@ MODULE MODULE_MPP_LAND
              if(i .ne. my_id) then
                call mpi_recv(recv,nsize,MPI_INTEGER,i,  &
                     tag,HYDRO_COMM_WORLD,mpp_status,ierr)
-               do k = 1, nsize 
+               do k = 1, nsize
                  if(recv(k) .eq. flag) vin(k) = flag
                  if(vin(k) .ne. flag) then
                    if(vin(k) .gt. 0 .and. recv(k) .gt. 0) then
                        vin(k) = flag
                    else
                        if(recv(k) .gt. 0) vin(k) = recv(k)
-                   endif 
+                   endif
                  endif
                end do
              endif
@@ -2403,9 +2475,9 @@ MODULE MODULE_MPP_LAND
        else
              call mpi_send(vin,nsize,MPI_INTEGER,IO_id,   &
                   tag,HYDRO_COMM_WORLD,ierr)
-       endif   
+       endif
        call mpp_land_bcast_int1d(vin)
-       return  
+       return
     end subroutine match1dLake
 
         subroutine mpp_land_abort()
@@ -2428,7 +2500,7 @@ MODULE MODULE_MPP_LAND
     real,    intent(inout) :: scalar
     integer, intent(in)    :: fromImage, toImage
     integer:: ierr, tag
-    tag=2   
+    tag=2
     if(my_id .eq. fromImage) &
          call mpi_send(scalar, 1, MPI_REAL, &
                        toImage, tag, HYDRO_COMM_WORLD, ierr)
@@ -2452,14 +2524,14 @@ MODULE MODULE_MPP_LAND
                        fromImage, tag, HYDRO_COMM_WORLD, mpp_status, ierr)
     end subroutine mpp_comm_scalar_char
 
-    
+
     subroutine mpp_comm_1d_real(vector, fromImage, toImage)
     implicit none
     real,    dimension(:), intent(inout) :: vector
     integer,               intent(in)    :: fromImage, toImage
     integer:: ierr, tag
     integer:: my_id,numprocs
-    tag=2   
+    tag=2
     call MPI_COMM_RANK(HYDRO_COMM_WORLD,my_id,ierr)
     call MPI_COMM_SIZE(HYDRO_COMM_WORLD,numprocs,ierr)
     if(numprocs > 1) then
@@ -2493,7 +2565,7 @@ MODULE MODULE_MPP_LAND
     endif
     end subroutine mpp_comm_1d_char
 
-    
+
 END MODULE MODULE_MPP_LAND
 
 

--- a/trunk/NDHMS/Routing/Reservoirs/Level_Pool/module_levelpool.F
+++ b/trunk/NDHMS/Routing/Reservoirs/Level_Pool/module_levelpool.F
@@ -145,7 +145,8 @@ contains
     ! which will then call the LEVELPOOL method/subroutine for processing the
     ! inputs and returning the output.
     subroutine run_levelpool_reservoir(this, previous_timestep_inflow, inflow, &
-        lateral_inflow, water_elevation, outflow, routing_period, dynamic_reservoir_type)
+        lateral_inflow, water_elevation, outflow, routing_period, dynamic_reservoir_type, &
+        assimilated_value, assimilated_source_file)
         implicit none
         class(levelpool), intent(inout) :: this
         real, intent(in)    :: previous_timestep_inflow ! cubic meters per second (cms)
@@ -155,6 +156,9 @@ contains
         real, intent(out)   :: outflow                  ! cubic meters per second (cms)
         real, intent(in)    :: routing_period           ! seconds
         integer, intent(out):: dynamic_reservoir_type   ! dynamic reservoir type sent to lake out files
+        real, intent(out)   :: assimilated_value        ! value assimilated from observation or forecast
+        character(len=256), intent(out) :: assimilated_source_file ! source file of assimilated value
+
 
         ! Update input variables
         this%input%inflow = inflow
@@ -193,6 +197,13 @@ contains
         ! The dynamic reservoir type is always set to 1 for level pool in this module because
         ! it cannot change reservoir types
         dynamic_reservoir_type = 1
+
+        ! The assimilated value would always be a sentinel of -9999.0 because level pool does
+        ! not assimilate any external observations or forecasts
+        assimilated_value = -9999.0
+
+        ! The assimilated source file would always be an empty string
+        assimilated_source_file = ""
 
 #ifdef RESERVOIR_D
         ! Log diagnostic data only for development/debugging purposes

--- a/trunk/NDHMS/Routing/Reservoirs/Persistence_Level_Pool_Hybrid/module_persistence_levelpool_hybrid.F
+++ b/trunk/NDHMS/Routing/Reservoirs/Persistence_Level_Pool_Hybrid/module_persistence_levelpool_hybrid.F
@@ -215,7 +215,8 @@ contains
 
     ! Subroutine for running reservoir for a hybrid reservoir
     subroutine run_hybrid_reservoir(this, previous_timestep_inflow, inflow, &
-        lateral_inflow, water_elevation, outflow, routing_period, dynamic_reservoir_type)
+        lateral_inflow, water_elevation, outflow, routing_period, dynamic_reservoir_type, &
+        assimilated_value, assimilated_source_file)
         implicit none
         class(persistence_levelpool_hybrid), intent(inout) :: this
         real, intent(in)    :: previous_timestep_inflow ! cubic meters per second (cms)
@@ -225,6 +226,8 @@ contains
         real, intent(out)   :: outflow                  ! cubic meters per second (cms)
         real, intent(in)    :: routing_period           ! seconds
         integer, intent(out):: dynamic_reservoir_type   ! dynamic reservoir type sent to lake out files
+        real, intent(out)   :: assimilated_value        ! value assimilated from observation
+        character(len=256), intent(out) :: assimilated_source_file ! source file of assimilated value
         real                :: delta_storage            ! timestep change in storage (cubic meters)
         real                :: local_water_elevation    ! water elevation passed to levelpool (meters AMSL)
         real                :: levelpool_outflow        ! cubic meters per second (cms)
@@ -270,7 +273,8 @@ contains
 
             ! Read new timeslice gage discharges
             call this%timeslice_data%setup_read_timeslice(this%properties%observation_update_time_interval_seconds, &
-            this%state%current_time, this%properties%gage_id, gage_lookback_seconds, this%state%gage_discharge)
+            this%state%current_time, this%properties%gage_id, gage_lookback_seconds, this%state%gage_discharge, &
+            this%state%assimilated_source_file)
 
             ! If no good quality gage discharge was found in the given lookback period, the gage discharge is returned
             ! as -1.0. The persistence weight index will be set out of bounds larger than the array. This causes the
@@ -299,6 +303,9 @@ contains
 
                 ! Set persisted outflow to gage discharge
                 this%state%persisted_outflow = this%state%gage_discharge
+
+                ! Set assimilated value to gage discharge
+                this%state%assimilated_value = this%state%gage_discharge
 
                 ! Start persistence weight index at 1
                 this%state%persistence_weight_index = 1
@@ -350,13 +357,20 @@ contains
         ! calculations.
         ! Run levelpool reservoir
         call this%state%levelpool_ptr%run(previous_timestep_inflow, inflow, &
-        lateral_inflow, local_water_elevation, levelpool_outflow, routing_period, this%state%levelpool_reservoir_type)
+        lateral_inflow, local_water_elevation, levelpool_outflow, routing_period, this%state%levelpool_reservoir_type, &
+        this%state%levelpool_assimilated_value, this%state%levelpool_assimilated_source_file)
 
         ! If the levelpool weight is within epsilon of 1.0
         if (this%state%levelpool_current_weight .ge. 1.0 - epsilon(1.0)) then
 
             ! Set dynamic_reservoir_type to levelpool type
             this%state%dynamic_reservoir_type = this%state%levelpool_reservoir_type
+
+            ! Set the assimilated_value to sentinel, -9999.0
+            this%state%assimilated_value = -9999.0
+
+            ! Set the assimilated_source_file to empty string
+            this%state%assimilated_source_file = ""
         else
 
             ! Set dynamic_reservoir_type to given USGS or USACE type
@@ -383,6 +397,12 @@ contains
 
             ! Set dynamic_reservoir_type to levelpool type
             this%state%dynamic_reservoir_type = this%state%levelpool_reservoir_type
+
+            ! Set the assimilated_value to sentinel, -9999.0
+            this%state%assimilated_value = -9999.0
+
+            ! Set the assimilated_source_file to empty string
+            this%state%assimilated_source_file = ""
         end if
 
         ! Calculate change in storage
@@ -406,6 +426,12 @@ contains
 
         ! Update the dynamic_reservoir_type returned from this subroutine
         dynamic_reservoir_type = this%state%dynamic_reservoir_type
+
+        ! Update the assimilated_value returned from this subroutine
+        assimilated_value = this%state%assimilated_value
+
+        ! Update the assimilated_source_file returned from this subroutine
+        assimilated_source_file = this%state%assimilated_source_file
 
         ! Update the current time
         this%state%current_time = this%state%current_time + int(routing_period)

--- a/trunk/NDHMS/Routing/Reservoirs/Persistence_Level_Pool_Hybrid/module_persistence_levelpool_hybrid_state.F
+++ b/trunk/NDHMS/Routing/Reservoirs/Persistence_Level_Pool_Hybrid/module_persistence_levelpool_hybrid_state.F
@@ -25,7 +25,11 @@ module module_persistence_levelpool_hybrid_state
         real    :: levelpool_current_weight
         real    :: persistence_current_weight
         integer :: dynamic_reservoir_type       ! dynamic reservoir type sent to lake out files
+        real    :: assimilated_value
+        character(len=256) :: assimilated_source_file
         integer :: levelpool_reservoir_type     ! reservoir type for levelpool
+        real    :: levelpool_assimilated_value  ! levelpool assimilated sentinel value
+        character(len=256) :: levelpool_assimilated_source_file ! none for levelpool assimilated source
 
         type (levelpool), pointer :: levelpool_ptr   ! pointer to levelpool object
 
@@ -77,8 +81,20 @@ contains
             this%dynamic_reservoir_type = 3
         end if
 
+        ! Initialize to default sentinel, -9999.0
+        this%assimilated_value = -9999.0
+
+        ! Initialize to default empty string
+        this%assimilated_source_file = ""
+
         ! Levelpool reservoir type set to 1
         this%levelpool_reservoir_type = 1
+
+        ! Set to default sentinel, -999.0
+        this%levelpool_assimilated_value = -9999.0
+
+        ! Set to default string
+        this%levelpool_assimilated_source_file = ""
 
     end subroutine hybrid_state_init
 

--- a/trunk/NDHMS/Routing/Reservoirs/RFC_Forecasts/module_rfc_forecasts.F
+++ b/trunk/NDHMS/Routing/Reservoirs/RFC_Forecasts/module_rfc_forecasts.F
@@ -167,6 +167,9 @@ contains
         ! If the forecast was found and returned a discharge array
         if (this%state%forecast_found) then
 
+            ! Set the assimilated_source_file
+            this%state%assimilated_source_file = this%properties%time_series_file_name
+
             ! Use modulo to calculate the offset seconds in between the hourly time-step to set the update time
             ! for shifting values in the discharge array.
             update_offset_seconds = mod(this%properties%lookback_seconds, this%properties%time_step_seconds)
@@ -198,7 +201,8 @@ contains
 
     ! Subroutine for running reservoir for a rfc forecasts reservoir
     subroutine run_rfc_forecasts_reservoir(this, previous_timestep_inflow, inflow, &
-        lateral_inflow, water_elevation, outflow, routing_period, dynamic_reservoir_type)
+        lateral_inflow, water_elevation, outflow, routing_period, dynamic_reservoir_type, &
+        assimilated_value, assimilated_source_file)
         implicit none
         class(rfc_forecasts), intent(inout) :: this
         real, intent(in)    :: previous_timestep_inflow ! cubic meters per second (cms)
@@ -208,6 +212,8 @@ contains
         real, intent(out)   :: outflow                  ! cubic meters per second (cms)
         real, intent(in)    :: routing_period           ! seconds
         integer, intent(out):: dynamic_reservoir_type   ! dynamic reservoir type sent to lake out files
+        real, intent(out)   :: assimilated_value        ! value assimilated from observation or forecast
+        character(len=256), intent(out) :: assimilated_source_file ! source file of assimilated value
         real                :: levelpool_outflow        ! cubic meters per second (cms)
         integer		        :: missing_outflow_index
         character(len=15)   :: lake_number_string
@@ -272,7 +278,8 @@ contains
 
         ! Run levelpool reservoir
         call this%state%levelpool_ptr%run(previous_timestep_inflow, inflow, &
-        lateral_inflow, this%state%water_elevation, levelpool_outflow, routing_period, this%state%levelpool_reservoir_type)
+        lateral_inflow, this%state%water_elevation, levelpool_outflow, routing_period, this%state%levelpool_reservoir_type, &
+        this%state%levelpool_assimilated_value, this%state%levelpool_assimilated_source_file)
 
         ! Check if Routing Period is greater than 1 hour, and if true, set forecast_found to false.
         if (routing_period .gt. 3600) then
@@ -306,6 +313,9 @@ contains
             ! Set dynamic_reservoir_type to RFC Forecasts Type
             this%state%dynamic_reservoir_type = this%properties%reservoir_type
 
+            ! Set the assimilated_value to corresponding discharge from array
+            this%state%assimilated_value = this%state%discharges(this%state%time_series_index)
+
             ! Check for outflows less than 0 and cycle backwards in the array until a
             ! non-negative value is found. If all previous values are negative, then
             ! use level pool outflow.
@@ -323,6 +333,12 @@ contains
 
                     ! Set dynamic_reservoir_type to levelpool type
                     this%state%dynamic_reservoir_type = this%state%levelpool_reservoir_type
+
+                    ! Set the assimilated_value to sentinel, -9999.0
+                    this%state%assimilated_value = -9999.0
+
+                    ! Set the assimilated_source_file to empty string
+                    this%state%assimilated_source_file = ""
                 end if
 
             end if
@@ -332,6 +348,12 @@ contains
 
             ! Set dynamic_reservoir_type to levelpool type
             this%state%dynamic_reservoir_type = this%state%levelpool_reservoir_type
+
+            ! Set the assimilated_value to sentinel, -9999.0
+            this%state%assimilated_value = -9999.0
+
+            ! Set the assimilated_source_file to empty string
+            this%state%assimilated_source_file = ""
         end if
 
         ! Update output variable returned from this subroutine
@@ -345,6 +367,12 @@ contains
 
         ! Update the dynamic_reservoir_type returned from this subroutine
         dynamic_reservoir_type = this%state%dynamic_reservoir_type
+
+        ! Update the assimilated_value returned from this subroutine
+        assimilated_value = this%state%assimilated_value
+
+        ! Update the assimilated_source_file returned from this subroutine
+        assimilated_source_file = this%state%assimilated_source_file
 
 #ifdef RESERVOIR_D
         ! Log diagnostic data only for development/debugging purposes

--- a/trunk/NDHMS/Routing/Reservoirs/RFC_Forecasts/module_rfc_forecasts_state.F
+++ b/trunk/NDHMS/Routing/Reservoirs/RFC_Forecasts/module_rfc_forecasts_state.F
@@ -14,16 +14,20 @@ module module_rfc_forecasts_state
     ! Extend/derive rfc forecasts state from the abstract base
     ! type for reservoir state.
     type, extends(reservoir_state) :: rfc_forecasts_state_interface
-        real                               :: water_elevation              ! meters AMSL
+        real                               :: water_elevation       ! meters AMSL
         real, allocatable, dimension(:)    :: discharges
         logical, allocatable, dimension(:) :: synthetic_values
-        integer                         :: time_series_update_time      ! seconds
-        integer                         :: current_time                 ! seconds
+        integer                         :: time_series_update_time  ! seconds
+        integer                         :: current_time             ! seconds
         integer                         :: time_series_index
         logical                         :: forecast_found
         logical                         :: all_discharges_synthetic
-        integer                         :: dynamic_reservoir_type       ! dynamic reservoir type sent to lake out files
-        integer                         :: levelpool_reservoir_type     ! reservoir type for levelpool
+        integer                         :: dynamic_reservoir_type    ! dynamic reservoir type sent to lake out files
+        real                            :: assimilated_value
+        character(len=256)              :: assimilated_source_file
+        integer                         :: levelpool_reservoir_type    ! reservoir type for levelpool
+        real                            :: levelpool_assimilated_value ! levelpool assimilated sentinel value
+        character(len=256)              :: levelpool_assimilated_source_file ! empty string for levelpool assimilated source
 
         type (levelpool), pointer :: levelpool_ptr   ! pointer to levelpool object
 
@@ -57,8 +61,20 @@ contains
         ! Initialize dynamic_reservoir_type to 4 for RFC type reservoir
         this%dynamic_reservoir_type = 4
 
+        ! Initialize to default sentinel, -9999.0
+        this%assimilated_value = -9999.0
+
+        ! Initialize to default empty string
+        this%assimilated_source_file = ""
+
         ! Levelpool reservoir type set to 1
         this%levelpool_reservoir_type = 1
+
+        ! Set to default sentinel, -999.0
+        this%levelpool_assimilated_value = -9999.0
+
+        ! Set to default string
+        this%levelpool_assimilated_source_file = ""
 
     end subroutine rfc_forecasts_state_init
 

--- a/trunk/NDHMS/Routing/Reservoirs/module_reservoir.F
+++ b/trunk/NDHMS/Routing/Reservoirs/module_reservoir.F
@@ -92,7 +92,8 @@ module module_reservoir
     ! inputs and outputs.
     abstract interface
         subroutine run_reservoir_interface(this, previous_timestep_inflow, inflow, &
-            lateral_inflow, water_elevation, outflow, routing_period, dynamic_reservoir_type)
+            lateral_inflow, water_elevation, outflow, routing_period, dynamic_reservoir_type, &
+            assimilated_value, assimilated_source_file)
             import reservoir
             class(reservoir), intent(inout) :: this
             real, intent(in)    :: previous_timestep_inflow ! cubic meters per second (cms)
@@ -102,6 +103,8 @@ module module_reservoir
             real, intent(out)   :: outflow                  ! cubic meters per second (cms)
             real, intent(in)    :: routing_period           ! seconds
             integer, intent(out):: dynamic_reservoir_type   ! dynamic reservoir type sent to lake out files
+            real, intent(out)   :: assimilated_value        ! value assimilated from observation or forecast
+            character(len=256), intent(out) :: assimilated_source_file ! source file of assimilated value
 
         end subroutine run_reservoir_interface
 

--- a/trunk/NDHMS/Routing/Reservoirs/module_reservoir_read_rfc_time_series_data.F
+++ b/trunk/NDHMS/Routing/Reservoirs/module_reservoir_read_rfc_time_series_data.F
@@ -176,7 +176,7 @@ contains
                 ! Call subroutine to read a particular time series file
                 call this%read_time_series_file(time_series_file_name)
 
-                this%time_series_file_name = old_date_trimmed // "/" //  "." // &
+                this%time_series_file_name = old_date_trimmed // "." // &
                             forecast_file_resolution_string // 'min.' // this%rfc_gage_id // '.RFCTimeSeries.ncdf'
 
                 exit

--- a/trunk/NDHMS/Routing/Reservoirs/module_reservoir_read_timeslice_data.F
+++ b/trunk/NDHMS/Routing/Reservoirs/module_reservoir_read_timeslice_data.F
@@ -139,9 +139,10 @@ contains
 
         this%last_update_time_seconds = -999
 
-        ! Allocate lookback and dishcharge arrays
+        ! Allocate lookback, dishcharge, and timeslice name arrays
         allocate (this%gage_lookback_seconds(this%number_of_reservoir_gages))
         allocate (this%reservoir_gage_discharges(this%number_of_reservoir_gages))
+        allocate(this%timeslice_file_names(this%number_of_reservoir_gages))
 
     end subroutine timeslice_data_init
 
@@ -158,7 +159,7 @@ contains
     ! Set up list of timeslice files to read
     ! The timeslices are read only once on each processor at each timeslice update time
     subroutine setup_read_timeslice(this, update_interval_seconds, current_reservoir_time_seconds, &
-        reservoir_gage_id, gage_lookback_seconds, reservoir_gage_discharge)
+        reservoir_gage_id, gage_lookback_seconds, reservoir_gage_discharge, reservoir_timeslice_file_name)
         implicit none
 
         class(timeslice_data_type), intent(inout) :: this
@@ -167,7 +168,9 @@ contains
         character(len=*), intent(in)  :: reservoir_gage_id
         integer, intent(out) :: gage_lookback_seconds
         real, intent(out)    :: reservoir_gage_discharge
+        character(len=256), intent(out)   :: reservoir_timeslice_file_name
         character(len=256)   :: timeslice_file_name
+        character(len=256)   :: timeslice_file_name_full
         character(len=19)    :: old_date, new_date
         character(len=2)     :: observation_resolution_string
         integer :: total_timeslice_time_periods, timeslice_file_index, reservoir_subset_index, lake_index
@@ -176,6 +179,7 @@ contains
 
         ! This check ensures that the timeslice is read only once for each processor at each timeslice update time
         if (current_reservoir_time_seconds .ne. this%last_update_time_seconds) then
+
             ! Checks if not the first timestep, then update date.
             if (this%last_update_time_seconds .ne. -999) then
                 call geth_newdate(this%current_date, this%current_date, update_interval_seconds)
@@ -189,12 +193,10 @@ contains
             this%gage_lookback_seconds = 0
             this%current_lookback_seconds = 0
 
-            total_timeslice_time_periods = this%observation_lookback_hours * (60 / observation_resolution_minutes)
+            ! Set timeslice file names to empty strings by default
+            this%timeslice_file_names = ""
 
-            ! Allocate array of all timeslice files to potentially read
-            if ( .not. allocated(this%timeslice_file_names) ) then
-                allocate(this%timeslice_file_names(total_timeslice_time_periods))
-            end if
+            total_timeslice_time_periods = this%observation_lookback_hours * (60 / observation_resolution_minutes)
 
             old_date = this%current_date
 
@@ -228,15 +230,18 @@ contains
                 ! time timeslice file available.
                 if ( any(this%reservoir_gage_discharges == -1.0)) then
 
-                    ! Construct timeslice filename with path
-                    timeslice_file_name = trim(this%timeslice_path) // '/' // old_date // "." // &
+                    ! Construct timeslice filename
+                    timeslice_file_name = old_date // "." // &
                             observation_resolution_string // 'min.' // ADJUSTL(trim(this%data_source)) // 'TimeSlice.ncdf'
 
+                    ! Add path to timeslice filename
+                    timeslice_file_name_full = trim(this%timeslice_path) // "/" // ADJUSTL(trim(timeslice_file_name))
+
                     ! Check if file exists
-                    inquire(FILE = timeslice_file_name, EXIST = file_exists)
+                    inquire(FILE = timeslice_file_name_full, EXIST = file_exists)
                     if (file_exists) then
                         ! Call subroutine to read a particular timeslice file
-                        call this%read_timeslice_file(timeslice_file_name)
+                        call this%read_timeslice_file(timeslice_file_name_full, timeslice_file_name)
                     end if
 
                     ! Call subroutine to get the date from one observation resolution back in time
@@ -258,6 +263,7 @@ contains
             if (this%reservoir_gage_ids(reservoir_subset_index) .eq. reservoir_gage_id) then
                 gage_lookback_seconds = this%gage_lookback_seconds(reservoir_subset_index)
                 reservoir_gage_discharge = this%reservoir_gage_discharges(reservoir_subset_index)
+                reservoir_timeslice_file_name = this%timeslice_file_names(reservoir_subset_index)
             end if
         end do
 
@@ -265,20 +271,21 @@ contains
 
 
     ! Read given timeslice file to get gage discharges
-    subroutine read_timeslice_file(this, timeslice_file)
+    subroutine read_timeslice_file(this, timeslice_file_full, timeslice_file)
         implicit none
         class(timeslice_data_type), intent(inout) :: this
+        character(len=256), intent(in) :: timeslice_file_full
         character(len=256), intent(in) :: timeslice_file
         integer :: reservoir_gage_index, timeslice_gage_index, number_of_gages
         integer :: ncid, status
 
         ! Open Timeslice NetCDF file
-        status = nf90_open(path = trim(timeslice_file), mode = nf90_nowrite, ncid = ncid)
+        status = nf90_open(path = trim(timeslice_file_full), mode = nf90_nowrite, ncid = ncid)
         if (status /= nf90_noerr) call handle_err(status, "Could not open timeslice file " &
-        // trim(ADJUSTL(timeslice_file)) // ".")
+        // trim(ADJUSTL(timeslice_file_full)) // ".")
 
         ! Get dimension of gage arrays
-        call get_timeslice_array_dimension(ncid, 'discharge', timeslice_file, number_of_gages)
+        call get_timeslice_array_dimension(ncid, 'discharge', timeslice_file_full, number_of_gages)
 
         ! Allocate gage info arrays
         allocate(this%gage_id(number_of_gages))
@@ -286,13 +293,13 @@ contains
         allocate(this%gage_quality(number_of_gages))
 
         ! Get gage ids
-        call read_timeslice_gage_ids(ncid, 'stationId', timeslice_file, this%gage_id)
+        call read_timeslice_gage_ids(ncid, 'stationId', timeslice_file_full, this%gage_id)
 
         ! Get gage discharges
-        call read_timeslice_netcdf_real_1D_variables(ncid, 'discharge', timeslice_file, this%gage_discharge)
+        call read_timeslice_netcdf_real_1D_variables(ncid, 'discharge', timeslice_file_full, this%gage_discharge)
 
         ! Get gage qualities
-        call read_timeslice_netcdf_real_1D_variables(ncid, 'discharge_quality', timeslice_file, this%gage_quality)
+        call read_timeslice_netcdf_real_1D_variables(ncid, 'discharge_quality', timeslice_file_full, this%gage_quality)
 
         ! Normalize gage qualities to 1
         this%gage_quality = this%gage_quality/100
@@ -327,6 +334,7 @@ contains
                         if (this%gage_quality(timeslice_gage_index) .gt. gage_quality_threshold) then
                             this%reservoir_gage_discharges(reservoir_gage_index) = this%gage_discharge(timeslice_gage_index)
                             this%gage_lookback_seconds(reservoir_gage_index) = this%current_lookback_seconds
+                            this%timeslice_file_names(reservoir_gage_index) = ADJUSTL(trim(timeslice_file))
                         end if
                         exit
                     end if
@@ -336,7 +344,7 @@ contains
 
     ! Close timeslice NetCDF file
     status = nf90_close(ncid)
-    if (status /= nf90_noerr) call handle_err(status, "Could not close timeslice file " // trim(ADJUSTL(timeslice_file)) // ".")
+    if (status /= nf90_noerr) call handle_err(status, "Could not close timeslice file " // trim(ADJUSTL(timeslice_file_full)) // ".")
 
     ! Deallocate gage arrays
     if(allocated(this%gage_id)) deallocate(this%gage_id)

--- a/trunk/NDHMS/Routing/Reservoirs/reservoir_tests.F
+++ b/trunk/NDHMS/Routing/Reservoirs/reservoir_tests.F
@@ -134,6 +134,8 @@ program reservoir_unit_tests
         integer :: timestep_count
         character*256 :: cwd_full
         integer :: dynamic_reservoir_type
+        real :: assimilated_value
+        character(len=256) :: assimilated_source_file
 
         prev_time_inflow = 0.0
         timestep_count = 0
@@ -175,7 +177,8 @@ program reservoir_unit_tests
 
             inflow = inflow_array(timestep_count)
             call persistence_levelpool_hybrid_reservoir_data%run(inflow, &
-            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type)
+            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type, &
+            assimilated_value, assimilated_source_file)
 
             prev_time_inflow = inflow
 
@@ -185,7 +188,9 @@ program reservoir_unit_tests
         print *, 'dynamic_reservoir_type: ', dynamic_reservoir_type
 
         if (outflow .ge. 13.73367 - epsilon(13.73367) .and. outflow .le. 13.73367 + epsilon(13.73367) &
-        .and. dynamic_reservoir_type == 2 ) then
+        .and. dynamic_reservoir_type == 2 .and. assimilated_value .ge. 13.73367 - epsilon(13.73367) &
+        .and. assimilated_value .le. 13.73367 + epsilon(13.73367) .and. &
+        assimilated_source_file == "2010-10-01_06:00:00.15min.usgsTimeSlice.ncdf") then
             rv2 = .true.
             print *, "========================================================================"
             print *, 'Persistence Levelpool Hybrid Run USGS Reservoir Test Passed'
@@ -223,6 +228,8 @@ program reservoir_unit_tests
         integer :: timestep_count
         character*256 :: cwd_full
         integer :: dynamic_reservoir_type
+        real :: assimilated_value
+        character(len=256) :: assimilated_source_file
 
         prev_time_inflow = 0.0
         timestep_count = 0
@@ -261,7 +268,8 @@ program reservoir_unit_tests
 
             inflow = inflow_array(timestep_count)
             call persistence_levelpool_hybrid_reservoir_data%run(inflow, &
-            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type)
+            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type, &
+            assimilated_value, assimilated_source_file)
 
             prev_time_inflow = inflow
 
@@ -271,7 +279,9 @@ program reservoir_unit_tests
         print *, 'dynamic_reservoir_type: ', dynamic_reservoir_type
 
         if (outflow .ge. 16.0820713 - epsilon(16.0820713) .and. outflow .le. 16.0820713 + epsilon(16.0820713) &
-        .and. dynamic_reservoir_type == 3) then
+        .and. dynamic_reservoir_type == 3 .and. assimilated_value .ge. 16.082071 - epsilon(16.082071) &
+        .and. assimilated_value .le. 16.082071 + epsilon(16.082071) .and. &
+        assimilated_source_file == "2016-10-10_00:00:00.15min.usaceTimeSlice.ncdf") then
             rv2 = .true.
             print *, "========================================================================"
             print *, 'Persistence Levelpool Hybrid Run USACE Reservoir Test Passed'
@@ -309,6 +319,8 @@ program reservoir_unit_tests
         integer :: timestep_count
         character*256 :: cwd_full
         integer :: dynamic_reservoir_type
+        real :: assimilated_value
+        character(len=256) :: assimilated_source_file
 
         prev_time_inflow = 0.0
         timestep_count = 0
@@ -348,7 +360,8 @@ program reservoir_unit_tests
 
             inflow = inflow_array(timestep_count)
             call persistence_levelpool_hybrid_reservoir_data%run(inflow, &
-            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type)
+            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type, &
+            assimilated_value, assimilated_source_file)
 
             prev_time_inflow = inflow
 
@@ -358,7 +371,9 @@ program reservoir_unit_tests
         print *, 'dynamic_reservoir_type: ', dynamic_reservoir_type
 
         if (outflow .ge. 229.226059 - epsilon(229.226059) .and. outflow .le. 229.226059 + epsilon(229.226059) &
-        .and. dynamic_reservoir_type == 1) then
+        .and. dynamic_reservoir_type == 1 .and. assimilated_value .ge. -9999.0 - epsilon(-9999.0) &
+        .and. assimilated_value .le. -9999.0 + epsilon(-9999.0) .and. &
+        assimilated_source_file == "") then
             rv2 = .true.
             print *, "========================================================================"
             print *, 'Persistence Levelpool Hybrid Run USACE Reservoir Overflow Max Height Test Passed'
@@ -396,6 +411,8 @@ program reservoir_unit_tests
         integer :: timestep_count
         character*256 :: cwd_full
         integer :: dynamic_reservoir_type
+        real :: assimilated_value
+        character(len=256) :: assimilated_source_file
 
         prev_time_inflow = 0.0
         timestep_count = 0
@@ -434,7 +451,8 @@ program reservoir_unit_tests
 
             inflow = inflow_array(timestep_count)
             call persistence_levelpool_hybrid_reservoir_data%run(inflow, &
-            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type)
+            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type, &
+            assimilated_value, assimilated_source_file)
 
             prev_time_inflow = inflow
 
@@ -444,7 +462,9 @@ program reservoir_unit_tests
         print *, 'dynamic_reservoir_type: ', dynamic_reservoir_type
 
         if (outflow .ge. 1.81549609 - epsilon(1.81549609) .and. outflow .le. 1.81549609 + epsilon(1.81549609) &
-        .and. dynamic_reservoir_type == 1) then
+        .and. dynamic_reservoir_type == 1 .and. assimilated_value .ge. -9999.0 - epsilon(-9999.0) &
+        .and. assimilated_value .le. -9999.0 + epsilon(-9999.0) .and. &
+        assimilated_source_file == "") then
             rv2 = .true.
             print *, "========================================================================"
             print *, 'Persistence Levelpool Hybrid Run USACE Reservoir No Timeslice Available Test Passed'
@@ -480,6 +500,8 @@ program reservoir_unit_tests
         real, dimension(108) :: inflow_array_overflow
         integer :: timestep_count
         integer :: dynamic_reservoir_type
+        real :: assimilated_value
+        character(len=256) :: assimilated_source_file
 
         rv = .false.
         prev_time_inflow = 0.0
@@ -521,7 +543,8 @@ program reservoir_unit_tests
 
         do timestep_count = 1, 108
             inflow = inflow_array_overflow(timestep_count)
-            call levelpool_reservoir_data%run(inflow, inflow, 0.0, water_elevation, outflow, 300.0, dynamic_reservoir_type)
+            call levelpool_reservoir_data%run(inflow, inflow, 0.0, water_elevation, outflow, 300.0, dynamic_reservoir_type, &
+            assimilated_value, assimilated_source_file)
 
             prev_time_inflow = inflow
 
@@ -531,7 +554,9 @@ program reservoir_unit_tests
         print *, 'dynamic_reservoir_type: ', dynamic_reservoir_type
 
         if (outflow .ge. 17.0451450 - epsilon(17.0451450) .and. outflow .le. 17.0451450 + epsilon(17.0451450) &
-        .and. dynamic_reservoir_type == 1) then
+        .and. dynamic_reservoir_type == 1 .and. assimilated_value .ge. -9999.0 - epsilon(-9999.0) &
+        .and. assimilated_value .le. -9999.0 + epsilon(-9999.0) .and. &
+        assimilated_source_file == "") then
             rv = .true.
             print *, "========================================================================"
             print *, 'Levelpool Overflow Max Height Test Passed'
@@ -640,6 +665,8 @@ program reservoir_unit_tests
         integer :: timestep_count
         character*256 :: cwd_full
         integer :: dynamic_reservoir_type
+        real :: assimilated_value
+        character(len=256) :: assimilated_source_file
 
         prev_time_inflow = 0.0
         timestep_count = 0
@@ -672,7 +699,8 @@ program reservoir_unit_tests
 
             inflow = inflow_array(timestep_count)
             call rfc_forecasts_reservoir_data%run(inflow, &
-            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type)
+            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type, &
+            assimilated_value, assimilated_source_file)
 
             prev_time_inflow = inflow
 
@@ -682,7 +710,9 @@ program reservoir_unit_tests
         print *, 'dynamic_reservoir_type: ', dynamic_reservoir_type
 
         if (outflow .ge. 1.81549609 - epsilon(1.81549609) .and. outflow .le. 1.81549609 + epsilon(1.81549609) &
-        .and. dynamic_reservoir_type == 1) then
+        .and. dynamic_reservoir_type == 1 .and. assimilated_value .ge. -9999.0 - epsilon(-9999.0) &
+        .and. assimilated_value .le. -9999.0 + epsilon(-9999.0) .and. &
+        assimilated_source_file == "") then
             rv = .true.
             print *, "========================================================================"
             print *, 'RFC Forecasts Levelpool Fallback Test Passed'
@@ -717,6 +747,8 @@ program reservoir_unit_tests
         integer :: timestep_count
         character*256 :: cwd_full
         integer :: dynamic_reservoir_type
+        real :: assimilated_value
+        character(len=256) :: assimilated_source_file
 
         prev_time_inflow = 0.0
         timestep_count = 0
@@ -748,7 +780,8 @@ program reservoir_unit_tests
 
             inflow = inflow_array(timestep_count)
             call rfc_forecasts_reservoir_data%run(inflow, &
-            inflow, 0.0, water_elevation, outflow, 3600.0, dynamic_reservoir_type)
+            inflow, 0.0, water_elevation, outflow, 3600.0, dynamic_reservoir_type, &
+            assimilated_value, assimilated_source_file)
 
             prev_time_inflow = inflow
 
@@ -757,7 +790,10 @@ program reservoir_unit_tests
 
         print *, 'dynamic_reservoir_type: ', dynamic_reservoir_type
 
-        if (outflow .ge. 3.6 - epsilon(3.6) .and. outflow .le. 3.6 + epsilon(3.6) .and. dynamic_reservoir_type == 4) then
+        if (outflow .ge. 3.6 - epsilon(3.6) .and. outflow .le. 3.6 + epsilon(3.6) .and. &
+        dynamic_reservoir_type == 4 .and. assimilated_value .ge. 3.6 - epsilon(3.6) &
+        .and. assimilated_value .le. 3.6 + epsilon(3.6) .and. &
+        assimilated_source_file == "2019-08-18_00.60min.CCHC1.RFCTimeSeries.ncdf") then
             rv = .true.
             print *, "========================================================================"
             print *, 'RFC Forecasts Time Series Output Test Passed'
@@ -790,6 +826,8 @@ program reservoir_unit_tests
         integer :: timestep_count
         character*256 :: cwd_full
         integer :: dynamic_reservoir_type
+        real :: assimilated_value
+        character(len=256) :: assimilated_source_file
 
         prev_time_inflow = 0.0
         timestep_count = 0
@@ -821,7 +859,8 @@ program reservoir_unit_tests
 
             inflow = inflow_array(timestep_count)
             call rfc_forecasts_reservoir_data%run(inflow, &
-            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type)
+            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type, &
+            assimilated_value, assimilated_source_file)
 
             prev_time_inflow = inflow
 
@@ -831,7 +870,9 @@ program reservoir_unit_tests
         print *, 'dynamic_reservoir_type: ', dynamic_reservoir_type
 
         if (outflow .ge. 1.81549609 - epsilon(1.81549609) .and. outflow .le. 1.81549609 + epsilon(1.81549609) &
-        .and. dynamic_reservoir_type == 1) then
+        .and. dynamic_reservoir_type == 1 .and. assimilated_value .ge. -9999.0 - epsilon(-9999.0) &
+        .and. assimilated_value .le. -9999.0 + epsilon(-9999.0) .and. &
+        assimilated_source_file == "") then
             rv = .true.
             print *, "========================================================================"
             print *, 'RFC Forecasts Time Series Output Negative Data Test Passed'
@@ -864,6 +905,8 @@ program reservoir_unit_tests
         integer :: timestep_count
         character*256 :: cwd_full
         integer :: dynamic_reservoir_type
+        real :: assimilated_value
+        character(len=256) :: assimilated_source_file
 
         prev_time_inflow = 0.0
         timestep_count = 0
@@ -895,7 +938,8 @@ program reservoir_unit_tests
 
             inflow = inflow_array(timestep_count)
             call rfc_forecasts_reservoir_data%run(inflow, &
-            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type)
+            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type, &
+            assimilated_value, assimilated_source_file)
 
             prev_time_inflow = inflow
 
@@ -905,7 +949,9 @@ program reservoir_unit_tests
         print *, 'dynamic_reservoir_type: ', dynamic_reservoir_type
 
         if (outflow .ge. 1.81549609 - epsilon(1.81549609) .and. outflow .le. 1.81549609 + epsilon(1.81549609) &
-        .and. dynamic_reservoir_type == 1) then
+        .and. dynamic_reservoir_type == 1 .and. assimilated_value .ge. -9999.0 - epsilon(-9999.0) &
+        .and. assimilated_value .le. -9999.0 + epsilon(-9999.0) .and. &
+        assimilated_source_file == "") then
             rv = .true.
             print *, "========================================================================"
             print *, 'RFC Forecasts Time Series Output All Synthetic Data Test Passed'
@@ -939,6 +985,8 @@ program reservoir_unit_tests
         integer :: timestep_count
         character*256 :: cwd_full
         integer :: dynamic_reservoir_type
+        real :: assimilated_value
+        character(len=256) :: assimilated_source_file
 
         prev_time_inflow = 0.0
         timestep_count = 0
@@ -970,7 +1018,8 @@ program reservoir_unit_tests
 
             inflow = inflow_array(timestep_count)
             call rfc_forecasts_reservoir_data%run(inflow, &
-            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type)
+            inflow, 0.0, water_elevation, outflow, 900.0, dynamic_reservoir_type, &
+            assimilated_value, assimilated_source_file)
 
             prev_time_inflow = inflow
 
@@ -980,7 +1029,9 @@ program reservoir_unit_tests
         print *, 'dynamic_reservoir_type: ', dynamic_reservoir_type
 
         if (outflow .ge. 1.81549609 - epsilon(1.81549609) .and. outflow .le. 1.81549609 + epsilon(1.81549609) &
-        .and. dynamic_reservoir_type == 1) then
+        .and. dynamic_reservoir_type == 1 .and. assimilated_value .ge. -9999.0 - epsilon(-9999.0) &
+        .and. assimilated_value .le. -9999.0 + epsilon(-9999.0) .and. &
+        assimilated_source_file == "") then
             rv = .true.
             print *, "========================================================================"
             print *, 'RFC Forecasts Time Series Output Data Exceeding Max Test Passed'
@@ -1015,6 +1066,8 @@ program reservoir_unit_tests
         integer :: timestep_count
         character*256 :: cwd_full
         integer :: dynamic_reservoir_type
+        real :: assimilated_value
+        character(len=256) :: assimilated_source_file
 
         prev_time_inflow = 0.0
         timestep_count = 0
@@ -1047,7 +1100,8 @@ program reservoir_unit_tests
 
             inflow = inflow_array(timestep_count)
             call rfc_forecasts_reservoir_data%run(inflow, &
-            inflow, 0.0, water_elevation, outflow, 3600.0, dynamic_reservoir_type)
+            inflow, 0.0, water_elevation, outflow, 3600.0, dynamic_reservoir_type, &
+            assimilated_value, assimilated_source_file)
 
             prev_time_inflow = inflow
 
@@ -1056,7 +1110,10 @@ program reservoir_unit_tests
 
         print *, 'dynamic_reservoir_type: ', dynamic_reservoir_type
 
-        if (outflow .ge. 7.8 - epsilon(7.8) .and. outflow .le. 7.8 + epsilon(7.8) .and. dynamic_reservoir_type == 4) then
+        if (outflow .ge. 7.8 - epsilon(7.8) .and. outflow .le. 7.8 + epsilon(7.8) &
+        .and. dynamic_reservoir_type == 4 .and. assimilated_value .ge. 7.8 - epsilon(7.8) &
+        .and. assimilated_value .le. 7.8 + epsilon(7.8) .and. &
+        assimilated_source_file == "2019-12-19_05.60min.CCHC1.RFCTimeSeries.ncdf") then
             rv = .true.
             print *, "========================================================================"
             print *, 'RFC Forecasts Time Series Output For Extended AnA Test Passed'

--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -1875,7 +1875,7 @@ subroutine output_rt_NWM(domainId,iGrid)
                        nlst(domainId)%olddate(15:16), igrid
 
    if(myId .eq. 0) then
-      ! Create output NetCDF file for writing. 
+      ! Create output NetCDF file for writing.
       iret = nf90_create(trim(output_flnm),cmode=NF90_NETCDF4,ncid = ftn)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create RT_DOMAIN NetCDF file.')
 
@@ -2309,13 +2309,15 @@ subroutine output_lakes_NWM(domainId,iGrid)
    integer :: ftn ! NetCDF file handle
    character(len=256) :: validTime ! Global attribute time string
    character(len=256) :: initTime ! Global attribute time string
-   integer :: dimId(3) ! Dimension ID values created during NetCDF created.
+   integer :: dimId(4) ! Dimension ID values created during NetCDF created.
    integer :: varId ! Variable ID value created as NetCDF variables are created and populated.
    integer :: timeId ! Dimension ID for the time dimension.
    integer :: refTimeId ! Dimension ID for the reference time dimension.
    integer :: coordVarId ! Variable to hold crs
    integer :: featureVarId ! feature_id NetCDF variable ID
    integer :: reservoirTypeVarId ! reservoir_type netCDF variable ID
+   integer :: reservoirAssimilatedValueVarId ! reservoir_assimilated_value netCDF variable ID
+   integer :: reservoirAssimilatedSourceFileVarId ! reservoir_assimilated_source_file netCDF variable ID
    integer :: latVarId, lonVarId ! lat/lon NetCDF variable ID values
    integer :: elevVarId ! elevation NetCDF variable ID
    integer :: varRange(2) ! Local storage of valid min/max values
@@ -2329,10 +2331,14 @@ subroutine output_lakes_NWM(domainId,iGrid)
    real, allocatable, dimension(:) :: g_lakeLat,g_lakeLon,g_lakeElev
    real, allocatable, dimension(:) :: g_lakeInflow,g_lakeOutflow
    real, allocatable, dimension(:) :: g_lakeType
+   real, allocatable, dimension(:) :: g_lake_assimilated_value
+   character(len=256), allocatable, dimension(:) :: g_lake_assimilated_source_file
    integer, allocatable, dimension(:) :: g_lakeid
    real, allocatable, dimension(:) :: g_lakeLatOut,g_lakeLonOut,g_lakeElevOut
    real, allocatable, dimension(:) :: g_lakeInflowOut,g_lakeOutflowOut
    integer, allocatable, dimension(:) :: g_lakeTypeOut, g_lakeidOut
+   real, allocatable, dimension(:) :: g_lake_assimilated_valueOut
+   character(len=256), allocatable, dimension(:) :: g_lake_assimilated_source_fileOut
    real, allocatable, dimension(:,:) :: varOutReal   ! Array holding output variables in real format
    integer, allocatable, dimension(:) :: varOutInt ! Array holding output variables after
                                                      ! scale_factor/add_offset
@@ -2428,6 +2434,8 @@ subroutine output_lakes_NWM(domainId,iGrid)
       allocate(g_lakeInflow(gsize))
       allocate(g_lakeOutflow(gsize))
       allocate(g_lakeType(gsize))
+      allocate(g_lake_assimilated_value(gsize))
+      allocate(g_lake_assimilated_source_file(gsize))
       allocate(g_lakeid(gsize))
 
       if(myId == 0) then
@@ -2437,6 +2445,8 @@ subroutine output_lakes_NWM(domainId,iGrid)
          allocate(g_lakeInflowOut(gsize))
          allocate(g_lakeOutflowOut(gsize))
          allocate(g_lakeTypeOut(gsize))
+         allocate(g_lake_assimilated_valueOut(gsize))
+         allocate(g_lake_assimilated_source_fileOut(gsize))
          allocate(g_lakeidOut(gsize))
          allocate(chIndArray(gsize))
       endif
@@ -2448,6 +2458,8 @@ subroutine output_lakes_NWM(domainId,iGrid)
       g_lakeOutflow = RT_DOMAIN(domainID)%QLAKEO
       g_lakeid = RT_DOMAIN(domainId)%LAKEIDM
       g_lakeType = RT_DOMAIN(domainID)%final_reservoir_type
+      g_lake_assimilated_value = RT_DOMAIN(domainID)%reservoir_assimilated_value
+      g_lake_assimilated_source_file = RT_DOMAIN(domainID)%reservoir_assimilated_source_file
 
       ! Sync everything up before the next step.
       if(mppFlag .eq. 1) then
@@ -2465,6 +2477,9 @@ subroutine output_lakes_NWM(domainId,iGrid)
       call write_lake_real(g_lakeInflow,RT_DOMAIN(domainId)%lake_index,gsize)
       call write_lake_real(g_lakeOutflow,RT_DOMAIN(domainId)%lake_index,gsize)
       call write_lake_real(g_lakeType,RT_DOMAIN(domainId)%lake_index,gsize)
+      call write_lake_real(g_lake_assimilated_value,RT_DOMAIN(domainId)%lake_index,gsize)
+      call write_lake_char(g_lake_assimilated_source_file,RT_DOMAIN(domainId)%lake_index,gsize)
+
 #endif
    else
       gSize = rt_domain(domainId)%NLAKES
@@ -2482,6 +2497,8 @@ subroutine output_lakes_NWM(domainId,iGrid)
       allocate(g_lakeOutflowOut(gsize))
       allocate(g_lakeidOut(gsize))
       allocate(g_lakeTypeOut(gsize))
+      allocate(g_lake_assimilated_valueOut(gsize))
+      allocate(g_lake_assimilated_source_fileOut(gsize))
       allocate(chIndArray(gsize))
       g_lakeLat = RT_DOMAIN(domainID)%LATLAKE
       g_lakeLon = RT_DOMAIN(domainID)%LONLAKE
@@ -2490,6 +2507,8 @@ subroutine output_lakes_NWM(domainId,iGrid)
       g_lakeOutflow = RT_DOMAIN(domainID)%QLAKEO
       g_lakeid = RT_DOMAIN(domainId)%LAKEIDM
       g_lakeType = RT_DOMAIN(domainId)%final_reservoir_type
+      g_lake_assimilated_value = RT_DOMAIN(domainID)%reservoir_assimilated_value
+      g_lake_assimilated_source_file = RT_DOMAIN(domainID)%reservoir_assimilated_source_file
    endif
 
    ! Sync all processes up.
@@ -2580,6 +2599,8 @@ subroutine output_lakes_NWM(domainId,iGrid)
             g_lakeLatOut(iTmp) = g_lakeLat(indTmp)
             g_lakeElevOut(iTmp) = g_lakeElev(indTmp)
             g_lakeTypeOut(iTmp) = g_lakeType(indTmp)
+            g_lake_assimilated_valueOut(iTmp) = g_lake_assimilated_value(indTmp)
+            g_lake_assimilated_source_fileOut(iTmp) = g_lake_assimilated_source_file(indTmp)
             g_lakeidOut(iTmp) = g_lakeid(indTmp)
          end do
       else
@@ -2589,6 +2610,8 @@ subroutine output_lakes_NWM(domainId,iGrid)
          g_lakeLatOut = g_lakeLat
          g_lakeElevOut = g_lakeElev
          g_lakeTypeOut = g_lakeType
+         g_lake_assimilated_valueOut = g_lake_assimilated_value
+         g_lake_assimilated_source_fileOut = g_lake_assimilated_source_file
          g_lakeidOut = g_lakeid
       endif
       varOutReal(1,:) = g_lakeInflowOut(:)
@@ -2635,6 +2658,8 @@ subroutine output_lakes_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create time dimension')
       iret = nf90_def_dim(ftn,"reference_time",1,dimId(3))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create reference_time dimension')
+      iret = nf90_def_dim(ftn,"string_length",256,dimId(4))
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to create string length dimension')
 
       ! Create and populate reference_time and time variables.
       iret = nf90_def_var(ftn,"time",nf90_int,dimId(2),timeId)
@@ -2709,6 +2734,20 @@ subroutine output_lakes_NWM(domainId,iGrid)
       call nwmCheck(diagFlag, iret, 'ERROR: Unable to place flag_values attribute into reservoir_type variable')
       iret = nf90_put_att(ftn, reservoirTypeVarId, 'flag_meanings', trim(fileMeta%reservoirTypeFlagMeanings))
       call nwmCheck(diagFlag, iret, 'ERROR: Unable to place flag_meanings attribute into reservoir_type variable')
+
+      ! Create reservoir_assimilated_value variable
+      iret = nf90_def_var(ftn, "reservoir_assimilated_value", nf90_float, dimId(1), reservoirAssimilatedValueVarId)
+      call nwmCheck(diagFlag, iret, 'ERROR: Unable to create reservoir_assimilated_value variable.')
+      iret = nf90_put_att(ftn, reservoirAssimilatedValueVarId, 'long_name', trim(fileMeta%reservoirAssimilatedValueLName))
+      call nwmCheck(diagFlag, iret, 'ERROR: Unable to place long_name attribute into reservoir_assimilated_value variable')
+
+      ! Create reservoir_assimilated_source_file variable
+      iret = nf90_def_var(ftn, "reservoir_assimilated_source_file", nf90_char, [dimId(4), dimId(1)], reservoirAssimilatedSourceFileVarId)
+      call nwmCheck(diagFlag, iret, 'ERROR: Unable to create reservoir_assimilated_source_file variable.')
+      iret = nf90_put_att(ftn, reservoirAssimilatedSourceFileVarId, 'long_name', trim(fileMeta%reservoirAssimilatedSourceFileLName))
+      call nwmCheck(diagFlag, iret, 'ERROR: Unable to place long_name attribute into reservoir_assimilated_source_file variable')
+      iret = nf90_def_var_fill(ftn, reservoirAssimilatedSourceFileVarId, 0, 0);
+      call nwmCheck(diagFlag, iret, 'ERROR: Unable to place _FillValue attribute into reservoir_assimilated_source_file variable')
 
       ! Create lake lat/lon variables
       iret = nf90_def_var(ftn,"latitude",nf90_float,dimId(1),latVarId)
@@ -2860,6 +2899,20 @@ subroutine output_lakes_NWM(domainId,iGrid)
       iret = nf90_put_var(ftn,varId,g_lakeTypeOut)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place data into reservoir_type output variable.')
 
+      ! Place reservoir_assimilated_value values into the NetCDF file
+      iret = nf90_inq_varid(ftn,'reservoir_assimilated_value',varId)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to locate reservoir_assimilated_value in NetCDF file.')
+      iret = nf90_put_var(ftn,varId,g_lake_assimilated_valueOut)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place data into reservoir_assimilated_value output variable.')
+
+      ! Place reservoir_assimilated_source_file values into the NetCDF file
+      iret = nf90_inq_varid(ftn,'reservoir_assimilated_source_file',varId)
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to locate reservoir_assimilated_source_file in NetCDF file.')
+      do iTmp = 1, gSize
+         iret = nf90_put_var(ftn,varId,trim(g_lake_assimilated_source_fileOut(iTmp)), start=[1,iTmp])
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to place data into reservoir_assimilated_source_file output variable.')
+      end do
+
       ! Place lake metadata into NetCDF file
       iret = nf90_inq_varid(ftn,'water_sfc_elev',varId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to locate water_sfc_elev in NetCDF file.')
@@ -2911,6 +2964,9 @@ subroutine output_lakes_NWM(domainId,iGrid)
    deallocate(g_lakeOutflow)
    deallocate(g_lakeid)
    deallocate(g_lakeType)
+   deallocate(g_lake_assimilated_value)
+   deallocate(g_lake_assimilated_source_file)
+
    if(myId .eq. 0) then
       deallocate(g_lakeLonOut)
       deallocate(g_lakeLatOut)
@@ -2919,6 +2975,8 @@ subroutine output_lakes_NWM(domainId,iGrid)
       deallocate(g_lakeOutflowOut)
       deallocate(g_lakeidOut)
       deallocate(g_lakeTypeOut)
+      deallocate(g_lake_assimilated_valueOut)
+      deallocate(g_lake_assimilated_source_fileOut)
       deallocate(chIndArray)
    endif
 
@@ -3135,7 +3193,7 @@ subroutine output_chrtout_grd_NWM(domainId,iGrid)
    modelConfigType = GetModelConfigType(nlst(1)%io_config_outputs)
 
    if(myId .eq. 0) then
-      ! Create output NetCDF file for writing. 
+      ! Create output NetCDF file for writing.
       iret = nf90_create(trim(output_flnm),cmode=NF90_NETCDF4,ncid = ftn)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create RT_DOMAIN NetCDF file.')
 
@@ -3604,7 +3662,7 @@ subroutine output_lsmOut_NWM(domainId)
             nlst(domainId)%olddate(6:7)//nlst(domainId)%olddate(9:10)//&
             nlst(domainId)%olddate(12:13)//nlst(domainId)%olddate(15:16),&
             nlst(domainId)%igrid
-  
+
       iret = nf90_create(trim(output_flnm),cmode=NF90_NETCDF4,ncid = ftn)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create LSMOUT NetCDF file.')
 

--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -310,6 +310,10 @@ type lakeMeta
    character (len=64) :: reservoirTypeLName ! long_name - usually "reservoir_type"
    integer, dimension(4) :: reservoirTypeFlagValues ! valid flags attribute
    character (len=64) :: reservoirTypeFlagMeanings ! flag meanings attribute
+   ! reservoir_assimilated_value attributes
+   character (len=64) :: reservoirAssimilatedValueLName ! long_name - usually "reservoir_assimilated_value, m3 s-1"
+   ! reservoir_assimilated_source_file attributes
+   character (len=64) :: reservoirAssimilatedSourceFileLName ! long_name - usually "reservoir_assimilated_source_file"
    ! latitude variable attributes
    character (len=64) :: latLName ! long_name
    character (len=64) :: latUnits ! units
@@ -1745,6 +1749,12 @@ subroutine initLakeDict(lakeOutDict,procId,diagFlag)
    lakeOutDict%reservoirTypeLName = "reservoir_type"
    lakeOutDict%reservoirTypeFlagValues = [1,2,3,4]
    lakeOutDict%reservoirTypeFlagMeanings = "Level_pool USGS-persistence USACE-persistence RFC-forecasts"
+
+   ! Establish reservoir_assimilated_value attributes
+   lakeOutDict%reservoirAssimilatedValueLName = "reservoir_assimilated_value"
+
+   ! Establish reservoir_assimilated_source_file attributes
+   lakeOutDict%reservoirAssimilatedSourceFileLName= "reservoir_assimilated_source_file"
 
   ! Esatablish lat/lon attributes
    lakeOutDict%latLName = "Lake latitude"

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -370,6 +370,8 @@ CONTAINS
         allocate ( rt_domain(did)%reservoirs(NLAKES) )    ! allocate array of pointers to reservoirs
         allocate ( rt_domain(did)%reservoir_type(NLAKES) )        ! allocate array to specify type of reservoir
         allocate ( rt_domain(did)%final_reservoir_type(NLAKES) )  ! allocate array to specify final type of reservoir
+        allocate ( rt_domain(did)%reservoir_assimilated_value(NLAKES) )  ! allocate array to specify assimilated value to reservoir discharge
+        allocate ( rt_domain(did)%reservoir_assimilated_source_file(NLAKES) )  ! allocate array to specify assimilated source file
         allocate( rt_domain(did)%LAKEIDM(NLAKES) )
         allocate( rt_domain(did)%HRZAREA(NLAKES) )
         allocate( rt_domain(did)%LAKEMAXH(NLAKES) )
@@ -394,6 +396,8 @@ CONTAINS
          rt_domain(did)%ORIFICEE = 0.0
          rt_domain(did)%reservoir_type = 1
          rt_domain(did)%final_reservoir_type = 1
+         rt_domain(did)%reservoir_assimilated_value = -9999.0
+         rt_domain(did)%reservoir_assimilated_source_file = repeat(char(0), 256)
      endif
 
 

--- a/trunk/NDHMS/Routing/module_channel_routing.F
+++ b/trunk/NDHMS/Routing/module_channel_routing.F
@@ -1172,7 +1172,8 @@ gwOption:   if(gwBaseSwCRT == 3) then
               ! Inflow, lateral inflow, water elevation, and the routing period
               ! are passed in. Updated outflow and water elevation are returned.
               call rt_domain(did)%reservoirs(i)%ptr%run(QLAKEIP(i), QLAKEI(i), &
-                   QLLAKE(i), RESHT(i), QLAKEO(i), DTCT, rt_domain(did)%final_reservoir_type(i))
+                   QLLAKE(i), RESHT(i), QLAKEO(i), DTCT, rt_domain(did)%final_reservoir_type(i), &
+                   rt_domain(did)%reservoir_assimilated_value(i), rt_domain(did)%reservoir_assimilated_source_file(i))
 
               ! TODO: Encapsulate the lake state variable for water elevation (RESHT(i))
               !       inside the reservoir module, but it requires a redesign of the lake
@@ -1675,6 +1676,8 @@ end subroutine drive_CHANNEL
        real, intent(in), dimension(:) :: qout_gwsubbas
        real, allocatable,dimension(:) :: tmpQLAKEO, tmpQLAKEI, tmpRESHT
        integer, allocatable, dimension(:) :: tmpFinalResType
+       real, allocatable,dimension(:) :: tmpAssimilatedValue
+       character(len=256), allocatable,dimension(:) :: tmpAssimilatedSourceFile
 
 #ifdef MPP_LAND
        if(my_id .eq. io_id) then
@@ -1847,6 +1850,9 @@ do nt = 1, nsteps
       tmpQLAKEI = QLAKEI
       tmpRESHT = RESHT
       tmpFinalResType = rt_domain(did)%final_reservoir_type
+      tmpAssimilatedValue = rt_domain(did)%reservoir_assimilated_value
+      tmpAssimilatedSourceFile = rt_domain(did)%reservoir_assimilated_source_file
+
 #ifdef MPP_LAND
    endif
 #endif
@@ -1898,7 +1904,8 @@ do nt = 1, nsteps
             ! Inflow, lateral inflow, water elevation, and the routing period
             ! are passed in. Updated outflow and water elevation are returned.
             call rt_domain(did)%reservoirs(lakeid)%ptr%run(Qup, Quc, 0.0, &
-                 RESHT(lakeid), tmpQLINK(k,2), DTRT_CH, rt_domain(did)%final_reservoir_type(lakeid))
+                 RESHT(lakeid), tmpQLINK(k,2), DTRT_CH, rt_domain(did)%final_reservoir_type(lakeid), &
+                 rt_domain(did)%reservoir_assimilated_value(lakeid), rt_domain(did)%reservoir_assimilated_source_file(lakeid))
 
             ! TODO: Encapsulate the lake state variable for water elevation (RESHT(lakeid))
             !       inside the reservoir module, but it requires a redesign of the lake
@@ -1944,6 +1951,8 @@ do nt = 1, nsteps
    call updateLake_seq(QLAKEI,nlakes,tmpQLAKEI)
    call updateLake_seq(RESHT,nlakes,tmpRESHT)
    call updateLake_seqInt(rt_domain(did)%final_reservoir_type, nlakes, tmpFinalResType)
+   call updateLake_seq(rt_domain(did)%reservoir_assimilated_value, nlakes, tmpAssimilatedValue)
+   call updateLake_seq_char(rt_domain(did)%reservoir_assimilated_source_file, nlakes, tmpAssimilatedSourceFile)
 #endif
 
    do k = 1, NLINKSL !tmpQLINK?


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: Reservoirs, Assimilated Data, Lake Out Files

SOURCE: David Mattern - NOAA, @jdmattern-noaa 

DESCRIPTION OF CHANGES: reservoir_assimilated_value and reservoir_assimilated_source_file are added variables to the Lake Out files. These are returned from the reservoir module at every timestep and passed over MPI to be written every hour. 

ISSUE: 
```
Fixes #475 
```

TESTS CONDUCTED: Unit tests added in reservoir module and short-term CONUS tests conducted. 


### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [x] Closes issue #475  (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [x] Tests added (unit tests and/or regression/integration tests)
 - [x] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [x] Fully documented
 - [ ] Short description in the Development section of `NEWS.md`
