### PR TITLE
Performance improvements in initialization routines using Fortran hashtable

### DIFF
--- a/trunk/NDHMS/MPP/CMakeLists.txt
+++ b/trunk/NDHMS/MPP/CMakeLists.txt
@@ -5,4 +5,5 @@ add_library(hydro_mpp STATIC
 	module_mpp_GWBUCKET.F
 	module_mpp_ReachLS.F
 	mpp_land.F          
+	hashtable.F
 )

--- a/trunk/NDHMS/MPP/Makefile
+++ b/trunk/NDHMS/MPP/Makefile
@@ -5,9 +5,17 @@
 
 include ../macros
 
-OBJS =  CPL_WRF.o mpp_land.o module_mpp_ReachLS.o module_mpp_GWBUCKET.o
+OBJS =  hashtable.o CPL_WRF.o mpp_land.o module_mpp_ReachLS.o module_mpp_GWBUCKET.o
 
 all:	$(OBJS)
+
+hashtable.o: hashtable.F
+	@echo ""
+	$(RMD) $(*).o $(*).mod $(*).stb *~
+	$(COMPILER90) -O3 -g $(F90FLAGS) $(LDFLAGS) -c $(*).F
+	cp hashtable.mod ../mod
+	ar -r ../lib/libHYDRO.a $(@)
+
 mpp_land.o: mpp_land.F
 	@echo ""
 	$(RMD) $(*).o $(*).mod $(*).stb *~

--- a/trunk/NDHMS/MPP/hashtable.F
+++ b/trunk/NDHMS/MPP/hashtable.F
@@ -190,6 +190,7 @@ contains
     integer :: bucket_id
 
     success = .false.
+    if(this%n_buckets == 0) return
     bucket_id = modulo(key,this%n_buckets) + 1
     call this%buckets(bucket_id)%node_get(key, value, success)
   end subroutine get

