### PR TITLE
Allocate and deallocate tmpAssimilated* variables

### DIFF
--- a/trunk/NDHMS/MPP/mpp_land.F
+++ b/trunk/NDHMS/MPP/mpp_land.F
@@ -1935,7 +1935,8 @@ MODULE MODULE_MPP_LAND
 
      subroutine write_lake_char(v,nodelist_in,nlakes)
         implicit none
-        character(len=256) recv(nlakes), v(nlakes)
+        character(len=256) recv(nlakes)
+        character(len=256), allocatable, intent(inout) :: v(:)
         integer nodelist(nlakes), nlakes, nodelist_in(nlakes)
         integer i, ierr, tag, k, in_len
         integer length, node

--- a/trunk/NDHMS/MPP/mpp_land.F
+++ b/trunk/NDHMS/MPP/mpp_land.F
@@ -2382,9 +2382,9 @@ MODULE MODULE_MPP_LAND
      subroutine updateLake_seq_char(in,nsize,in0)
        implicit none
        integer :: nsize
-       character(len=256), dimension(nsize) :: in
+       character(len=256), dimension(nsize), intent(inout) :: in
        character(len=256), dimension(nsize) :: tmp
-       character(len=256), dimension(:) :: in0
+       character(len=256), dimension(:), intent(in) :: in0
        integer tag, i, status, ierr, k, in_len
        if(nsize .le. 0) return
 

--- a/trunk/NDHMS/Routing/module_channel_routing.F
+++ b/trunk/NDHMS/Routing/module_channel_routing.F
@@ -1686,6 +1686,8 @@ end subroutine drive_CHANNEL
             allocate(tmpQLAKEI(NLAKES))
             allocate(tmpRESHT(NLAKES))
             allocate(tmpFinalResType(nlakes))
+            allocate(tmpAssimilatedValue(NLAKES))
+            allocate(tmpAssimilatedSourceFile(NLAKES))
 #ifdef MPP_LAND
         endif
 #endif
@@ -1982,6 +1984,8 @@ if(my_id .eq. io_id)      then
    if(allocated(tmpQLAKEI))  deallocate(tmpQLAKEI)
    if(allocated(tmpRESHT))  deallocate(tmpRESHT)
    if(allocated(tmpFinalResType)) deallocate(tmpFinalResType)
+   if(allocated(tmpAssimilatedSourceFile)) deallocate(tmpAssimilatedSourceFile)
+   if(allocated(tmpAssimilatedValue)) deallocate(tmpAssimilatedValue)
 endif
 #endif
 

--- a/trunk/NDHMS/Routing/module_channel_routing.F
+++ b/trunk/NDHMS/Routing/module_channel_routing.F
@@ -1688,6 +1688,7 @@ end subroutine drive_CHANNEL
             allocate(tmpFinalResType(nlakes))
             allocate(tmpAssimilatedValue(NLAKES))
             allocate(tmpAssimilatedSourceFile(NLAKES))
+            tmpAssimilatedSourceFile = repeat(char(0), 256)
 #ifdef MPP_LAND
         endif
 #endif


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: lakeout, assimilation, channel-routing

SOURCE: Ryan Cabell, NCAR

DESCRIPTION OF CHANGES: Add missing allocate / deallocate of tmpAssimilatedValue and tmpAssimilatedSourceFile in drive_CHANNEL_RSL routine.

TESTS CONDUCTED: Local testing

NOTES: This is a potential fix for crashing observed on WCOSS but is a bug that needs to be addressed in any case.