### PR TITLE
Add global attribute TITLE to all output files

### DIFF
--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -645,6 +645,8 @@ subroutine output_chrt_NWM(domainId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create CHRTOUT NetCDF file.')
 
       ! Write global attributes.
+      iret = nf90_put_att(ftn,NF90_GLOBAL,"TITLE",trim(fileMeta%title))
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to create TITLE attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"featureType",trim(fileMeta%fType))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create featureType attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"proj4",trim(fileMeta%proj4))
@@ -1884,6 +1886,8 @@ subroutine output_rt_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create RT_DOMAIN NetCDF file.')
 
       ! Write global attributes
+      iret = nf90_put_att(ftn,NF90_GLOBAL,'TITLE',trim(fileMeta%title))
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to create TITLE attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,'model_initialization_time',trim(fileMeta%initTime))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place model init time attribute into RT_DOMAIN file.')
       iret = nf90_put_att(ftn,NF90_GLOBAL,'model_output_valid_time',trim(fileMeta%validTime))
@@ -2628,6 +2632,8 @@ subroutine output_lakes_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create LAKEOUT NetCDF file.')
 
       ! Write global attributes.
+      iret = nf90_put_att(ftn,NF90_GLOBAL,"TITLE",trim(fileMeta%title))
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to create TITLE attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"featureType",trim(fileMeta%fType))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create featureType attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"proj4",trim(fileMeta%proj4))
@@ -3202,6 +3208,8 @@ subroutine output_chrtout_grd_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create RT_DOMAIN NetCDF file.')
 
       ! Write global attributes
+      iret = nf90_put_att(ftn,NF90_GLOBAL,'TITLE',trim(fileMeta%title))
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to create TITLE attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,'model_initialization_time',trim(fileMeta%initTime))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place model init time attribute into RT_DOMAIN file.')
       iret = nf90_put_att(ftn,NF90_GLOBAL,'model_output_valid_time',trim(fileMeta%validTime))
@@ -3672,15 +3680,15 @@ subroutine output_lsmOut_NWM(domainId)
 
       ! Write global attributes
       iret = nf90_put_att(ftn,NF90_GLOBAL,'TITLE',trim(fileMeta%title))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place TITLE attribute into LDASOUT file.')
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place TITLE attribute into LSMOUT file.')
       iret = nf90_put_att(ftn,NF90_GLOBAL,'model_initialization_time',trim(fileMeta%initTime))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place model init time attribute into LDASOUT file.')
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place model init time attribute into LSMOUT file.')
       iret = nf90_put_att(ftn,NF90_GLOBAL,'model_output_valid_time',trim(fileMeta%validTime))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place model output time attribute into LDASOUT file.')
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place model output time attribute into LSMOUT file.')
       iret = nf90_put_att(ftn,NF90_GLOBAL,'modle_total_valid_time',fileMeta%totalValidTime)
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place model total valid time attribute into LDASOUT file.')
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place model total valid time attribute into LSMOUT file.')
       iret = nf90_put_att(ftn,NF90_GLOBAL,'Conventions',trim(fileMeta%conventions))
-      call nwmCheck(diagFlag,iret,'ERROR: Unable to place CF conventions attribute into LDASOUT file.')
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to place CF conventions attribute into LSMOUT file.')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"code_version",trim(get_code_version()))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create code_version attribute')
 #ifdef NWM_META
@@ -4636,6 +4644,8 @@ subroutine output_chanObs_NWM(domainId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create CHANOBS NetCDF file.')
 
       ! Write global attributes.
+      iret = nf90_put_att(ftn,NF90_GLOBAL,"TITLE",trim(fileMeta%title))
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to create TITLE attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"featureType",trim(fileMeta%fType))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create featureType attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"proj4",trim(fileMeta%proj4))
@@ -5273,6 +5283,8 @@ subroutine output_gw_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create GWOUT NetCDF file.')
 
       ! Write global attributes.
+      iret = nf90_put_att(ftn,NF90_GLOBAL,"TITLE",trim(fileMeta%title))
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to create TITLE attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"featureType",trim(fileMeta%fType))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create featureType attribute')
       !iret = nf90_put_att(ftn,NF90_GLOBAL,"proj4",trim(fileMeta%proj4))

--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -100,6 +100,7 @@ type chrtMeta
    character (len=64) :: orderLName ! long_name
    character (len=64) :: orderStName ! Standard Name
    ! Global attributes
+   character (len=128) :: title ! file title
    character (len=128) :: fType ! featureType attribute
    character (len=128) :: proj4 ! proj4 attribute
    character (len=128) :: initTime ! model_initialization_time attribute
@@ -181,7 +182,7 @@ type ldasMeta
    integer :: nyRealAtts, nyCharAtts
 
    ! Global attributes
-   character (len=128) :: title ! File TITLE
+   character (len=128) :: title ! file title
    character (len=128) :: initTime ! model_initialization_time attribute
    character (len=128) :: validTime ! model_output_valid_time attribute
    character (len=128) :: conventions ! Conventions string
@@ -253,6 +254,7 @@ type rtDomainMeta
 
    ! Global attributes
    integer :: decimation ! Decimation factor
+   character (len=128) :: title ! file title
    character (len=128) :: initTime ! model_initialization_time attribute
    character (len=128) :: validTime ! model_output_valid_time attribute
    character (len=128) :: conventions ! Conventions string
@@ -327,6 +329,7 @@ type lakeMeta
    character (len=64) :: elevUnits ! units
    character (len=64) :: elevStName ! Standard Name
    ! Global attributes