--- a/trunk/NDHMS/MPP/hashtable.F
+++ b/trunk/NDHMS/MPP/hashtable.F
@@ -1,0 +1,249 @@
+module hashtable
+
+  implicit none
+
+  type kv_type
+     integer :: key
+     integer :: value
+  end type kv_type
+
+  type node_type
+     type(kv_type), allocatable :: kv
+     type(node_type), pointer :: next => null()
+
+   contains
+     ! If kv is not allocated, allocate and set to the key, value passed in.
+     ! If key is present and the same as the key passed in, overwrite the value.
+     ! Otherwise, defer to the next node (allocate if not allocated)
+     procedure :: node_set
+
+     ! If kv is not allocated, fail and return 0.
+     ! If key is present and the same as the key passed in, return the value in kv.
+     ! If next pointer is associated, delegate to it.
+     ! Otherwise, fail and return 0.
+     procedure :: node_get
+
+     ! If kv is not allocated, fail and return
+     ! If key is present and node is first in bucket, set first node in bucket to 
+     !   the next node of first. Return success
+     ! If key is present and the node is another member of the linked list, link the 
+     !   previous node's next node to this node's next node, deallocate this node, 
+     !   return success
+
+     ! Deallocate kv is allocated.
+     ! Call the clear method of the next node if the next pointer associated.
+     ! Deallocate and nullify the next pointer.
+     procedure :: node_clear
+
+     ! Return the length of the linked list start from the current node.
+     procedure :: node_depth
+  end type node_type
+
+  public
+  type hash_t
+     integer :: n_buckets = 0
+     integer :: n_keys = 0
+     type(node_type), allocatable :: buckets(:)
+   contains
+     procedure, public :: bucket_count
+     procedure, public :: n_collisions
+     ! Returns number of keys.
+     procedure, public :: key_count
+     ! Set the value at a given a key.
+     procedure, public :: set
+     procedure, public :: set_all
+     procedure, public :: set_all_idx
+     ! Get the value at the given key.
+     procedure, public :: get
+     ! Clear all the allocated memory (must be called to prevent memory leak).
+     procedure, public :: clear
+     ! Private hashing function
+     procedure, private :: hash
+  end type hash_t
+
+contains
+
+  function hash(this,key_value) result(bucket)
+
+    class(hash_t), intent(inout) :: this
+    integer, intent(in) :: key_value
+    integer :: bucket
+
+    bucket = key_value
+
+  end function hash
+
+  function bucket_count(this)
+    class(hash_t), intent(inout) :: this
+    integer :: bucket_count
+
+    bucket_count = this%n_buckets
+  end function bucket_count
+
+  function n_collisions(this)
+    class(hash_t), intent(inout) :: this
+    integer :: n_collisions
+    integer :: i
+
+    n_collisions = 0
+    do i = 1, this%n_buckets
+       n_collisions = n_collisions + node_depth(this%buckets(i)) - 1
+    enddo
+  end function n_collisions
+
+  recursive function node_depth(this) result(depth)
+    class(node_type), intent(inout) :: this
+    integer :: depth
+
+    if (.not. associated(this%next)) then
+       depth = 1
+    else
+       depth = 1 + node_depth(this%next)
+    endif
+  end function node_depth
+
+  pure function key_count(this)
+    class(hash_t), intent(in) :: this
+    integer :: key_count
+
+    key_count = this%n_keys
+  end function key_count
+
+  subroutine set(this, key, value)
+    class(hash_t), intent(inout) :: this
+    integer, intent(in) :: key
+    integer, intent(in) :: value
+    integer :: bucket_id
+    logical :: is_new
+
+    bucket_id = modulo(this%hash(key), this%n_buckets) + 1
+
+    call this%buckets(bucket_id)%node_set(key, value)
+
+    if (is_new) this%n_keys = this%n_keys + 1
+  end subroutine set
+
+  subroutine set_all_idx(this, keys, length)
+    class(hash_t), intent(inout) :: this
+    integer, intent(in) :: keys(:)
+    integer, optional, intent(in) :: length
+    integer :: bucket_id, i, n
+
+    if(present(length)) then
+       n = length
+    else
+       n = size(keys)
+    end if
+    
+    this%n_buckets = n
+    allocate(this%buckets(n))
+
+    do i = 1, n
+       bucket_id = modulo(this%hash(keys(i)),this%n_buckets) + 1
+       call this%buckets(bucket_id)%node_set(keys(i), i)
+       this%n_keys = this%n_keys + 1
+    end do
+  end subroutine set_all_idx
+
+  subroutine set_all(this, keys, values)
+    class(hash_t), intent(inout) :: this
+    integer, intent(in) :: keys(:)
+    integer, intent(in) :: values(:)
+    integer :: bucket_id, i, n
+
+    n = size(keys)
+
+    this%n_buckets = n
+    allocate(this%buckets(n))
+
+    do i = 1, n
+       bucket_id = modulo(this%hash(keys(i)), this%n_buckets) + 1
+       call this%buckets(bucket_id)%node_set(keys(i), values(i))
+       this%n_keys = this%n_keys + 1
+    end do
+  end subroutine set_all
+
+  recursive subroutine node_set(this, key, value)
+    class(node_type), intent(inout) :: this
+    integer, intent(in) :: key
+    integer, intent(in) :: value
+
+    if (.not. allocated(this%kv)) then
+       allocate(this%kv)
+       this%kv%key = key
+       this%kv%value = value
+    else if (this%kv%key == key) then
+       this%kv%value = this%kv%value
+    else
+       if (.not. associated(this%next)) then
+          allocate(this%next)
+       end if
+       call this%next%node_set(key, value)
+    endif
+  end subroutine node_set
+
+  subroutine get(this, key, value, success)
+    class(hash_t), intent(inout) :: this
+    integer, intent(in) :: key
+    integer, intent(out) :: value
+    logical, intent(out) :: success
+    integer :: bucket_id
+
+    success = .false.
+    bucket_id = modulo(key,this%n_buckets) + 1
+    call this%buckets(bucket_id)%node_get(key, value, success)
+  end subroutine get
+
+  recursive subroutine node_get(this, key, value, success)
+    class(node_type), intent(inout) :: this
+    integer, intent(in) :: key
+    integer, intent(out) :: value
+    logical, intent(out) :: success
+
+    success = .false.
+
+    if (.not. allocated(this%kv)) then
+       ! Not found. (Initial node in the bucket not set)
+       success = .false.
+    else if (this%kv%key == key) then
+       value = this%kv%value
+       success = .true.
+    else if (associated(this%next)) then
+       call this%next%node_get(key, value, success)
+    else
+       success = .false.
+    endif
+  end subroutine node_get
+
+  subroutine clear(this)
+    class(hash_t), intent(inout) :: this
+    integer :: i
+
+    if (.not. allocated(this%buckets)) return
+
+    do i = 1, size(this%buckets)
+       if (associated(this%buckets(i)%next)) then 
+          call this%buckets(i)%next%node_clear()
+          deallocate(this%buckets(i)%next)
+          if(allocated(this%buckets(i)%kv)) then
+             deallocate(this%buckets(i)%kv)
+          endif
+       end if
+    enddo
+    deallocate(this%buckets)
+    this%n_keys = 0
+    this%n_buckets = 0
+  end subroutine clear
+
+  recursive subroutine node_clear(this)
+    class(node_type), intent(inout) :: this
+
+    if (associated(this%next)) then
+       call this%next%node_clear()
+       deallocate(this%next)
+       deallocate(this%kv)
+       nullify(this%next)
+    endif
+  end subroutine node_clear
+
+end module hashtable

--- a/trunk/NDHMS/MPP/module_mpp_ReachLS.F
+++ b/trunk/NDHMS/MPP/module_mpp_ReachLS.F
@@ -22,6 +22,7 @@
 MODULE MODULE_mpp_ReachLS
 
   use module_mpp_land, only:  io_id, my_id, mpp_status, mpp_land_max_int1, mpp_land_sync, HYDRO_COMM_WORLD
