### PR TITLE
IO update for RTOUT frequency and metadata

### DIFF
--- a/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
+++ b/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
@@ -63,7 +63,7 @@ module module_HYDRO_drv
   integer :: clock_count_2 = 0
   integer :: clock_rate    = 0
 #endif
-  integer :: rtout_factor
+  integer :: rtout_factor  = 0
 
   integer, parameter :: r4 = selected_real_kind(4)
   real,    parameter :: zeroFlt=0.0000000000000000000_r4
@@ -265,7 +265,9 @@ module module_HYDRO_drv
             if(nlst(did)%RTOUT_DOMAIN       .eq. 1 .and. &
                     nlst(did)%channel_only       .eq. 0 .and. &
                     nlst(did)%channelBucket_only .eq. 0       ) then
-                if(mod(rtout_factor,3) .eq. 0 .or. nlst(did)%io_config_outputs .ne. 5) then
+                if(mod(rtout_factor,3) .eq. 2 .or. &
+                   nlst(did)%io_config_outputs .ne. 5 .and. &
+                   nlst(did)%io_config_outputs .ne. 3) then
                     ! Output gridded routing variables on National Water Model
                     ! high-res routing grid
                     if(nlst(did)%io_form_outputs .ne. 0) then

--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -1865,7 +1865,11 @@ subroutine output_rt_NWM(domainId,iGrid)
    fileMeta%timeValidMax = minSinceEpoch1 + int(nlst(1)%khour * 60/nlst(1)%out_dt) * nlst(1)%out_dt
 
    ! calculate total_valid_time
-   fileMeta%totalValidTime = int(nlst(1)%khour * 60 / nlst(1)%out_dt)  ! # number of valid time (#of output files)
+   if(nlst(domainId)%io_config_outputs .ne. 3 .and. nlst(domainId)%io_config_outputs .ne. 5) then
+       fileMeta%totalValidTime = int(nlst(1)%khour * 60 / nlst(1)%out_dt)  ! # number of valid time (#of output files)
+   else
+       fileMeta%totalValidTime = int(nlst(1)%khour * 60 / nlst(1)%out_dt / 3)  ! # number of valid time (#of output files)
+   endif
 
    ! Create output filename
    write(output_flnm, '(A12,".RTOUT_DOMAIN",I1)') nlst(domainId)%olddate(1:4)//&


### PR DESCRIPTION
TYPE: bug fix + "enhancement"

KEYWORDS: IO, medium range, retrospective, output frequency

SOURCE: Katelyn, NCAR

DESCRIPTION OF CHANGES: 
Similar to the retrospective model output configuration, a reduced output frequency was desired for the terrain routing grids in the medium range forecast outputs (every third file).  

This was implemented, the number of valid_times in the output files was updated, and the timing issue (outputs should occur for hours 3,6,9... and not 1,4,7...  for hourly outputs) was addressed.

ISSUE: Closes #477

TESTS CONDUCTED: Full test suite.

NOTES: This is really just an update to an existing hack.  In the longer term we should think about a better way to specify output frequencies for different file types.

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment on why below the bullet.

 - [X] Closes issue #477 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? Nope
 - [ ] Fully documented
 - [ ] Short description in the Development section of `NEWS.md`