+   character (len=128) :: title ! file title
    character (len=128) :: fType ! featureType attribute
    character (len=128) :: proj4 ! proj4 attribute
    character (len=128) :: initTime ! model_initialization_time attribute
@@ -403,6 +406,7 @@ type chrtGrdMeta
 
    ! Global attributes
    integer :: decimation ! Decimation factor
+   character (len=128) :: title ! file title
    character (len=128) :: initTime ! model_initialization_time attribute
    character (len=128) :: validTime ! model_output_valid_time attribute
    character (len=128) :: conventions ! Conventions string
@@ -476,7 +480,7 @@ type lsmMeta
    integer :: nyRealAtts, nyCharAtts
 
    ! Global attributes
-   character (len=128) :: title ! File TITLE
+   character (len=128) :: title ! file title
    character (len=128) :: initTime ! model_initialization_time attribute
    character (len=128) :: validTime ! model_output_valid_time attribute
    character (len=128) :: conventions ! Conventions string
@@ -543,6 +547,7 @@ type chObsMeta
    character (len=64) :: orderLName ! long_name
    character (len=64) :: orderStName ! Standard Name
    ! Global attributes
+   character (len=128) :: title ! file title
    character (len=128) :: fType ! featureType attribute
    character (len=128) :: proj4 ! proj4 attribute
    character (len=128) :: initTime ! model_initialization_time attribute
@@ -617,6 +622,7 @@ type gwMeta
    !character (len=64) :: elevUnits ! units
    !character (len=64) :: elevStName ! Standard Name
    ! Global attributes
+   character (len=128) :: title ! file title
    character (len=128) :: fType ! featureType attribute
    !character (len=128) :: proj4 ! proj4 attribute
    character (len=128) :: initTime ! model_initialization_time attribute
@@ -686,6 +692,7 @@ subroutine initChrtDict(chrtOutDict,diagFlag,procId)
    !            which means meta-data standards have yet to be determined
    !            for these variables. Fill in if it's desired to output....
    ! First establish global attributes for the channel output files
+   chrtOutDict%title = "OUTPUT FROM " // trim(get_model_version())
    chrtOutDict%fType = 'timeSeries'
    chrtOutDict%initTime = '1970-01-01_00:00:00' ! This will be calculated in I/O code
    chrtOutDict%validTime = '1970-01-01_00:00:00' ! This will be calculated in I/O code
@@ -1362,6 +1369,7 @@ subroutine initRtDomainDict(rtDomainDict,procId,diagFlag)
    rtDomainDict%modelNdv = -9.E15
 
    ! First establish global attributes.
+   rtDomainDict%title = "OUTPUT FROM " // trim(get_model_version())
    rtDomainDict%initTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    rtDomainDict%validTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    rtDomainDict%decimation = 1
@@ -1686,6 +1694,7 @@ subroutine initLakeDict(lakeOutDict,procId,diagFlag)
    !            which means meta-data standards have yet to be determined
    !            for these variables. Fill in if it's desired to output....
    ! First establish global attributes for the channel output files
+   lakeOutDict%title = "OUTPUT FROM " // trim(get_model_version())
    lakeOutDict%fType = 'timeSeries'
    lakeOutDict%initTime = '1970-01-01_00:00:00' ! This will be calculated in I/O code
    lakeOutDict%validTime = '1970-01-01_00:00:00' ! This will be calculated in I/O code
@@ -1820,6 +1829,7 @@ subroutine initChrtGrdDict(chrtGrdDict,procId,diagFlag)
    chrtGrdDict%modelNdv = -9.E15
 
    ! First establish global attributes.
+   chrtGrdDict%title = "OUTPUT FROM " // trim(get_model_version())
    chrtGrdDict%initTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    chrtGrdDict%validTime = "1970-01-01_00:00:00" ! This will be calculated in I/O code.
    chrtGrdDict%decimation = 1
@@ -2475,6 +2485,7 @@ subroutine initChanObsDict(chObsDict,diagFlag,procId)
       endif
    endif
 
+   chObsDict%title = "OUTPUT FROM " // trim(get_model_version())
    chObsDict%fType = 'timeSeries'
    chObsDict%initTime = '1970-01-01_00:00:00' ! This will be calculated in I/O code
    chObsDict%validTime = '1970-01-01_00:00:00' ! This will be calculated in I/O code
@@ -2554,6 +2565,7 @@ subroutine initGwDict(gwOutDict)
 
    gwOutDict%modelNdv = -9.E15
 
+   gwOutDict%title = "OUTPUT FROM " // trim(get_model_version())
    gwOutDict%fType = 'timeSeries'
    !gwOutDict%proj4 = '+proj=longlat +datum=NAD83 +no_defs'
    gwOutDict%initTime = '1970-01-01_00:00:00' ! This will be calculated in I/O code


### PR DESCRIPTION
TYPE: output metadata update

KEYWORDS: IO, metadata, version

SOURCE: Katelyn, NCAR

DESCRIPTION OF CHANGES: Add global attribute TITLE to all output files.  Previously this was only on LSMOUT and LDASOUT files.

ISSUE: Fixes #483

TESTS CONDUCTED: Local test suite

NOTES: 
For NWM v2.1
Worth noting as well that the .version file for alpha2 was not updated


### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment on why below the bullet.

 - [X] Closes issue #483
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
 - [ ] Short description in the Development section of `NEWS.md`