+  use hashtable
   implicit none
 
 
@@ -346,8 +347,6 @@ MODULE MODULE_mpp_ReachLS
        integer, dimension(:) :: LINKID, LLINKID
        integer :: i,k, glinksl, ierr
        integer :: gLinkId(glinksl)
-       integer :: cache_idx, cache_block
-       integer :: cache_block_begin, cache_block_end
 
        LLINKLEN = size(LLINKID,1)
        allocate(LLINKIDINDX(LLINKLEN))
@@ -359,19 +358,31 @@ MODULE MODULE_mpp_ReachLS
        call mpi_bcast(gLinkId(1:glinksl),glinksl,MPI_INTEGER,   &
             IO_id,HYDRO_COMM_WORLD,ierr)
 
-       cache_block = 256
-       do cache_idx = 0, glinksl - 1, cache_block
-          cache_block_begin = cache_idx + 1
-          cache_block_end = min(cache_idx + cache_block, glinksl)
-          do i = 1, LLINKLEN
-             if(LLINKIDINDX(i) /= 0) cycle
-             do k = cache_block_begin, cache_block_end
-                if(LLINKID(i) .eq. gLinkId(k)) then
-                   LLINKIDINDX(i) = k
-                endif
-             end do
-          end do
-       end do
+       ! The following loops are replaced by a hashtable-based algorithm
+       !        do i = 1, LLINKLEN
+       !           do k = 1, glinksl
+       !              if(LLINKID(i) .eq. gLinkId(k)) then
+       !                 LLINKIDINDX(i) = k
+       !                 goto 1001
+       !              endif
+       !           end do
+       ! 1001      continue
+       !     end do
+
+       block
+         type(hash_t) :: hash_table
+         integer :: val,it
+         logical :: found
+         
+         call hash_table%set_all_idx(LLINKID,LLINKLEN)
+         do it=1, glinksl
+            call hash_table%get(gLinkId(it), val, found)
+            if(found .eqv. .true.) then
+               llinkidindx(val) = it
+            end if
+         end do
+         call hash_table%clear()
+       end block
 
        call mpp_land_sync()
   end subroutine getLocalIndx
@@ -825,42 +836,53 @@ MODULE MODULE_mpp_ReachLS
   end subroutine getFromInd
 
   subroutine getToInd(from,to,ind,indLen,gToNodeOut)
-      integer,dimension(:) :: from, to
-      integer, allocatable, dimension(:) ::ind
-      integer, allocatable, dimension(:,:) :: gToNodeOut
-      integer :: k, m, kk, mm,indLen, i, ierr
-      integer, dimension(gnlinksl) :: gto
-      integer :: maxNum, num, tmp_num
-      integer :: cache_block_begin, cache_block_end, cache_idx, cache_block
+    integer,dimension(:) :: from, to
+    integer, allocatable, dimension(:) ::ind
+    integer, allocatable, dimension(:,:) :: gToNodeOut
+    integer :: k, m, kk, mm,indLen, i, ierr
+    integer, dimension(gnlinksl) :: gto
+    integer :: maxNum, num
+
+    call gBcastValue(to,gto)
+
+    !      mm = size(from,1)
+    mm = l_nlinksl
+
+    kk = 0
+    maxNum = 0
+
+    ! The following loops are replaced by a hashtable-based algorithm
+    ! do m = 1, mm
+    !    num = 0
+    !    do k = 1, gnlinksl
+    !       if(gto(k) .eq. from(m) ) then
+    !          kk = kk +1
+    !          num = num + 1
+    !       endif
+    !    end do
+    !    if(num .gt. maxNum) maxNum = num
+    ! end do
+
+    block
+      type(hash_t) :: hash_table
+      integer :: val,it
       integer, allocatable :: num_a(:)
-
-      call gBcastValue(to,gto)
-
-!      mm = size(from,1)
-       mm = l_nlinksl
+      logical :: found
 
       allocate(num_a(mm))
-      cache_block = 256
       num_a = 0
-      tmp_num = 0
       kk = 0
-      maxNum = 0
-      do cache_idx = 0, gnlinksl-1, cache_block
-         cache_block_begin = cache_idx + 1
-         cache_block_end = min(cache_idx + cache_block, gnlinksl)
-         do m = 1, mm
-            tmp_num = num_a(m)
-            do k = cache_block_begin, cache_block_end
-               if(gto(k) .eq. from(m) ) then
-                  kk = kk + 1
-                  tmp_num = tmp_num + 1
-               endif
-            end do
-            num_a(m) = tmp_num
-            num = tmp_num
-            if(num .gt. maxNum) maxNum = num
-         end do
-      enddo
+
+      call hash_table%set_all_idx(from, mm)
+      do it=1, gnlinksl
+         call hash_table%get(gto(it), val, found)
+         if(found .eqv. .true.) then
+            kk = kk + 1
+            num_a(val) = num_a(val) + 1
+         end if
+      end do
+      maxNum = maxval(num_a)
+
 
       allocate(ind(kk))
       allocate(gToNodeOut(mm,maxNum+1))
