### PR TITLE
PGI Fortran 20.4 compatibility patches

### DIFF
--- a/trunk/NDHMS/IO/netcdf_layer.f90
+++ b/trunk/NDHMS/IO/netcdf_layer.f90
@@ -4,15 +4,15 @@ module netcdf_layer_base
   include "mpif.h"
   
   type, abstract :: NetCDF_layer_
-     procedure (nf90_open), pointer, nopass :: open_file => nf90_open
-     procedure (nf90_def_dim), pointer, nopass :: def_dim => nf90_def_dim
-     procedure (nf90_inq_varid), pointer, nopass :: inq_varid => nf90_inq_varid
-     procedure (nf90_close), pointer, nopass :: close_file => nf90_close
+     procedure (nf90_open), pointer, nopass :: open_file    ! => nf90_open
+     procedure (nf90_def_dim), pointer, nopass :: def_dim !=> nf90_def_dim
+     procedure (nf90_inq_varid), pointer, nopass :: inq_varid !=> nf90_inq_varid
+     procedure (nf90_close), pointer, nopass :: close_file !=> nf90_close
 
-     procedure (integer), pointer, nopass :: put_var => nf_put_var
-     procedure (integer), pointer, nopass :: get_var => nf_get_var
-     procedure (integer), pointer, nopass :: put_att => nf_put_att
-     procedure (integer), pointer, nopass :: def_var => nf_def_var
+     procedure (integer), pointer, nopass :: put_var !=> nf_put_var
+     procedure (integer), pointer, nopass :: get_var !=> nf_get_var
+     procedure (integer), pointer, nopass :: put_att !=> nf_put_att
+     procedure (integer), pointer, nopass :: def_var !=> nf_def_var
    contains
      procedure (create_file_signature), pass(object), deferred :: create_file
   end type NetCDF_layer_

--- a/trunk/NDHMS/OrchestratorLayer/io_manager.f90
+++ b/trunk/NDHMS/OrchestratorLayer/io_manager.f90
@@ -27,8 +27,10 @@ contains
 
     if( IOManager_init%parallel .eqv. .false.) then
        allocate(NetCDF_serial_ :: IOManager_init%netcdf_layer)
+       IOManager_init%netcdf_layer%open_file => nf90_open
     else
        allocate(NetCDF_parallel_ :: IOManager_init%netcdf_layer)
+       IOManager_init%netcdf_layer%open_file => nf90_open
     end if
     
   end function IOManager_init

--- a/trunk/NDHMS/Routing/module_HYDRO_io.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_io.F
@@ -9317,19 +9317,20 @@ end function get_netcdf_dim
 subroutine readBucket_nhd(infile, numbasns, gw_buck_coeff, gw_buck_exp, &
                 gw_buck_loss, z_max, z_init, LINKID, nhdBuckMask)
     implicit none
-    integer :: numbasns
+    integer, intent(in) :: numbasns
     integer(kind=int64), dimension(numbasns) :: LINKID
     real, dimension(numbasns) :: gw_buck_coeff, gw_buck_exp, gw_buck_loss
     real, dimension(numbasns) :: z_max, z_init
     integer, dimension(numbasns) :: nhdBuckMask
-    character(len=*) :: infile
+    character(len=*), intent(in) :: infile
 !   define temp array
-    integer :: i,j,k, gnid, ncid, varid, ierr, dimid, iret
+    integer, volatile :: i,j,k, gnid, ncid, varid, ierr, dimid, iret
     integer(kind=int64), allocatable, dimension(:) :: tmpLinkid
     real, allocatable, dimension(:) :: tmpCoeff, tmpExp, tmpLoss
     real, allocatable, dimension(:) :: tmpz_max, tmpz_init
 
 !   get gnid
+    gnid = 0
 #ifdef MPP_LAND
     if(my_id .eq. io_id ) then
 #endif
@@ -9343,7 +9344,7 @@ subroutine readBucket_nhd(infile, numbasns, gw_buck_coeff, gw_buck_exp, &
                !print*, "nf90_inq_dimid:  BasinDim"
                call hydro_stop("Failed read GBUCKETPARM - nf90_inq_dimid:  BasinDim")
        endif
-       iret = nf90_inquire_dimension(ncid, dimid, len = gnid)
+       iret = nf90_inquire_dimension(ncid, dimid, len=gnid)
     endif
     call mpp_land_bcast_int1(gnid)
 #endif

--- a/trunk/NDHMS/arc/macros.mpp.linux
+++ b/trunk/NDHMS/arc/macros.mpp.linux
@@ -51,11 +51,11 @@ endif
 RM		=	rm -f  
 RMD		=	rm -f    
 COMPILER90=	mpif90
-F90FLAGS  =     -Mfree -c -byteswapio -O2 -Kieee 
+F90FLAGS  =     -g -Mfree -c -byteswapio -O2 -Kieee 
 LDFLAGS  =      $(F90FLAGS)
-MODFLAG	=	-I./ -I ../../MPP -I ../MPP -I ../mod 
+MODFLAG	=	-I./ -I ../../MPP -I ../MPP -I ../mod -I ../../mod -I ../../../mod
 LDFLAGS	=	
-CPPINVOKE	=
+CPPINVOKE	= -Mpreprocess
 CPPFLAGS	=  -DMPP_LAND -I../Data_Rec $(HYDRO_D) $(SPATIAL_SOIL) $(WRF_HYDRO_NUDGING) $(OUTPUT_CHAN_CONN) $(PRECIP_DOUBLE)
 LIBS 	=	
 NETCDFINC	=	$(NETCDF_INC) 


### PR DESCRIPTION
TYPE: compatibility enhancement

KEYWORDS: compiler

SOURCE: Ryan@NCAR

DESCRIPTION OF CHANGES: PGI Fortran version 20.4 finally supports the Fortran 2008 features used in the model, but a few small changes were required to build correctly and run without crashing when optimization are turned on. Specifically, some variables in the `readBucket_nhd` subroutine  needed to be marked as `volatile` so the PGI optimizer wouldn't move them out of loops. Also, PGI doesn't seem to like static assignment of type-bound procedure pointers to netCDF NF90 routines, so these assignments were moved to the IO_Manager initializer. 

ISSUE: 
```
Fixes #460 
```

TESTS CONDUCTED: Compared values in Croton with Intel build and they match within 1E-4 places. 

**NOTE**: The model built with PGI Fortran, even with optimizations turned on, is 15-20% slower than the Intel Fortran build, so for performance reasons this compiler is not recommended unless no better compiler is available.

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment on why below the bullet.

 - [X] Closes issue #460 (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
 - [ ] Short description in the Development section of `NEWS.md`