@@ -870,33 +892,44 @@ MODULE MODULE_mpp_ReachLS
 
       kk = 0
       num_a = 1
-      tmp_num = 1
-      do cache_idx = 0, gnlinksl-1, cache_block
-         cache_block_begin = cache_idx + 1
-         cache_block_end = min(cache_idx + cache_block, gnlinksl)
-         do m = 1, mm
-            tmp_num = num_a(m)
-            do k = cache_block_begin, cache_block_end
-               if(gto(k) .eq. from(m) ) then
-                  kk = kk +1
-                  !yw ind(kk) = gto(k)
-                  ind(kk) = k
-                  !! gToNodeOut(m,num+1) = gto(k)
-                  gToNodeOut(m,tmp_num+1) = kk
-                  gToNodeOut(m,1) = tmp_num
-                  tmp_num = tmp_num + 1
-               endif
-            end do
-            num_a(m) = tmp_num
-         end do
-      enddo
-      deallocate(num_a)
 
-      ToInd(my_id+1) = kk
-      do i = 0, numprocs - 1
-         call mpi_bcast(ToInd(i+1),1,MPI_INTEGER,   &
-            i,HYDRO_COMM_WORLD,ierr)
+      ! The following loops are replaced by a hashtable-based algorithm
+      ! do m = 1, mm
+      !    num = 1
+      !    do k = 1, gnlinksl
+      !        if(gto(k) .eq. from(m) ) then
+      !            kk = kk +1
+      !            !yw ind(kk) = gto(k)
+      !            ind(kk) = k
+      !            !! gToNodeOut(m,num+1) = gto(k)
+      !            gToNodeOut(m,num+1) = kk
+      !            gToNodeOut(m,1) = num
+      !            num = num + 1
+      !        endif
+      !     end do
+      ! end do
+
+      do it=1, gnlinksl
+         call hash_table%get(gto(it), val, found)
+         if(found .eqv. .true.) then
+            kk = kk + 1
+            ind(kk) = it
+            gToNodeOut(val,num_a(val)+1) = kk
+            gToNodeOut(val,1) = num_a(val)
+            num_a(val) = num_a(val) + 1
+         end if
       end do
+
+      deallocate(num_a)
+      call hash_table%clear()
+
+    end block
+
+    ToInd(my_id+1) = kk
+    do i = 0, numprocs - 1
+       call mpi_bcast(ToInd(i+1),1,MPI_INTEGER,   &
+            i,HYDRO_COMM_WORLD,ierr)
+    end do
 
   end subroutine getToInd
 

--- a/trunk/NDHMS/Routing/module_HYDRO_io.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_io.F
@@ -34,6 +34,7 @@ module module_HYDRO_io
    use module_reservoir_utilities, only: read_reservoir_type
    use netcdf
    use module_hydro_stop, only:HYDRO_stop
+   use hashtable
 
    implicit none
 
@@ -9144,7 +9145,6 @@ subroutine readBucket_nhd(infile, numbasns, gw_buck_coeff, gw_buck_exp, &
     integer, allocatable, dimension(:) :: tmpLinkid
     real, allocatable, dimension(:) :: tmpCoeff, tmpExp, tmpLoss
     real, allocatable, dimension(:) :: tmpz_max, tmpz_init
-    integer :: cache_block, cache_idx, cache_block_begin, cache_block_end
 
 !   get gnid
 #ifdef MPP_LAND
@@ -9232,26 +9232,45 @@ subroutine readBucket_nhd(infile, numbasns, gw_buck_coeff, gw_buck_exp, &
 #endif
 
        nhdBuckMask = -999
-       cache_block = 128
-       do cache_idx = 0, gnid-1, cache_block
-          cache_block_begin = cache_idx + 1
-          cache_block_end = min(cache_idx + cache_block, gnid)
-          do k = 1, numbasns
-             if(nhdBuckMask(k) /= -999) cycle
-             do i = cache_block_begin, cache_block_end
-                if(LINKID(k) .eq. tmpLinkid(i)) then
-                   gw_buck_coeff(k) = tmpCoeff(i)
-                   gw_buck_exp(k) = tmpExp(i)
-                   if(nlst(did)%bucket_loss .eq. 1) then
-                      gw_buck_loss(k) = tmpLoss(i)
-                   endif
-                   z_max(k) = tmpz_max(i)
-                   z_init(k) = tmpz_init(i)
-                   nhdBuckMask(k) = 1
-                endif
-             end do
-          end do
-       end do
+
+       ! The following loops are replaced by a hashtable-based algorithm
+       !   do k = 1, numbasns
+       !         do i = 1, gnid
+       !             if(LINKID(k) .eq. tmpLinkid(i)) then
+       !                gw_buck_coeff(k) = tmpCoeff(i)
+       !                gw_buck_exp(k) = tmpExp(i)
+       !                z_max(k) = tmpz_max(i)
+       !                z_init(k) = tmpz_init(i)
+       !                nhdBuckMask(k) = 1
+       !                goto 301 
+       !             endif
+       !         end do
+       ! 301     continue
+       !     end do
+
+       block
+         type(hash_t) :: hash_table
+         integer :: val,it
+         logical :: found
+         
+         call hash_table%set_all_idx(LINKID,numbasns)
+         do it=1, gnid
+            call hash_table%get(tmpLinkid(it), val, found)
+            if((found .eqv. .true.)) then
+               if((nhdBuckMask(val) == -999)) then
+                  gw_buck_coeff(val) = tmpCoeff(it)
+                  gw_buck_exp(val) = tmpExp(it)
+                  if(nlst(did)%bucket_loss == 1) then
+                     gw_buck_loss(val) = tmpLoss(it)
+                  end if
+                  z_max(val) = tmpz_max(it)
+                  z_init(val) = tmpz_init(it)
+                  nhdBuckMask(val) = 1
+               end if
+            end if
+         end do
+         call hash_table%clear()
+       end block
 
     if(allocated(tmpCoeff)) deallocate(tmpCoeff)
     if(allocated(tmpExp)) deallocate(tmpExp)
@@ -10258,8 +10277,6 @@ end subroutine output_chrt2
         integer,allocatable, dimension(:) ::  gto, tmpLAKELINKID, gTYPEL, gOUTLAKEID
 
       integer tmpBuf(GNLINKSL)
-      integer, allocatable :: num_a(:)
-      integer :: tmp_num, cache_block_begin, cache_block_end, cache_idx, cache_block
 
       tmpSize = size(TO_NODE,1)
       allocate(OUTLAKEID(tmpSize))
@@ -10282,68 +10299,95 @@ end subroutine output_chrt2
 
       maxNum = 0
       kk = 0
-      allocate(num_a(NLINKSL))
-      cache_block = 256
-      num_a = 0
-      tmp_num = 0
-      do cache_idx = 0, gnlinksl-1, cache_block
-         cache_block_begin = cache_idx + 1
-         cache_block_end = min(cache_idx + cache_block, gnlinksl)
-         do m = 1, NLINKSL
-            tmp_num = num_a(m)
-            do k = cache_block_begin, cache_block_end
-               if(gto(k) .eq. LINKID(m) ) then
-                  kk = kk +1
-                  tmp_num = tmp_num + 1
-               endif
-            end do
-            num_a(m) = tmp_num
-            num = tmp_num
-            if(num .gt. maxNum) maxNum = num
-         end do
-      end do
 
-      allocate(ind(kk))
-      allocate(gToNodeOut(NLINKSL,maxNum+1))
-      gToNodeOut = -99
-      allocate(tmpTYPEL(kk))
-      allocate(tmpLINKID(kk))
-      allocate(tmpLAKEIDA(kk))
-      allocate(tmpOUTLAKEID(kk))
-      allocate(tmpTO_NODE(kk))
+            ! The following loops are replaced by a hashtable-based algorithm
+      ! do m = 1, NLINKSL
+      !       num = 0
+      !       do k = 1, gnlinksl
+      !          if(gto(k) .eq. LINKID(m) ) then
+      !              kk = kk +1
+      !              num = num + 1
+      !          endif
+      !       end do
+      !       if(num .gt. maxNum) maxNum = num
+      ! end do
 
-      if(kk .gt. 0) then
-         tmpOUTLAKEID = -999
-         tmpTYPEL = -999
-         tmpTO_NODE = -999
-      endif
-      if(NLINKSL .gt. 0) then
-         OUTLAKEID = -999
-         TYPEL = -999
-      endif
 
-      num_a = 1
-      tmp_num = 0
-      kk = 0
-      do cache_idx = 0, gnlinksl-1, cache_block
-         cache_block_begin = cache_idx + 1
-         cache_block_end = min(cache_idx + cache_block, gnlinksl)
-         do m = 1, NLINKSL
-            tmp_num = num_a(m)
-            do k = cache_block_begin, cache_block_end
-               if(gto(k) .eq. LINKID(m) ) then
-                  kk = kk +1
-                  ind(kk) = k
-                  tmpTO_NODE(kk) = gto(k)
-                  gToNodeOut(m,tmp_num+1) = kk
-                  gToNodeOut(m,1) = tmp_num
-                  tmp_num = tmp_num + 1
-               endif
-            end do
-            num_a(m) = tmp_num
-         end do
-      end do
-      deallocate(num_a)
+
+      block
+        type(hash_t) :: hash_table
+        integer :: val,it
+        integer, allocatable :: num_a(:)
+        logical :: found
+        
+        allocate(num_a(NLINKSL))
+        num_a = 0
+        kk = 0
+        
+        call hash_table%set_all_idx(linkid, NLINKSL)
+        do it=1, gnlinksl
+           call hash_table%get(gto(it), val, found)
+           if(found .eqv. .true.) then
+              kk = kk + 1
+              num_a(val) = num_a(val) + 1
+           end if
+        end do
+        maxNum = maxval(num_a)
+        num_a = 1
+      
+        allocate(ind(kk))
+        allocate(gToNodeOut(NLINKSL,maxNum+1))
+        gToNodeOut = -99
+        allocate(tmpTYPEL(kk))
+        allocate(tmpLINKID(kk))
+        allocate(tmpLAKEIDA(kk))
+        allocate(tmpOUTLAKEID(kk))
+        allocate(tmpTO_NODE(kk))
+        
+        if(kk .gt. 0) then
+           tmpOUTLAKEID = -999
+           tmpTYPEL = -999
+           tmpTO_NODE = -999
+        endif
+        if(NLINKSL .gt. 0) then
+           OUTLAKEID = -999
+           TYPEL = -999
+        endif
+        
+        kk = 0
+        
+        ! The following loops are replaced by a hashtable-based algorithm
+        ! do m = 1, NLINKSL
+        !          num = 1
+        !          do k = 1, gnlinksl
+        !              if(gto(k) .eq. LINKID(m) ) then
+        !                  kk = kk +1
+        !                  ind(kk) = k
+        !                  tmpTO_NODE(kk) = gto(k)
+        !                  gToNodeOut(m,num+1) = kk
+        !                  gToNodeOut(m,1) = num
+        !                  num = num + 1
+        !              endif
+        !           end do
+        ! enddo
+        
+        do it=1, gnlinksl
+           call hash_table%get(gto(it), val, found)
+           if(found .eqv. .true.) then
+              kk = kk + 1
+              ind(kk) = it
+              tmpTO_NODE(kk) = gto(it)
+              gToNodeOut(val,num_a(val)+1) = kk
+              gToNodeOut(val,1) = num_a(val)
+              num_a(val) = num_a(val) + 1
+           end if
+        end do
+        
+        deallocate(num_a)
+        call hash_table%clear()
+        
+      end block
+      
       size2 = kk
       deallocate (gto)
 
@@ -10533,8 +10577,6 @@ end subroutine output_chrt2
 !       integer tmpBuf(GNLINKSL)
         integer, dimension(nlakes) :: lakemask
         integer ii
-        integer, allocatable :: num_a(:)
-        integer :: tmp_num, cache_block_begin, cache_block_end, cache_idx, cache_block
 
       allocate (gto(GNLINKSL))
       allocate (gtoLakeId_g(GNLINKSL))
@@ -10551,56 +10593,82 @@ end subroutine output_chrt2
 
       maxNum = 0
       kk = 0
-      allocate(num_a(NLINKSL))
-      cache_block = 256
-      num_a = 0
-      tmp_num = 0
-      do cache_idx = 0, gnlinksl-1, cache_block
-         cache_block_begin = cache_idx + 1
-         cache_block_end = min(cache_idx + cache_block, gnlinksl)
-         do m = 1, NLINKSL
-            tmp_num = num_a(m)
-            do k = cache_block_begin, cache_block_end
-               if(gto(k) .eq. LINKID(m) ) then
-                  gtoLakeId_g(k) = lakeida(m)
-                  kk = kk +1
-                  tmp_num = tmp_num + 1
-               endif
-            end do
-            num_a(m) = tmp_num
-            num = tmp_num
-            if(num .gt. maxNum) maxNum = num
-         end do
-      end do
 
-      allocate(ind(kk))
-      allocate(gToNodeOut(NLINKSL,maxNum+1))
-      gToNodeOut = -99
-      allocate(tmpLAKEIDA(kk))
-      allocate(tmpTO_NODE(kk))
+      ! The following loops are replaced by a hashtable-based algorithm
+      ! do m = 1, NLINKSL
+      !    num = 0
+      !    do k = 1, gnlinksl
+      !       if(gto(k) .eq. LINKID(m) ) then
+      !          gtoLakeId_g(k) = lakeida(m)
+      !          kk = kk +1
+      !          num = num + 1
+      !       endif
+      !    end do
+      !    if(num .gt. maxNum) maxNum = num
+      ! end do
 
-      num_a = 1
-      tmp_num = 0
-      kk = 0
-      do cache_idx = 0, gnlinksl-1, cache_block
-         cache_block_begin = cache_idx + 1
-         cache_block_end = min(cache_idx + cache_block, gnlinksl)
-         do m = 1, NLINKSL
-            tmp_num = num_a(m)
-            do k = cache_block_begin, cache_block_end
-               if(gto(k) .eq. LINKID(m) ) then
-                  kk = kk +1
-                  ind(kk) = k
-                  tmpTO_NODE(kk) = gto(k)
-                  gToNodeOut(m,tmp_num+1) = kk
-                  gToNodeOut(m,1) = tmp_num
-                  tmp_num = tmp_num + 1
-               endif
-            end do
-            num_a(m) = tmp_num
-         end do
-      end do
-      deallocate(num_a)
+      block
+        type(hash_t) :: hash_table
+        integer :: val,it
+        integer, allocatable :: num_a(:)
+        logical :: found
+        
+        allocate(num_a(NLINKSL))
+        num_a = 0
+        kk = 0
+         
+        call hash_table%set_all_idx(linkid, NLINKSL)
+        do it=1, gnlinksl
+           call hash_table%get(gto(it), val, found)
+           if(found .eqv. .true.) then
+              gtoLakeId_g(it) = lakeida(val)
+              kk = kk + 1
+              num_a(val) = num_a(val) + 1
+           end if
+        end do
+        maxNum = maxval(num_a)
+        num_a = 1
+        
+        allocate(ind(kk))
+        allocate(gToNodeOut(NLINKSL,maxNum+1))
+        gToNodeOut = -99
+        allocate(tmpLAKEIDA(kk))
+        allocate(tmpTO_NODE(kk))
+        
+        kk = 0 
+        
+        ! The following loops are replaced by a hashtable-based algorithm
+        ! do m = 1, NLINKSL
+        !    num = 1
+        !    do k = 1, gnlinksl
+        !       if(gto(k) .eq. LINKID(m) ) then
+        !          kk = kk +1
+        !          ind(kk) = k
+        !          tmpTO_NODE(kk) = gto(k)
+        !          gToNodeOut(m,num+1) = kk
+        !          gToNodeOut(m,1) = num
+        !          num = num + 1
+        !       endif
+        !    end do
+        ! end do
+        
+        do it=1, gnlinksl
+           call hash_table%get(gto(it), val, found)
+           if(found .eqv. .true.) then
+              kk = kk + 1
+              ind(kk) = it
+              tmpTO_NODE(kk) = gto(it)
+              gToNodeOut(val,num_a(val)+1) = kk
+              gToNodeOut(val,1) = num_a(val)
+              num_a(val) = num_a(val) + 1
+           end if
+        end do
+        
+        deallocate(num_a)
+        call hash_table%clear()
+        
+      end block
+         
       size = kk
       if(allocated(gto)) deallocate (gto)
 

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -40,6 +40,7 @@ MODULE module_Routing
    use module_persistence_levelpool_hybrid, only: persistence_levelpool_hybrid
    use module_rfc_forecasts, only: rfc_forecasts
    use module_hydro_stop, only: HYDRO_stop
+   use hashtable
 
    IMPLICIT NONE
 
@@ -674,8 +675,6 @@ subroutine LandRT_ini(did)
   integer, allocatable, dimension(:) :: buf
   real, allocatable, dimension(:) :: tmpRESHT
   integer :: new_start_i, new_start_j, new_end_i, new_end_j
-  integer :: cache_block, cache_block_begin_i, cache_block_end_i
-  integer :: cache_idx, num_blocks, cache_idx_k, cache_block_begin_k, cache_block_end_k
 
 #ifdef OUTPUT_CHAN_CONN
   real :: connCalcTimeStart, connCalcTimeEnd
@@ -998,28 +997,33 @@ subroutine LandRT_ini(did)
         if(down_id .ge. 0) new_start_j = 2
         if(up_id .ge. 0) new_end_j = rt_domain(did)%jxrt - 1
 
-        cache_block = 256
-        num_blocks = ceiling((new_end_i - new_start_i)/real(cache_block))
-        !$omp parallel do private(cache_idx,cache_block_begin_i,cache_block_end_i,cache_idx_k,i,k) &
-        !$omp private(cache_block_begin_k, cache_block_end_k), schedule(static)
-        do j = new_start_j, new_end_j
-           do cache_idx = 0, num_blocks - 1
-              cache_block_begin_i = new_start_i + cache_idx * cache_block + 1
-              cache_block_end_i = min(cache_block_begin_i + cache_block - 1, new_end_i)
-              do cache_idx_k = 0, rt_domain(did)%LNLINKSL - 1, cache_block
-                 cache_block_begin_k = min(cache_idx_k + 1, rt_domain(did)%LNLINKSL)
-                 cache_block_end_k = min(cache_block_begin_k + cache_block - 1, rt_domain(did)%LNLINKSL)
-                 do i = cache_block_begin_i, cache_block_end_i
-                    do k = cache_block_begin_k, cache_block_end_k
-                       if(rt_domain(did)%CH_LNKRT(i,j) .eq. rt_domain(did)%LLINKID(k) ) then
-                          rt_domain(did)%CH_LNKRT_SL(i,j) = k   !! mapping
-                       endif
-                    end do
-                 end do
-              end do
-           end do
-        end do
-        !$omp end parallel do
+                ! The following loops are replaced by a hashtable-based algorithm
+        ! do k = 1, rt_domain(did)%LNLINKSL
+        !    do j = new_start_j, new_end_j
+        !       do i = new_start_i, new_end_i
+        !          if(rt_domain(did)%CH_LNKRT(i,j) .eq. rt_domain(did)%LLINKID(k) ) then
+        !             rt_domain(did)%CH_LNKRT_SL(i,j) = k   !! mapping
+        !          endif
+        !       end  do
+        !    end do
+        ! end do
+
+        block
+          type(hash_t) :: hash_table
+          integer :: val,ii,jj
+          logical :: found
+          
+          call hash_table%set_all_idx(rt_domain(did)%LLINKID, rt_domain(did)%LNLINKSL)
+          do jj = new_start_j, new_end_j
+             do ii = new_start_i, new_end_i
+                call hash_table%get(rt_domain(did)%CH_LNKRT(ii,jj), val, found)
+                if(found .eqv. .true.) then
+                   rt_domain(did)%CH_LNKRT_SL(ii,jj) = val
+                end if
+             end do
+          end do
+          call hash_table%clear()
+        end block
 
         call getLocalIndx(rt_domain(did)%gnlinksl,rt_domain(did)%LINKID, rt_domain(did)%LLINKID)
 

--- a/trunk/NDHMS/Routing/module_UDMAP.F
+++ b/trunk/NDHMS/Routing/module_UDMAP.F
@@ -33,7 +33,7 @@ module module_UDMAP
   use MODULE_mpp_ReachLS, only : updatelinkv, ReachLS_write_io, com_write1dInt, &
        com_decomp1dInt, pack_decomp_int, pack_decomp_real8
   use module_hydro_stop, only:HYDRO_stop
-
+  use hashtable
 #endif
 
   implicit none
@@ -89,7 +89,6 @@ contains
         integer :: ix_bufid, ii, ixrt,jxrt
         integer, allocatable, dimension(:) :: gbufi,gbufj,bufsize
         real*8 , allocatable, dimension(:) :: gbufw
-        integer :: cache_block, cache_idx, cache_block_begin, cache_block_end
         
         did = 1
         call get_dimension(trim(nlst(did)%UDMAP_FILE), ndata, npid) 
@@ -169,19 +168,32 @@ contains
           bufidflag = -999
        endif
 
-       cache_block = 256
-       do cache_idx = 0, nlinksl - 1, cache_block
-          cache_block_begin = cache_idx + 1
-          cache_block_end = min(cache_idx + cache_block, nlinksl)
-          do i = 1, ix_bufid
-             if(bufidflag(i) /= -999) cycle
-             do j = cache_block_begin, cache_block_end
-                if(bufid_tmp(i) .eq. linkid(j)) then
-                   bufidflag(i) = bufid_tmp(i)
-                endif
-             end do
-          enddo
-       enddo
+       ! The following loops are replaced by a hashtable-based algorithm
+       !  do i = 1, ix_bufid
+       !           do j = 1, nlinksl
+       !                if(bufid_tmp(i) .eq. linkid(j)) then
+       !                   bufidflag(i) = bufid_tmp(i)
+       !                   goto 102
+       !                endif
+       !           end do
+       ! 102       continue
+       !        end do
+
+       block
+         type(hash_t) :: hash_table
+         integer :: val,it
+         logical :: found
+         
+         call hash_table%set_all_idx(bufid_tmp, ix_bufid)
+         do it = 1, nlinksl
+            call hash_table%get(linkid(it), val, found)
+            if(found .eqv. .true.) then
+               bufidflag(val) = bufid_tmp(val)
+            end if
+         end do
+         call hash_table%clear()
+       end block
+
 #ifdef MPP_LAND
       call com_write1dInt(bufidflag,ix_bufid,gbufid,npid)
 #endif


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: performance improvement, hashtable lookup to build topology, initialization

SOURCE: Alessandro Fanfarillo - NCAR 

DESCRIPTION OF CHANGES: Several routines during the initialization were implemented with loops over the arrays of local and global links. This PR replaces those loops with searches into a hashtable-like structure. This new approach is faster than the previous one. This PR is an improved version of #487 .

ISSUE: None

TESTS CONDUCTED: nwm_ana, nwm_long_range, gridded and reach using the croton_ny domain.

NOTES: The current hash function of the hashtable is a simple identity passed through a modulo operator. A better memory usage can be reached with a better hash function (fewer collisions). The hashtable module is a revised version of the hashtable implemented in https://github.com/jl2922/fhash. This code is released under MIT License and it can be made part of the WRF-Hydro code.

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [x] Backwards compatible
 - [x] Requires new files? If so, how to generate them.
 - [x] Fully documented
 - [ ] Short description in the Development section of `NEWS.md`
