### PR TITLE
Updates the WRF-Hydro NUOPC cap to v5.2.0.

### DIFF
--- a/trunk/NDHMS/CPL/LIS_cpl/module_lis_HYDRO.F
+++ b/trunk/NDHMS/CPL/LIS_cpl/module_lis_HYDRO.F
@@ -88,7 +88,9 @@ module module_lis_HYDRO
         CALL mpi_initialized( mpi_inited, ierr )
         if ( .NOT. mpi_inited ) then
            call MPI_INIT( ierr )  ! stand alone land model.
-           HYDRO_COMM_WORLD = MPI_COMM_WORLD
+           if (ierr /= MPI_SUCCESS) stop "MPI_INIT"
+           call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
+           if (ierr /= MPI_SUCCESS) stop "MPI_COMM_DUP"
         endif
         call MPI_COMM_RANK( HYDRO_COMM_WORLD, my_id, ierr )
         call MPI_COMM_SIZE( HYDRO_COMM_WORLD, numprocs, ierr )

--- a/trunk/NDHMS/CPL/NUOPC_cpl/Makefile
+++ b/trunk/NDHMS/CPL/NUOPC_cpl/Makefile
@@ -43,6 +43,11 @@ override ESMF_F90COMPILECPPFLAGS += -DDEBUG
 override ESMF_CXXCOMPILECPPFLAGS += -DDEBUG
 endif
 
+ifdef DBGBUILD
+ESMF_F90COMPILEOPTS += -g -traceback
+ESMF_CXXCOMPILEOPTS += -g -traceback
+endif
+
 # ###########################
 # Determine Installation Path
 # ###########################

--- a/trunk/NDHMS/CPL/NUOPC_cpl/Makefile
+++ b/trunk/NDHMS/CPL/NUOPC_cpl/Makefile
@@ -68,13 +68,15 @@ MODEL_DIR    := $(abspath $(DIR)/../..)
 else
 MODEL_DIR    := $(abspath $(WRFHYDRO_DIR))
 endif
+MODEL_MKDIR  := $(abspath $(MODEL_DIR))
 MODEL_LIBDIR := $(abspath $(MODEL_DIR)/lib)
 MODEL_MODDIR := $(abspath $(MODEL_DIR)/mod)
 MODEL_MPPDIR := $(abspath $(MODEL_DIR)/MPP)
-MODEL_LIB    := $(abspath $(MODEL_LIBDIR)/libHYDRO.a)
-MODEL_MKDIR  := $(abspath $(MODEL_DIR))
+MODEL_RTGDIR := $(abspath $(MODEL_DIR)/Routing)
+
 MODEL_MK     := $(abspath $(MODEL_MKDIR)/Makefile.comm)
 MODEL_MKINC  := $(abspath $(MODEL_DIR)/macros)
+MODEL_LIB    := $(abspath $(MODEL_LIBDIR)/libHYDRO.a)
 
 MODEL_MODS   := $(abspath $(MODEL_MPPDIR)/module_mpp_land.mod)
 MODEL_MODS   += $(abspath $(MODEL_MPPDIR)/module_cpl_land.mod)
@@ -83,6 +85,8 @@ MODEL_MODS   += $(abspath $(MODEL_MODDIR)/module_rt_data.mod)
 MODEL_MODS   += $(abspath $(MODEL_MODDIR)/module_namelist.mod)
 MODEL_MODS   += $(abspath $(MODEL_MODDIR)/module_hydro_io.mod)
 MODEL_MODS   += $(abspath $(MODEL_MODDIR)/module_lsm_forcing.mod)
+MODEL_MODS   += $(abspath $(MODEL_RTGDIR)/Overland/overland_data.mod)
+MODEL_MODS   += $(abspath $(MODEL_RTGDIR)/Overland/overland_control.mod)
 
 MODEL_FILES  := $(MODEL_LIB) $(MODEL_MODS)
 

--- a/trunk/NDHMS/CPL/NUOPC_cpl/Makefile
+++ b/trunk/NDHMS/CPL/NUOPC_cpl/Makefile
@@ -69,10 +69,11 @@ endif
 # ###############
 
 ifndef WRFHYDRO_DIR
-MODEL_DIR    := $(abspath $(DIR)/../..)
+MODEL_RDIR   := $(abspath $(DIR)/../../../..)
 else
-MODEL_DIR    := $(abspath $(WRFHYDRO_DIR))
+MODEL_RDIR   := $(abspath $(WRFHYDRO_DIR))
 endif
+MODEL_DIR    := $(abspath $(MODEL_RDIR)/trunk/NDHMS)
 MODEL_MKDIR  := $(abspath $(MODEL_DIR))
 MODEL_LIBDIR := $(abspath $(MODEL_DIR)/lib)
 MODEL_MODDIR := $(abspath $(MODEL_DIR)/mod)
@@ -211,17 +212,29 @@ $(CAP_VERS):
 	@echo $(HR)
 	@echo "Generating Version Information"
 	@echo
-	@echo "# NUOPC Cap Version" > $(CAP_VERS)
-	@if [ -d .svn ]; then \
-	  echo "SVN Repository" > $(CAP_VERS); \
-	  svn info . | grep URL >> $(CAP_VERS); \
-	  svn info . | grep "Last Changed Rev" >> $(CAP_VERS); \
-	elif [ -d .git ]; then \
-	  echo "Git Repository" > $(CAP_VERS); \
-	  git show . | grep -m 1 "commit " >> $(CAP_VERS); \
-	  git show . | grep -m 1 "Author: " >> $(CAP_VERS); \
-	  git show . | grep -m 1 "Date: " >> $(CAP_VERS); \
-	fi
+ifneq (,$(wildcard $(MODEL_RDIR)/.git))
+	@echo "# NUOPC Cap Revision #" > $(CAP_VERS)
+	@git log . | grep -m 1 "commit " >> $(CAP_VERS)
+	@git log . | grep -m 1 "Author: " >> $(CAP_VERS)
+	@git log . | grep -m 1 "Date: " >> $(CAP_VERS)
+	@echo >> $(CAP_VERS)
+	@echo "# Model Revision     #" >> $(CAP_VERS)
+	@git log $(MODEL_RDIR) | grep -m 1 "commit " >> $(CAP_VERS)
+	@git log $(MODEL_RDIR) | grep -m 1 "Author: " >> $(CAP_VERS)
+	@git log $(MODEL_RDIR) | grep -m 1 "Date: " >> $(CAP_VERS)
+	@echo >> $(CAP_VERS)
+else ifneq (,$(wildcard $(MODEL_RDIR)/.svn))
+	@echo "# NUOPC Cap Revision #" > $(CAP_VERS)
+	@svn info . | grep URL >> $(CAP_VERS)
+	@svn info . | grep "Last Changed Rev" >> $(CAP_VERS)
+	@echo >> $(CAP_VERS)
+	@echo "# Model Revision     #" >> $(CAP_VERS)
+	@svn info $(MODEL_RDIR) | grep URL >> $(CAP_VERS)
+	@svn info $(MODEL_RDIR) | grep "Last Changed Rev" >> $(CAP_VERS)
+	@echo >> $(CAP_VERS)
+else
+	@echo "# Version Information Not Found" > $(CAP_VERS)
+endif
 
 $(CAP_MK): 
 	@echo $(HR)
@@ -245,7 +258,7 @@ $(INSTPATH)/%:
 	@echo "Installing $(notdir $@)"
 	@echo
 	@mkdir -p $(INSTPATH)
-	cp $(notdir $@) $@
+	@cp $(notdir $@) $@
 
 install_mk: 
 	@echo $(HR)

--- a/trunk/NDHMS/CPL/NUOPC_cpl/WRFHydro_ESMF_Extensions.F90
+++ b/trunk/NDHMS/CPL/NUOPC_cpl/WRFHydro_ESMF_Extensions.F90
@@ -58,6 +58,7 @@ module WRFHydro_ESMF_Extensions
   public :: WRFHYDRO_ESMF_LogArrayLclVal
   public :: WRFHYDRO_ESMF_LogFarrayLclVal
   public :: WRFHYDRO_ESMF_LogCplList
+  public :: WRFHYDRO_ESMF_ChDir
 
 
 !==============================================================================
@@ -136,6 +137,13 @@ module WRFHydro_ESMF_Extensions
     module procedure WRFHYDRO_ESMF_LogFarrayLclVal_R81D
     module procedure WRFHYDRO_ESMF_LogFarrayLclVal_R82D
     module procedure WRFHYDRO_ESMF_LogFarrayLclVal_R83D
+  end interface
+
+  interface
+    integer function local_chdir(path) bind(C, name="chdir")
+      use iso_c_binding
+      character(c_char) :: path(*)
+    end function
   end interface
 
 !==============================================================================
@@ -5000,5 +5008,44 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     endif
 
   end subroutine
+
+  !-----------------------------------------------------------------------------
+
+#define METHOD "WRFHYDRO_ESMF_ChDir"
+!BOP
+! !IROUTINE: WRFHYDRO_ESMF_ChDir - Change working directory
+! !INTERFACE:
+  ! call using: WRFHYDRO_ESMF_ChDir
+  subroutine WRFHYDRO_ESMF_ChDir(path,rc)
+! ! USES
+    use iso_c_binding
+! ! ARGUMENTS
+    character(*), intent(in)       :: path
+    integer, intent(out), optional :: rc
+! !DESCRIPTION:
+!   Change working directory
+!
+!   The arguments are:
+!   \begin{description}
+!   \end{description}
+!
+!EOP
+  !-----------------------------------------------------------------------------
+    ! local variables
+    integer :: stat
+
+    stat = local_chdir(path//c_null_char)
+    if (stat /= 0) then
+      call ESMF_LogSetError(rcToCheck=ESMF_RC_ARG_BAD,   &
+        msg="WRFHYDRO_ESMF_ChDir failed changing to "//trim(path), &
+        CONTEXT, rcToReturn=stat)
+    else
+      stat = ESMF_SUCCESS
+    endif
+    if (present(rc)) rc = stat
+
+  end subroutine
+
+  !-----------------------------------------------------------------------------
 
 end module WRFHydro_ESMF_Extensions

--- a/trunk/NDHMS/CPL/NUOPC_cpl/WRFHydro_ESMF_Extensions.F90
+++ b/trunk/NDHMS/CPL/NUOPC_cpl/WRFHydro_ESMF_Extensions.F90
@@ -5008,6 +5008,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     endif
 
   end subroutine
+#undef METHOD
 
   !-----------------------------------------------------------------------------
 
@@ -5045,6 +5046,7 @@ type(ESMF_KeywordEnforcer), optional:: keywordEnforcer ! must use keywords below
     if (present(rc)) rc = stat
 
   end subroutine
+#undef METHOD
 
   !-----------------------------------------------------------------------------
 

--- a/trunk/NDHMS/CPL/NUOPC_cpl/WRFHydro_NUOPC_Gluecode.F90
+++ b/trunk/NDHMS/CPL/NUOPC_cpl/WRFHydro_NUOPC_Gluecode.F90
@@ -94,6 +94,7 @@ module wrfhydro_nuopc_gluecode
   type WRFHYDRO_Field
     character(len=64)   :: stdname        = ' '
     character(len=10)   :: units          = ' '
+    character(len=16)   :: stateName      = ' '
     character(len=64)   :: transferOffer  = 'will provide'
     logical             :: adImport       = .FALSE.
     logical             :: realizedImport = .FALSE.
@@ -106,142 +107,142 @@ module wrfhydro_nuopc_gluecode
   type(WRFHYDRO_Field),dimension(46) :: WRFHYDRO_FieldList = (/ &
     WRFHYDRO_Field( & !(01)
       stdname='aerodynamic_roughness_length', units='m', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='z0',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(02)
       stdname='canopy_moisture_storage', units='kg m-2', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='cmc',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(03)
       stdname='carbon_dioxide', units='mol?', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='co2',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(04)
       stdname='cosine_zenith_angle', units='?', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='cosz',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(05)
       stdname='exchange_coefficient_heat', units='?', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='ch',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(06)
       stdname='exchange_coefficient_heat_height2m', units='?', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='ch2',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(07)
       stdname='exchange_coefficient_moisture_height2m', units='?', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='ch2',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(08)
       stdname='ice_mask', units='1', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='xice',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(09)
       stdname='inst_down_lw_flx', units='W m-2', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='lwdown',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(10)
       stdname='inst_down_sw_flx', units='W m-2', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='swdown',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(11)
       stdname='inst_height_lowest', units='m', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='hgt',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(12)
       stdname='inst_merid_wind_height_lowest', units='m s-1', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='vwind',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(13)
       stdname='inst_pres_height_lowest', units='Pa', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='psurf',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(14)
       stdname='inst_pres_height_surface', units='Pa', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='psurf',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(15)
       stdname='inst_spec_humid_height_lowest', units='kg kg-1', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='q2',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(16)
       stdname='inst_temp_height_lowest', units='K', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='sfctmp',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(17)
       stdname='inst_temp_height_surface', units='K', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='sfctmp',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(18)
       stdname='inst_wind_speed_height_lowest', units='m s-1', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='sfcspd',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(19)
       stdname='inst_zonal_wind_height_lowest', units='m s-1', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='uwind',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(20)
       stdname='liquid_fraction_of_soil_moisture_layer_1', units='m3 m-3', &
-      adImport=.TRUE.,adExport=.TRUE.), &
+      stateName='sh2ox1',adImport=.TRUE.,adExport=.TRUE.), &
     WRFHYDRO_Field( & !(21)
       stdname='liquid_fraction_of_soil_moisture_layer_2', units='m3 m-3', &
-      adImport=.TRUE.,adExport=.TRUE.), &
+      stateName='sh2ox2',adImport=.TRUE.,adExport=.TRUE.), &
     WRFHYDRO_Field( & !(22)
       stdname='liquid_fraction_of_soil_moisture_layer_3', units='m3 m-3', &
-      adImport=.TRUE.,adExport=.TRUE.), &
+      stateName='sh2ox3',adImport=.TRUE.,adExport=.TRUE.), &
     WRFHYDRO_Field( & !(23)
       stdname='liquid_fraction_of_soil_moisture_layer_4', units='m3 m-3', &
-      adImport=.TRUE.,adExport=.TRUE.), &
+      stateName='sh2ox4',adImport=.TRUE.,adExport=.TRUE.), &
     WRFHYDRO_Field( & !(24)
       stdname='mean_cprec_rate', units='kg s-1 m-2', &
-      adImport=.FALSE.,adExport=.TRUE.), &
+      stateName='prcpconv',adImport=.FALSE.,adExport=.TRUE.), &
     WRFHYDRO_Field( & !(25)
       stdname='mean_down_lw_flx', units='W m-2', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='lwdown',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(26)
       stdname='mean_down_sw_flx', units='W m-2', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='swdown',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(27)
       stdname='mean_fprec_rate', units='kg s-1 m-2', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='prcp_frozen',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(28)
       stdname='mean_prec_rate', units='kg s-1 m-2', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='prcprain',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(29)
       stdname='mean_surface_albedo', units='lm lm-1', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='albedo',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(30)
       stdname='soil_moisture_fraction_layer_1', units='m3 m-3', &
-      adImport=.TRUE.,adExport=.TRUE.), &
+      stateName='smc1',adImport=.TRUE.,adExport=.TRUE.), &
     WRFHYDRO_Field( & !(31)
       stdname='soil_moisture_fraction_layer_2', units='m3 m-3', &
-      adImport=.TRUE.,adExport=.TRUE.), &
+      stateName='smc2',adImport=.TRUE.,adExport=.TRUE.), &
     WRFHYDRO_Field( & !(32)
       stdname='soil_moisture_fraction_layer_3', units='m3 m-3', &
-      adImport=.TRUE.,adExport=.TRUE.), &
+      stateName='smc3',adImport=.TRUE.,adExport=.TRUE.), &
     WRFHYDRO_Field( & !(33)
       stdname='soil_moisture_fraction_layer_4', units='m3 m-3', &
-      adImport=.TRUE.,adExport=.TRUE.), &
+      stateName='smc4',adImport=.TRUE.,adExport=.TRUE.), &
     WRFHYDRO_Field( & !(34)
       stdname='soil_porosity', units='1', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='smcmax1',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(35)
       stdname='subsurface_runoff_amount', units='kg m-2', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='soldrain',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(36)
       stdname='surface_runoff_amount', units='kg m-2', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='infxsrt',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(37)
       stdname='surface_snow_thickness', units='m', &
-      adImport=.FALSE.,adExport=.TRUE.), & 
+      stateName='snowdepth',adImport=.FALSE.,adExport=.TRUE.), & 
     WRFHYDRO_Field( & !(38)
       stdname='soil_temperature_layer_1', units='K', &
-      adImport=.TRUE.,adExport=.FALSE.), &
+      stateName='stc1',adImport=.TRUE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(39)
       stdname='soil_temperature_layer_2', units='K', &
-      adImport=.TRUE.,adExport=.FALSE.), &
+      stateName='stc2',adImport=.TRUE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(40)
       stdname='soil_temperature_layer_3', units='K', &
-      adImport=.TRUE.,adExport=.FALSE.), &
+      stateName='stc3',adImport=.TRUE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(41)
       stdname='soil_temperature_layer_4', units='K', &
-      adImport=.TRUE.,adExport=.FALSE.), &
+      stateName='stc4',adImport=.TRUE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(42)
       stdname='vegetation_type', units='1', &
-      adImport=.FALSE.,adExport=.FALSE.), &
+      stateName='vegtyp',adImport=.FALSE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(43)
       stdname='volume_fraction_of_total_water_in_soil', units='m3 m-3', &
-      adImport=.FALSE.,adExport=.TRUE.), & 
+      stateName='snliqv',adImport=.FALSE.,adExport=.TRUE.), & 
     WRFHYDRO_Field( & !(44)
       stdname='surface_water_depth', units='mm', &
-      adImport=.FALSE.,adExport=.TRUE.), &
+      stateName='sfchead',adImport=.FALSE.,adExport=.TRUE.), &
     WRFHYDRO_Field( & !(45)
       stdname='time_step_infiltration_excess', units='mm', &
-      adImport=.TRUE.,adExport=.FALSE.), &
+      stateName='infxsrt',adImport=.TRUE.,adExport=.FALSE.), &
     WRFHYDRO_Field( & !(46)
       stdname='soil_column_drainage', units='mm', &
-      adImport=.TRUE.,adExport=.FALSE.)/)
+      stateName='soldrain',adImport=.TRUE.,adExport=.FALSE.)/)
 
   ! PARAMETERS
   character(len=ESMF_MAXSTR) :: indir = 'WRFHYDRO_FORCING'
@@ -686,11 +687,11 @@ contains
 #undef METHOD
 #define METHOD "WRFHYDRO_FieldCreate"
 
-  function WRFHYDRO_FieldCreate(stdName,grid,did,rc)
+  function WRFHYDRO_FieldCreate(stateName,grid,did,rc)
     ! RETURN VALUE
     type(ESMF_Field) :: WRFHYDRO_FieldCreate
     ! ARGUMENTS
-    character(*), intent(in)                :: stdName
+    character(*), intent(in)                :: stateName
     type(ESMF_Grid), intent(in)             :: grid
     integer, intent(in)                     :: did
     integer,          intent(out)           :: rc
@@ -702,105 +703,95 @@ contains
 
     rc = ESMF_SUCCESS
 
-    SELECT CASE (trim(stdName))
-      CASE ('liquid_fraction_of_soil_moisture_layer_1')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+    SELECT CASE (trim(stateName))
+      CASE ('sh2ox1')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%sh2ox(:,:,1), &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('liquid_fraction_of_soil_moisture_layer_2')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('sh2ox2')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%sh2ox(:,:,2), &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('liquid_fraction_of_soil_moisture_layer_3')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('sh2ox3')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%sh2ox(:,:,3), &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('liquid_fraction_of_soil_moisture_layer_4')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('sh2ox4')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%sh2ox(:,:,4), &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('soil_moisture_fraction_layer_1')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('smc1')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%smc(:,:,1), &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('soil_moisture_fraction_layer_2')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('smc2')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%smc(:,:,2), &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('soil_moisture_fraction_layer_3')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('smc3')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%smc(:,:,3), &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('soil_moisture_fraction_layer_4')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('smc4')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%smc(:,:,4), &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('soil_porosity')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('smcmax1')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%smcmax1, &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('subsurface_runoff_amount')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
-          farray=rt_domain(did)%soldrain, &
-          indexflag=ESMF_INDEX_DELOCAL, rc=rc)
-        if (ESMF_STDERRORCHECK(rc)) return
-      CASE ('surface_runoff_amount')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
-          farray=rt_domain(did)%infxsrt, &
-          indexflag=ESMF_INDEX_DELOCAL, rc=rc)
-        if (ESMF_STDERRORCHECK(rc)) return
-      CASE ('soil_temperature_layer_1')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('stc1')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%stc(:,:,1), &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('soil_temperature_layer_2')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('stc2')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%stc(:,:,2), &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('soil_temperature_layer_3')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('stc3')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%stc(:,:,3), &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('soil_temperature_layer_4')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('stc4')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%stc(:,:,4), &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('vegetation_type')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('vegtyp')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%vegtyp, &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('surface_water_depth')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('sfchead')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%overland%control%surface_water_head_lsm, &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
-      CASE ('time_step_infiltration_excess')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('infxsrt')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%infxsrt, &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if (ESMF_STDERRORCHECK(rc)) return
-      CASE ('soil_column_drainage')
-        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
+      CASE ('soldrain')
+        WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stateName, grid=grid, &
           farray=rt_domain(did)%soldrain, &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if (ESMF_STDERRORCHECK(rc)) return
       CASE DEFAULT
         call ESMF_LogSetError(ESMF_RC_ARG_OUTOFRANGE, &
-          msg=METHOD//": Field hookup missing: "//trim(stdName), &
+          msg=METHOD//": Field hookup missing: "//trim(stateName), &
           file=FILENAME,rcToReturn=rc)
         return  ! bail out
     END SELECT
@@ -1274,13 +1265,13 @@ contains
         forcingCount = forcingCount + 1
         ! Check itemType to see if field exists in state
         call ESMF_StateGet(importState, &
-          itemName=trim(WRFHYDRO_FieldList(fieldIndex)%stdname), &
+          itemName=trim(WRFHYDRO_FieldList(fieldIndex)%stateName), &
           itemType=itemType, rc=rc)
         if (ESMF_STDERRORCHECK(rc)) return
 
         if (itemType == ESMF_STATEITEM_FIELD) then
           if (NUOPC_IsConnected(importState, &
-          fieldName=trim(WRFHYDRO_FieldList(fieldIndex)%stdname))) then
+          fieldName=trim(WRFHYDRO_FieldList(fieldIndex)%stateName))) then
             connectedCount = connectedCount + 1
           endif
         endif

--- a/trunk/NDHMS/CPL/NUOPC_cpl/WRFHydro_NUOPC_Gluecode.F90
+++ b/trunk/NDHMS/CPL/NUOPC_cpl/WRFHydro_NUOPC_Gluecode.F90
@@ -44,6 +44,10 @@ module wrfhydro_nuopc_gluecode
     cpl_outdate
   use module_rt_data, only: &
     rt_domain
+  use overland_data, only: &
+    overland_struct
+  use overland_control, only: &
+    overland_control_struct
   use module_namelist, only: &
     nlst_rt, &
     read_rt_nlst
@@ -781,7 +785,7 @@ contains
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
       CASE ('surface_water_depth')
         WRFHYDRO_FieldCreate = ESMF_FieldCreate(name=stdName, grid=grid, &
-          farray=rt_domain(did)%sfcheadrt, &
+          farray=rt_domain(did)%overland%control%surface_water_head_lsm, &
           indexflag=ESMF_INDEX_DELOCAL, rc=rc)
         if(ESMF_STDERRORCHECK(rc)) return ! bail out
       CASE ('time_step_infiltration_excess')

--- a/trunk/NDHMS/CPL/NUOPC_cpl/WRFHydro_NUOPC_Gluecode.F90
+++ b/trunk/NDHMS/CPL/NUOPC_cpl/WRFHydro_NUOPC_Gluecode.F90
@@ -48,11 +48,11 @@ module wrfhydro_nuopc_gluecode
     overland_struct
   use overland_control, only: &
     overland_control_struct
-  use module_namelist, only: &
-    nlst_rt, &
-    read_rt_nlst
   use module_lsm_forcing, only: &
     read_ldasout
+  use config_base, only: &
+    nlst, &
+    init_namelist_rt_field
 !  use module_gw_gw2d_data, only: &
 !    gw2d
 !  use module_domain, only: &
@@ -323,36 +323,43 @@ contains
     if(ESMF_STDERRORCHECK(rc)) return ! bail out
 
     ! Set default namelist values
-    read (startTimeStr(1:4),"(I)")   nlst_rt(did)%START_YEAR
-    read (startTimeStr(6:7),"(I)")   nlst_rt(did)%START_MONTH
-    read (startTimeStr(9:10),"(I)")  nlst_rt(did)%START_DAY
-    read (startTimeStr(12:13),"(I)") nlst_rt(did)%START_HOUR
-    read (startTimeStr(15:16),"(I)") nlst_rt(did)%START_MIN
-    nlst_rt(did)%startdate(1:19) = startTimeStr(1:19)
-    nlst_rt(did)%olddate(1:19)   = startTimeStr(1:19)
-    nlst_rt(did)%dt = dt
+    read (startTimeStr(1:4),"(I)")   nlst(did)%START_YEAR
+    read (startTimeStr(6:7),"(I)")   nlst(did)%START_MONTH
+    read (startTimeStr(9:10),"(I)")  nlst(did)%START_DAY
+    read (startTimeStr(12:13),"(I)") nlst(did)%START_HOUR
+    read (startTimeStr(15:16),"(I)") nlst(did)%START_MIN
+    nlst(did)%startdate(1:19) = startTimeStr(1:19)
+    nlst(did)%olddate(1:19)   = startTimeStr(1:19)
+    nlst(did)%dt = dt
     cpl_outdate = startTimeStr(1:19)
-    nlst_rt(did)%nsoil=4
-    allocate(nlst_rt(did)%zsoil8(4),stat=stat)
+    nlst(did)%nsoil=4
+    allocate(nlst(did)%zsoil8(4),stat=stat)
     if (ESMF_LogFoundAllocError(statusToCheck=stat, &
       msg=METHOD//': Allocation of model soil depths memory failed.', &
       file=FILENAME, rcToReturn=rc)) return ! bail out
-    nlst_rt(did)%zsoil8(1:4)=(/-0.1,-0.4,-1.0,-2.0/)
-    nlst_rt(did)%geo_static_flnm = "geo_em.d01.nc"
-    nlst_rt(did)%geo_finegrid_flnm = "fulldom_hires_hydrofile.d01.nc"
-    nlst_rt(did)%sys_cpl = 2
-    nlst_rt(did)%IGRID = did
-    write(nlst_rt(did)%hgrid,'(I1)') did
+    nlst(did)%zsoil8(1:4)=(/-0.1,-0.4,-1.0,-2.0/)
+    nlst(did)%geo_static_flnm = "geo_em.d01.nc"
+    nlst(did)%geo_finegrid_flnm = "fulldom_hires_hydrofile.d01.nc"
+    nlst(did)%sys_cpl = 2
+    nlst(did)%IGRID = did
+    write(nlst(did)%hgrid,'(I1)') did
 
-    ! Read information from hydro.namelist config file
-    call read_rt_nlst(nlst_rt(did))
+    if(nlst(did)%dt .le. 0) then
+      call ESMF_LogSetError(ESMF_RC_ARG_OUTOFRANGE, &
+        msg=METHOD//": Timestep less than 1 is not supported!", &
+        file=FILENAME,rcToReturn=rc)
+      return  ! bail out
+    endif
+
+!    ! Read information from hydro.namelist config file
+     call init_namelist_rt_field(did)
 
 #if DEBUG
     call WRFHYDRO_nlstLog(did,MODNAME,rc=rc)
     if(ESMF_STDERRORCHECK(rc)) return ! bail out
 #endif
 
-    if(nlst_rt(did)%nsoil .gt. 4) then
+    if(nlst(did)%nsoil .gt. 4) then
       call ESMF_LogSetError(ESMF_RC_ARG_OUTOFRANGE, &
         msg=METHOD//": Maximum soil levels supported is 4.", &
         file=FILENAME,rcToReturn=rc)
@@ -360,7 +367,7 @@ contains
     endif
 
     call MPP_LAND_INIT()  ! required before get_file_dimension
-    call get_file_dimension(fileName=nlst_rt(did)%geo_static_flnm,& 
+    call get_file_dimension(fileName=nlst(did)%geo_static_flnm,& 
       ix=nx_global(1),jx=ny_global(1))
 
 #ifdef DEBUG
@@ -380,7 +387,7 @@ contains
     rt_domain(did)%jx = ny_global(1)
 
     call MPP_LAND_PAR_INI(1,rt_domain(did)%ix,rt_domain(did)%jx,&
-         nlst_rt(did)%AGGFACTRT)
+         nlst(did)%AGGFACTRT)
 
     call ESMF_VMBroadcast(vm, startx, count=numprocs, rootPet=IO_id, rc=rc)
     if(ESMF_STDERRORCHECK(rc)) return ! bail out
@@ -446,6 +453,7 @@ contains
 #ifdef DEBUG
     call ESMF_LogWrite(MODNAME//": Enter HYDRO_ini", ESMF_LOGMSG_INFO)
 #endif
+
     if(sf_surface_physics .eq. 5) then
       ! clm4
       ! Use wrfinput vegetation type and soil type
@@ -461,17 +469,18 @@ contains
 #endif
 
     ! Override the clock configuration in hyro.namelist
-    read (startTimeStr(1:4),"(I)")   nlst_rt(did)%START_YEAR
-    read (startTimeStr(6:7),"(I)")   nlst_rt(did)%START_MONTH
-    read (startTimeStr(9:10),"(I)")  nlst_rt(did)%START_DAY
-    read (startTimeStr(12:13),"(I)") nlst_rt(did)%START_HOUR
-    read (startTimeStr(15:16),"(I)") nlst_rt(did)%START_MIN
-    nlst_rt(did)%startdate(1:19) = startTimeStr(1:19)
-    nlst_rt(did)%olddate(1:19)   = startTimeStr(1:19)
-    nlst_rt(did)%dt = dt
+    read (startTimeStr(1:4),"(I)")   nlst(did)%START_YEAR
+    read (startTimeStr(6:7),"(I)")   nlst(did)%START_MONTH
+    read (startTimeStr(9:10),"(I)")  nlst(did)%START_DAY
+    read (startTimeStr(12:13),"(I)") nlst(did)%START_HOUR
+    read (startTimeStr(15:16),"(I)") nlst(did)%START_MIN
+    nlst(did)%startdate(1:19) = startTimeStr(1:19)
+    nlst(did)%olddate(1:19)   = startTimeStr(1:19)
+    nlst(did)%dt = dt
+    nlst(did)%nsoil=4
     cpl_outdate = startTimeStr(1:19)
 
-    if(nlst_rt(did)%dt .le. 0) then
+    if(nlst(did)%dt .le. 0) then
       call ESMF_LogSetError(ESMF_RC_ARG_OUTOFRANGE, &
         msg=METHOD//": Timestep less than 1 is not supported!", &
         file=FILENAME,rcToReturn=rc)
@@ -481,29 +490,29 @@ contains
     ! Adjust the routing timestep and factor
     ! At this point the coupling driver timestep is unknown
     ! and uses WRFHYDRO Config as best guess
-    if(nlst_rt(did)%dtrt_ter .ge. dt) then
-       nlst_rt(did)%dtrt_ter = dt
+    if(nlst(did)%dtrt_ter .ge. nlst(did)%dt) then
+       nlst(did)%dtrt_ter = nlst(did)%dt
        dt_factor0 = 1
     else
-       dt_factor = dt/nlst_rt(did)%dtrt_ter
-       if (dt_factor*nlst_rt(did)%dtrt_ter .lt. dt) &
-         nlst_rt(did)%dtrt_ter = dt/dt_factor
+       dt_factor = nlst(did)%dt/nlst(did)%dtrt_ter
+       if (dt_factor*nlst(did)%dtrt_ter .lt. nlst(did)%dt) &
+         nlst(did)%dtrt_ter = nlst(did)%dt/dt_factor
        dt_factor0 = dt_factor
     endif
 
-    if(nlst_rt(did)%dtrt_ch .ge. dt) then
-      nlst_rt(did)%dtrt_ch = dt
+    if(nlst(did)%dtrt_ch .ge. nlst(did)%dt) then
+      nlst(did)%dtrt_ch = nlst(did)%dt
       dt_factor0 = 1
     else
-      dt_factor = dt/nlst_rt(did)%dtrt_ch
-      if(dt_factor*nlst_rt(did)%dtrt_ch .lt. dt) &
-        nlst_rt(did)%dtrt_ch = dt/dt_factor
+      dt_factor = nlst(did)%dt/nlst(did)%dtrt_ch
+      if(dt_factor*nlst(did)%dtrt_ch .lt. nlst(did)%dt) &
+        nlst(did)%dtrt_ch = nlst(did)%dt/dt_factor
       dt_factor0 = dt_factor
     endif
 
-    dt0 = nlst_rt(did)%dt
-    dtrt_ter0 = nlst_rt(did)%dtrt_ter
-    dtrt_ch0 = nlst_rt(did)%dtrt_ch
+    dt0 = nlst(did)%dt
+    dtrt_ter0 = nlst(did)%dtrt_ter
+    dtrt_ch0 = nlst(did)%dtrt_ch
 
     RT_DOMAIN(did)%initialized = .true.
 
@@ -549,47 +558,47 @@ contains
 
     call WRFHYDRO_ClockToString(clock,timestr=cpl_outdate,rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return
-    nlst_rt(did)%olddate(1:19) = cpl_outdate(1:19) ! Current time is the
+    nlst(did)%olddate(1:19) = cpl_outdate(1:19) ! Current time is the
 
-    nlst_rt(did)%dt = WRFHYDRO_TimeIntervalGetReal(timeInterval=timeStep,rc=rc)
+    nlst(did)%dt = WRFHYDRO_TimeIntervalGetReal(timeInterval=timeStep,rc=rc)
     if(ESMF_STDERRORCHECK(rc)) return ! bail out
 
-    if(nlst_rt(did)%dt .le. 0) then
+    if(nlst(did)%dt .le. 0) then
       call ESMF_LogSetError(ESMF_RC_ARG_OUTOFRANGE, &
         msg=METHOD//": Timestep less than 1 is not supported!", &
         file=FILENAME,rcToReturn=rc)
       return  ! bail out
     endif
 
-    if((dt_factor0*nlst_rt(did)%dtrt_ter) .ne. nlst_rt(did)%dt) then   ! NUOPC driver time step changed.
+    if((dt_factor0*nlst(did)%dtrt_ter) .ne. nlst(did)%dt) then   ! NUOPC driver time step changed.
       call ESMF_LogWrite(METHOD//": Driver timestep changed.",ESMF_LOGMSG_INFO)
-      if(dtrt_ter0 .ge. nlst_rt(did)%dt) then
-        nlst_rt(did)%dtrt_ter = nlst_rt(did)%dt
+      if(dtrt_ter0 .ge. nlst(did)%dt) then
+        nlst(did)%dtrt_ter = nlst(did)%dt
         dt_factor0 = 1
       else
-        dt_factor = nlst_rt(did)%dt / dtrt_ter0
-        if(dt_factor*dtrt_ter0 .lt. nlst_rt(did)%dt) &
-          nlst_rt(did)%dtrt_ter = nlst_rt(did)%dt / dt_factor
+        dt_factor = nlst(did)%dt / dtrt_ter0
+        if(dt_factor*dtrt_ter0 .lt. nlst(did)%dt) &
+          nlst(did)%dtrt_ter = nlst(did)%dt / dt_factor
         dt_factor0 = dt_factor
       endif
     endif
 
-    if((dt_factor0*nlst_rt(did)%dtrt_ch) .ne. nlst_rt(did)%dt) then   ! NUOPD driver time step changed.
+    if((dt_factor0*nlst(did)%dtrt_ch) .ne. nlst(did)%dt) then   ! NUOPD driver time step changed.
       call ESMF_LogWrite(METHOD//": Driver timestep changed.",ESMF_LOGMSG_INFO)
-      if(dtrt_ch0 .ge. nlst_rt(did)%dt) then
-        nlst_rt(did)%dtrt_ch = nlst_rt(did)%dt
+      if(dtrt_ch0 .ge. nlst(did)%dt) then
+        nlst(did)%dtrt_ch = nlst(did)%dt
         dt_factor0 = 1
       else
-        dt_factor = nlst_rt(did)%dt / dtrt_ch0
-        if(dt_factor*dtrt_ch0 .lt. nlst_rt(did)%dt) &
-          nlst_rt(did)%dtrt_ch = nlst_rt(did)%dt / dt_factor
+        dt_factor = nlst(did)%dt / dtrt_ch0
+        if(dt_factor*dtrt_ch0 .lt. nlst(did)%dt) &
+          nlst(did)%dtrt_ch = nlst(did)%dt / dt_factor
         dt_factor0 = dt_factor
       endif
     endif
 
-    if(nlst_rt(did)%SUBRTSWCRT .eq.0  .and. &
-      nlst_rt(did)%OVRTSWCRT .eq. 0 .and. &
-      nlst_rt(did)%GWBASESWCRT .eq. 0) then
+    if(nlst(did)%SUBRTSWCRT .eq.0  .and. &
+      nlst(did)%OVRTSWCRT .eq. 0 .and. &
+      nlst(did)%GWBASESWCRT .eq. 0) then
        call ESMF_LogWrite(METHOD//": SUBRTSWCRT,OVRTSWCRT,GWBASESWCRT are zero!", &
             ESMF_LOGMSG_WARNING)
       !call ESMF_LogSetError(ESMF_RC_ARG_OUTOFRANGE, &
@@ -598,25 +607,25 @@ contains
       !return  ! bail out
     endif
 
-    if((.not. RT_DOMAIN(did)%initialized) .and. (nlst_rt(did)%rst_typ .eq. 1) ) then
+    if((.not. RT_DOMAIN(did)%initialized) .and. (nlst(did)%rst_typ .eq. 1) ) then
       call ESMF_LogWrite(METHOD//": Restart initial data from offline file.", &
         ESMF_LOGMSG_INFO)
     else
 
       select case (mode)
         case (WRFHYDRO_Offline)
-          call read_ldasout(olddate=nlst_rt(did)%olddate(1:19), &
-            hgrid=nlst_rt(did)%hgrid, &
-            indir=trim(indir), dt=nlst_rt(did)%dt, &
+          call read_ldasout(olddate=nlst(did)%olddate(1:19), &
+            hgrid=nlst(did)%hgrid, &
+            indir=trim(indir), dt=nlst(did)%dt, &
             ix=rt_domain(did)%ix,jx=rt_domain(did)%jx, &
             infxsrt=rt_domain(did)%infxsrt,soldrain=rt_domain(did)%soldrain)
         case (WRFHYDRO_Coupled)
 
 
         case (WRFHYDRO_Hybrid)
-          call read_ldasout(olddate=nlst_rt(did)%olddate(1:19), &
-            hgrid=nlst_rt(did)%hgrid, &
-            indir=trim(indir), dt=nlst_rt(did)%dt, &
+          call read_ldasout(olddate=nlst(did)%olddate(1:19), &
+            hgrid=nlst(did)%hgrid, &
+            indir=trim(indir), dt=nlst(did)%dt, &
             ix=rt_domain(did)%ix,jx=rt_domain(did)%jx, &
             infxsrt=rt_domain(did)%infxsrt,soldrain=rt_domain(did)%soldrain)
 
@@ -633,10 +642,10 @@ contains
     call HYDRO_exe(did=did)
 
     ! provide groundwater soil flux to WRF for fully coupled simulations (FERSCH 09/2014)
-    !if(nlst_rt(did)%GWBASESWCRT .eq. 3 ) then
+    !if(nlst(did)%GWBASESWCRT .eq. 3 ) then
       !Wei Yu: comment the following two lines. Not ready
     !yw     qsgw(x_start(1):x_end(1),y_start(1):y_end(1)) = gw2d(did)%qsgw
-    !yw     config_flags%gwsoilcpl = nlst_rt(did)%gwsoilcpl
+    !yw     config_flags%gwsoilcpl = nlst(did)%gwsoilcpl
     !end if
 
 #ifdef DEBUG
@@ -667,7 +676,7 @@ contains
     ! WRF-Hydro finish routine cannot be called because it stops MPI
 
 !    DCR - Turned off to let the model deallocate memory
-!    deallocate(nlst_rt(did)%zsoil8)
+!    deallocate(nlst(did)%zsoil8)
 !    if (ESMF_LogFoundDeallocError(statusToCheck=stat, &
 !      msg=METHOD//': Deallocation of model soil depth memory failed.', &
 !      file=FILENAME,rcToReturn=rc)) return ! bail out
@@ -835,7 +844,7 @@ contains
 
     rc = ESMF_SUCCESS
 
-    WRFHYDRO_GridCreate = ESMF_GridCreate(name='WRFHYDRO_Grid_'//trim(nlst_rt(did)%hgrid), &
+    WRFHYDRO_GridCreate = ESMF_GridCreate(name='WRFHYDRO_Grid_'//trim(nlst(did)%hgrid), &
       distgrid=WRFHYDRO_DistGrid, coordSys = ESMF_COORDSYS_SPH_DEG, &
       coordTypeKind=ESMF_TYPEKIND_COORD, &
 !      gridEdgeLWidth=(/0,0/), gridEdgeUWidth=(/0,1/), &
@@ -849,7 +858,7 @@ contains
     if (ESMF_LogFoundAllocError(statusToCheck=stat, &
       msg=METHOD//': Allocation of latitude memory failed.', &
       file=FILENAME, rcToReturn=rc)) return ! bail out
-    call WRFHYDRO_ESMF_NetcdfReadIXJX("XLAT_M",nlst_rt(did)%geo_static_flnm, &
+    call WRFHYDRO_ESMF_NetcdfReadIXJX("XLAT_M",nlst(did)%geo_static_flnm, &
       (/x_start,y_start/),latitude,rc=rc)
     if(ESMF_STDERRORCHECK(rc)) return ! bail out
 
@@ -858,7 +867,7 @@ contains
     if (ESMF_LogFoundAllocError(statusToCheck=stat, &
       msg=METHOD//': Allocation of longitude memory failed.', &
       file=FILENAME, rcToReturn=rc)) return ! bail out
-    call WRFHYDRO_ESMF_NetcdfReadIXJX("XLONG_M",nlst_rt(did)%geo_static_flnm, &
+    call WRFHYDRO_ESMF_NetcdfReadIXJX("XLONG_M",nlst(did)%geo_static_flnm, &
       (/x_start,y_start/),longitude,rc=rc)
     if(ESMF_STDERRORCHECK(rc)) return ! bail out
 
@@ -900,7 +909,7 @@ contains
     if (ESMF_LogFoundAllocError(statusToCheck=stat, &
       msg=METHOD//': Allocation of mask memory failed.', &
       file=FILENAME, rcToReturn=rc)) return ! bail out
-    call WRFHYDRO_ESMF_NetcdfReadIXJX("LANDMASK",nlst_rt(did)%geo_static_flnm, &
+    call WRFHYDRO_ESMF_NetcdfReadIXJX("LANDMASK",nlst(did)%geo_static_flnm, &
       (/x_start,y_start/),mask,rc=rc)
     if(ESMF_STDERRORCHECK(rc)) return ! bail out
 
@@ -931,12 +940,12 @@ contains
     ! The original WPS implementation used the _CORNER names
     ! but it was then changes to the _C names.  Support both
     ! options.
-    if (WRFHYDRO_ESMF_NetcdfIsPresent("XLAT_CORNER",nlst_rt(did)%geo_static_flnm) .AND. &
-         WRFHYDRO_ESMF_NetcdfIsPresent("XLONG_CORNER",nlst_rt(did)%geo_static_flnm)) then
+    if (WRFHYDRO_ESMF_NetcdfIsPresent("XLAT_CORNER",nlst(did)%geo_static_flnm) .AND. &
+         WRFHYDRO_ESMF_NetcdfIsPresent("XLONG_CORNER",nlst(did)%geo_static_flnm)) then
        xlat_corner_name = "XLAT_CORNER"
        xlon_corner_name = "XLONG_CORNER"
-    else if (WRFHYDRO_ESMF_NetcdfIsPresent("XLAT_C",nlst_rt(did)%geo_static_flnm) .AND. &
-         WRFHYDRO_ESMF_NetcdfIsPresent("XLONG_C",nlst_rt(did)%geo_static_flnm)) then
+    else if (WRFHYDRO_ESMF_NetcdfIsPresent("XLAT_C",nlst(did)%geo_static_flnm) .AND. &
+         WRFHYDRO_ESMF_NetcdfIsPresent("XLONG_C",nlst(did)%geo_static_flnm)) then
        xlat_corner_name = "XLAT_C"
        xlon_corner_name = "XLONG_C"
     else
@@ -950,7 +959,7 @@ contains
       if (ESMF_LogFoundAllocError(statusToCheck=stat, &
         msg=METHOD//': Allocation of corner latitude memory failed.', &
         file=FILENAME, rcToReturn=rc)) return ! bail out
-      call WRFHYDRO_ESMF_NetcdfReadIXJX(trim(xlat_corner_name),nlst_rt(did)%geo_static_flnm, &
+      call WRFHYDRO_ESMF_NetcdfReadIXJX(trim(xlat_corner_name),nlst(did)%geo_static_flnm, &
         (/x_start,y_start/),latitude,rc=rc)
       if(ESMF_STDERRORCHECK(rc)) return ! bail out
 
@@ -959,7 +968,7 @@ contains
       if (ESMF_LogFoundAllocError(statusToCheck=stat, &
        msg=METHOD//': Allocation of corner longitude memory failed.', &
        file=FILENAME, rcToReturn=rc)) return ! bail out
-      call WRFHYDRO_ESMF_NetcdfReadIXJX(trim(xlon_corner_name),nlst_rt(did)%geo_static_flnm, &
+      call WRFHYDRO_ESMF_NetcdfReadIXJX(trim(xlon_corner_name),nlst(did)%geo_static_flnm, &
         (/x_start,y_start/),longitude,rc=rc)
       if(ESMF_STDERRORCHECK(rc)) return ! bail out
 
@@ -1175,7 +1184,7 @@ contains
 
     rc = ESMF_SUCCESS
 
-    WRFHYDRO_get_timestep = nlst_rt(did)%dt
+    WRFHYDRO_get_timestep = nlst(did)%dt
 
 #ifdef DEBUG
     call ESMF_LogWrite(MODNAME//": leaving "//METHOD, ESMF_LOGMSG_INFO)
@@ -1200,7 +1209,7 @@ contains
 
     rc = ESMF_SUCCESS
 
-    nlst_rt(did)%dt = dt
+    nlst(did)%dt = dt
 
 #ifdef DEBUG
     call ESMF_LogWrite(MODNAME//": leaving "//METHOD, ESMF_LOGMSG_INFO)
@@ -1225,7 +1234,7 @@ contains
 
     rc = ESMF_SUCCESS
 
-    hgrid = nlst_rt(did)%hgrid
+    hgrid = nlst(did)%hgrid
 
 #ifdef DEBUG
     call ESMF_LogWrite(MODNAME//": leaving "//METHOD, ESMF_LOGMSG_INFO)
@@ -1472,63 +1481,63 @@ contains
     call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
 
     write (logMsg,"(A,5(I0,A))") ": Start Date     = ", &
-      nlst_rt(did)%START_YEAR,"-",nlst_rt(did)%START_MONTH,"-", &
-      nlst_rt(did)%START_DAY,"_",nlst_rt(did)%START_HOUR,":", &
-      nlst_rt(did)%START_MIN
+      nlst(did)%START_YEAR,"-",nlst(did)%START_MONTH,"-", &
+      nlst(did)%START_DAY,"_",nlst(did)%START_HOUR,":", &
+      nlst(did)%START_MIN
     call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,F0.3)") ": Timestep       = ",nlst_rt(did)%dt
+    write (logMsg,"(A,F0.3)") ": Timestep       = ",nlst(did)%dt
     call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,F0.3)") ": Output Step    = ",nlst_rt(did)%out_dt
+    write (logMsg,"(A,F0.3)") ": Output Step    = ",nlst(did)%out_dt
     call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,F0.3)") ": Restart Step   = ",nlst_rt(did)%rst_dt
+    write (logMsg,"(A,F0.3)") ": Restart Step   = ",nlst(did)%rst_dt
     call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,F0.3)") ": Ter Routing Step   = ",nlst_rt(did)%dtrt_ter
+    write (logMsg,"(A,F0.3)") ": Ter Routing Step   = ",nlst(did)%dtrt_ter
     call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,F0.3)") ": Ch Routing Step   = ",nlst_rt(did)%dtrt_ch
-    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-
-    write (logMsg,"(A,I0)") ": Grid ID        = ",nlst_rt(did)%igrid
-    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,A)") ": Hydro Grid     = ",nlst_rt(did)%hgrid
-    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,A)") ": Geo Grid File  = ",nlst_rt(did)%geo_static_flnm
-    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,A)") ": Fine Grid File = ",nlst_rt(did)%geo_finegrid_flnm
-    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,A)") ": GW Basin File  = ",nlst_rt(did)%gwbasmskfil
+    write (logMsg,"(A,F0.3)") ": Ch Routing Step   = ",nlst(did)%dtrt_ch
     call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
 
-    write (logMsg,"(A,I0)") ": Restart Type   = ",nlst_rt(did)%rst_typ
+    write (logMsg,"(A,I0)") ": Grid ID        = ",nlst(did)%igrid
     call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,A)") ": Restart file   = ",nlst_rt(did)%restart_file
+    write (logMsg,"(A,A)") ": Hydro Grid     = ",nlst(did)%hgrid
     call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,I0)") ": Coupling       = ",nlst_rt(did)%sys_cpl
+    write (logMsg,"(A,A)") ": Geo Grid File  = ",nlst(did)%geo_static_flnm
     call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-
-    write (logMsg,"(A,I0)") ": Channel RT     = ",nlst_rt(did)%CHANRTSWCRT
+    write (logMsg,"(A,A)") ": Fine Grid File = ",nlst(did)%geo_finegrid_flnm
     call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,I0)") ": Subsurface RT  = ",nlst_rt(did)%SUBRTSWCRT
-    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,I0)") ": Overland RT    = ",nlst_rt(did)%OVRTSWCRT
-    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,I0)") ": GW Baseflow RT = ",nlst_rt(did)%GWBASESWCRT
-    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,I0)") ": Routing Option = ",nlst_rt(did)%RT_OPTION
-    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,I0)") ": Channel Option = ",nlst_rt(did)%channel_option
-    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,I0)") ": Aggr Factor    = ",nlst_rt(did)%AGGFACTRT
-    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,I0)") ": GW Restart     = ",nlst_rt(did)%GW_RESTART
-    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    write (logMsg,"(A,I0)") ": SWC Restart    = ",nlst_rt(did)%RSTRT_SWC
+    write (logMsg,"(A,A)") ": GW Basin File  = ",nlst(did)%gwbasmskfil
     call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
 
-    write (logMsg,"(A,I0)") ": Soil Layers    = ",nlst_rt(did)%nsoil
+    write (logMsg,"(A,I0)") ": Restart Type   = ",nlst(did)%rst_typ
     call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
-    do layerIndex=1,nlst_rt(did)%nsoil
+    write (logMsg,"(A,A)") ": Restart file   = ",nlst(did)%restart_file
+    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
+    write (logMsg,"(A,I0)") ": Coupling       = ",nlst(did)%sys_cpl
+    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
+
+    write (logMsg,"(A,I0)") ": Channel RT     = ",nlst(did)%CHANRTSWCRT
+    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
+    write (logMsg,"(A,I0)") ": Subsurface RT  = ",nlst(did)%SUBRTSWCRT
+    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
+    write (logMsg,"(A,I0)") ": Overland RT    = ",nlst(did)%OVRTSWCRT
+    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
+    write (logMsg,"(A,I0)") ": GW Baseflow RT = ",nlst(did)%GWBASESWCRT
+    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
+    write (logMsg,"(A,I0)") ": Routing Option = ",nlst(did)%RT_OPTION
+    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
+    write (logMsg,"(A,I0)") ": Channel Option = ",nlst(did)%channel_option
+    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
+    write (logMsg,"(A,I0)") ": Aggr Factor    = ",nlst(did)%AGGFACTRT
+    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
+    write (logMsg,"(A,I0)") ": GW Restart     = ",nlst(did)%GW_RESTART
+    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
+    write (logMsg,"(A,I0)") ": SWC Restart    = ",nlst(did)%RSTRT_SWC
+    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
+
+    write (logMsg,"(A,I0)") ": Soil Layers    = ",nlst(did)%nsoil
+    call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
+    do layerIndex=1,nlst(did)%nsoil
       write (logMsg,"(A,I0,A,F0.3)") ": Soil layer depth (", &
-        layerIndex,") = ",nlst_rt(did)%ZSOIL8(layerIndex)
+        layerIndex,") = ",nlst(did)%ZSOIL8(layerIndex)
       call ESMF_LogWrite(trim(l_label)//logMsg,ESMF_LOGMSG_INFO)
     enddo
 

--- a/trunk/NDHMS/Land_models/Noah/IO_code/Noah_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/Noah/IO_code/Noah_hrldas_driver.F
@@ -641,12 +641,14 @@ program Noah_hrldas_driver
 
   call MPI_INIT(ierr)
   if (ierr /= MPI_SUCCESS) stop "MPI_INIT"
+  call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
+  if (ierr /= MPI_SUCCESS) stop "MPI_COMM_DUP"
 
-  call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+  call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
   if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
 
-  call MPI_COMM_SIZE(MPI_COMM_WORLD, numtasks, ierr)
-  if (ierr /= MPI_SUCCESS) stop "MPI_COMM_WORLD"
+  call MPI_COMM_SIZE(HYDRO_COMM_WORLD, numtasks, ierr)
+  if (ierr /= MPI_SUCCESS) stop "MPI_COMM_SIZE"
 
 #else
   rank = 0
@@ -682,12 +684,14 @@ program Noah_hrldas_driver
 !KWM
 !KWM  call MPI_INIT(ierr)
 !KWM  if (ierr /= MPI_SUCCESS) stop "MPI_INIT"
+!KWM  call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
+!KWM  if (ierr /= MPI_SUCCESS) stop "MPI_COMM_DUP"
 !KWM
-!KWM  call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+!KWM  call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
 !KWM  if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
 !KWM
-!KWM  call MPI_COMM_SIZE(MPI_COMM_WORLD, numtasks, ierr)
-!KWM  if (ierr /= MPI_SUCCESS) stop "MPI_COMM_WORLD"
+!KWM  call MPI_COMM_SIZE(HYDRO_COMM_WORLD, numtasks, ierr)
+!KWM  if (ierr /= MPI_SUCCESS) stop "MPI_COMM_SIZE"
 !KWM
 !KWM#else
 !KWM  rank = 0
@@ -723,9 +727,9 @@ program Noah_hrldas_driver
 
            if ( j > 0 ) then
               ! Send the starting and ending points we've computed to the appropriate process (rank).
-              call mpi_send( i, 1, MPI_INTEGER, j, 0, MPI_COMM_WORLD, ierr )
+              call mpi_send( i, 1, MPI_INTEGER, j, 0, HYDRO_COMM_WORLD, ierr )
               if (ierr /= MPI_SUCCESS) stop "Problem with MPI_SEND"
-              call mpi_send( ip, 1, MPI_INTEGER, j, 1, MPI_COMM_WORLD, ierr )
+              call mpi_send( ip, 1, MPI_INTEGER, j, 1, HYDRO_COMM_WORLD, ierr )
               if (ierr /= MPI_SUCCESS) stop "Problem with MPI_SEND"
            else
               parallel_xstart = subwindow_xstart
@@ -737,9 +741,9 @@ program Noah_hrldas_driver
         endif
      enddo
   else
-     call mpi_recv( parallel_xend, 1, MPI_INTEGER, 0, 0, MPI_COMM_WORLD, istatus, ierr )
+     call mpi_recv( parallel_xend, 1, MPI_INTEGER, 0, 0, HYDRO_COMM_WORLD, istatus, ierr )
      if (ierr /= MPI_SUCCESS) stop "Problem with MPI_RECV"
-     call mpi_recv( parallel_xstart, 1, MPI_INTEGER, 0, 1, MPI_COMM_WORLD, istatus, ierr )
+     call mpi_recv( parallel_xstart, 1, MPI_INTEGER, 0, 1, HYDRO_COMM_WORLD, istatus, ierr )
      if (ierr /= MPI_SUCCESS) stop "Problem with MPI_RECV"
      ! print*, 'Rank ', rank, ' received ', parallel_xstart, parallel_xend
   endif
@@ -2446,7 +2450,7 @@ program Noah_hrldas_driver
 #ifdef _PARALLEL_
      ! Just for sanity's sake, make sure all processors have caught up 
      ! before continuing to the next time step.
-     call mpi_barrier(MPI_COMM_WORLD, ierr)
+     call mpi_barrier(HYDRO_COMM_WORLD, ierr)
      if (ierr /= MPI_SUCCESS) stop "Problem with MPI_BARRIER"
 #endif
 
@@ -2708,7 +2712,7 @@ SUBROUTINE calc_declin ( nowdate, latitude, longitude, cosz, hrang, declin )
    integer :: rank
 
 #ifdef _PARALLEL_
-  call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+  call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
   if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
 #else
   rank = 0

--- a/trunk/NDHMS/Land_models/Noah/IO_code/module_hrldas_netcdf_io.F
+++ b/trunk/NDHMS/Land_models/Noah/IO_code/module_hrldas_netcdf_io.F
@@ -228,7 +228,7 @@ contains
     integer :: rank
 
 #ifdef _PARALLEL_  
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
 #else
     rank = 0
@@ -239,7 +239,7 @@ contains
     if (rank == 0) write(*,'("wrfinput_flnm: ''", A, "''")') trim(wrfinput_flnm)
 
 !KWM#ifdef _PARALLEL_
-!KWM    ierr = nf90_open_par(wrfinput_flnm, NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+!KWM    ierr = nf90_open_par(wrfinput_flnm, NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 !KWM#else
     ierr = nf90_open(wrfinput_flnm, NF90_NOWRITE, ncid)
 !KWM#endif
@@ -351,7 +351,7 @@ contains
     integer :: rank
 
 #ifdef _PARALLEL_  
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
 #else
     rank = 0
@@ -361,7 +361,7 @@ contains
     ! Open the NetCDF file.
     if (rank == 0) write(*,'("wrfinput_flnm: ''", A, "''")') trim(wrfinput_flnm)
 #ifdef _PARALLEL_
-    ierr = nf90_open_par(wrfinput_flnm, NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(wrfinput_flnm, NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     ierr = nf90_open(wrfinput_flnm, NF90_NOWRITE, ncid)
 #endif
@@ -630,10 +630,10 @@ contains
 
 #ifdef _PARALLEL_
 
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
 
-    ierr = nf90_open_par(netcdf_flnm, NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(netcdf_flnm, NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     rank = 0
     ierr = nf90_open(netcdf_flnm, NF90_NOWRITE, ncid)
@@ -761,7 +761,7 @@ contains
     integer :: rank
 
 #ifdef _PARALLEL_    
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
 #else
     rank = 0
@@ -892,7 +892,7 @@ contains
     ! Open the NetCDF file.
 !KWM    write(*,'("flnm: ''", A, "''")') trim(flnm)
 #ifdef _PARALLEL_
-    iret = nf90_open_par(flnm, NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    iret = nf90_open_par(flnm, NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     iret = nf90_open(flnm, NF90_NOWRITE, ncid)
 #endif
@@ -1013,13 +1013,13 @@ contains
 
        ! Open the NetCDF file.
 #ifdef _PARALLEL_
-       ierr = nf90_open_par(flnm, NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+       ierr = nf90_open_par(flnm, NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
        ierr = nf90_open(flnm, NF90_NOWRITE, ncid)
 #endif
        if (ierr /= 0) then
 #ifdef _PARALLEL_
-          call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+          call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
           if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
           if (rank == 0) then
 #endif
@@ -1304,7 +1304,7 @@ contains
     ! Open the NetCDF file.
 
 #ifdef _PARALLEL_
-    ierr = nf90_open_par(flnm, NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(flnm, NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     ierr = nf90_open(flnm, NF90_NOWRITE, ncid)
 #endif
@@ -1411,7 +1411,7 @@ contains
        endif
 #ifdef _PARALLEL_
        iret = nf90_create(trim(output_flnm), &
-            OR(NF90_CLOBBER, NF90_NETCDF4), ncid, comm=MPI_COMM_WORLD, info=MPI_INFO_NULL)
+            OR(NF90_CLOBBER, NF90_NETCDF4), ncid, comm=HYDRO_COMM_WORLD, info=MPI_INFO_NULL)
 #else
        iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
 #endif
@@ -1831,7 +1831,7 @@ contains
 
 #ifdef _PARALLEL_
 
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
 
 #else
@@ -1853,7 +1853,7 @@ contains
 #ifdef _PARALLEL_
 
     ierr = nf90_create(trim(output_flnm), &
-         OR(NF90_CLOBBER, NF90_NETCDF4), ncid, comm=MPI_COMM_WORLD, info=MPI_INFO_NULL)
+         OR(NF90_CLOBBER, NF90_NETCDF4), ncid, comm=HYDRO_COMM_WORLD, info=MPI_INFO_NULL)
 #else
     ierr = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
 #endif
@@ -1961,7 +1961,7 @@ contains
     endif
     
 #ifdef _PARALLEL_
-    ierr = nf90_open_par(trim(output_flnm), NF90_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(trim(output_flnm), NF90_WRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     ierr = nf90_open(trim(output_flnm), NF90_WRITE, ncid)
 #endif
@@ -2035,7 +2035,7 @@ contains
     endif
     
 #ifdef _PARALLEL_
-    ierr = nf90_open_par(trim(output_flnm), NF90_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(trim(output_flnm), NF90_WRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     ierr = nf90_open(trim(output_flnm), NF90_WRITE, ncid)
 #endif
@@ -2112,7 +2112,7 @@ contains
     endif
     
 #ifdef _PARALLEL_
-    ierr = nf90_open_par(trim(output_flnm), NF90_WRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(trim(output_flnm), NF90_WRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     ierr = nf90_open(trim(output_flnm), NF90_WRITE, ncid)
 #endif
@@ -2186,10 +2186,10 @@ contains
     restart_filename_remember = restart_flnm
 
 #ifdef _PARALLEL_
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
 
-    ierr = nf90_open_par(trim(restart_flnm), NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(trim(restart_flnm), NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     rank = 0
     ierr = nf90_open(trim(restart_flnm), NF90_NOWRITE, ncid)
@@ -2344,10 +2344,10 @@ contains
 
 #ifdef _PARALLEL_
 
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
 
-    ierr = nf90_open_par(trim(restart_filename_remember), NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(trim(restart_filename_remember), NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 
 #else
     rank = 0
@@ -2406,7 +2406,7 @@ contains
     integer, dimension(4) :: ncount
 
 #ifdef _PARALLEL_
-    ierr = nf90_open_par(trim(restart_filename_remember), NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(trim(restart_filename_remember), NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     ierr = nf90_open(trim(restart_filename_remember), NF90_NOWRITE, ncid)
 #endif
@@ -2461,7 +2461,7 @@ contains
     integer, dimension(4) :: ncount
 
 #ifdef _PARALLEL_
-    ierr = nf90_open_par(trim(restart_filename_remember), NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(trim(restart_filename_remember), NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     ierr = nf90_open(trim(restart_filename_remember), NF90_NOWRITE, ncid)
 #endif
@@ -2566,7 +2566,7 @@ contains
     write(*, '("Additional flnm = ''",A,"''")') trim(flnm)
 
 #ifdef _PARALLEL_
-    ierr = nf90_open_par(trim(flnm), NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(trim(flnm), NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     ierr = nf90_open(trim(flnm), NF90_NOWRITE, ncid)
 #endif

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -432,7 +432,7 @@ contains
     integer :: rank
 
 #ifdef _PARALLEL_
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In module_hrldas_netcdf_io.F "// &
                                   "read_hrldas_hdrinfo() - MPI_COMM_RANK"
 #else
@@ -448,7 +448,7 @@ contains
     endif
 
 !KWM#ifdef _PARALLEL_
-!KWM    ierr = nf90_open_par(wrfinput_flnm, NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+!KWM    ierr = nf90_open_par(wrfinput_flnm, NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 !KWM#else
     ierr = nf90_open(wrfinput_flnm, NF90_NOWRITE, ncid)
 !KWM#endif
@@ -598,7 +598,7 @@ contains
     integer :: rank
 
 #ifdef _PARALLEL_
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In module_hrldas_netcdf_io.F readland_hrldas()"// &
                                   " - MPI_COMM_RANK"
 #else
@@ -613,7 +613,7 @@ contains
 #endif
     endif
 #ifdef _PARALLEL_
-    ierr = nf90_open_par(wrfinput_flnm, NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(wrfinput_flnm, NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     ierr = nf90_open(wrfinput_flnm, NF90_NOWRITE, ncid)
 #endif
@@ -707,7 +707,7 @@ contains
     integer :: rank
 
 #ifdef _PARALLEL_
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In module_hrldas_netcdf_io.F read_mmf_runoff()"// &
                                   " - MPI_COMM_RANK"
 #else
@@ -722,7 +722,7 @@ contains
 #endif
     endif
 #ifdef _PARALLEL_
-    ierr = nf90_open_par(wrfinput_flnm, NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(wrfinput_flnm, NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     ierr = nf90_open(wrfinput_flnm, NF90_NOWRITE, ncid)
 #endif
@@ -1295,11 +1295,11 @@ contains
 
 #ifdef _PARALLEL_
 
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In  module_hrldas_netcdf_io.F"// &
                                   " readinit_hrldas() - MPI_COMM_RANK"
 
-    ierr = nf90_open_par(netcdf_flnm, NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(netcdf_flnm, NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     rank = 0
     ierr = nf90_open(netcdf_flnm, NF90_NOWRITE, ncid)
@@ -1440,7 +1440,7 @@ contains
     integer :: rank
 
 #ifdef _PARALLEL_
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In  module_hrldas_netcdf_io.F init_interp()"// &
                                   " - MPI_COMM_RANK."
 #else
@@ -1590,7 +1590,7 @@ contains
     ! Open the NetCDF file.
 !KWM    write(*,'("flnm: ''", A, "''")') trim(flnm)
 #ifdef _PARALLEL_
-    iret = nf90_open_par(flnm, NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    iret = nf90_open_par(flnm, NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     iret = nf90_open(flnm, NF90_NOWRITE, ncid)
 #endif
@@ -1723,13 +1723,13 @@ contains
        !print*, 'read file:  ', trim(flnm)
        ! Open the NetCDF file.
 #ifdef _PARALLEL_
-       ierr = nf90_open_par(flnm, NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+       ierr = nf90_open_par(flnm, NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
        ierr = nf90_open(flnm, NF90_NOWRITE, ncid)
 #endif
        if (ierr /= 0) then
 #ifdef _PARALLEL_
-          call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+          call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
           if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In  module_hrldas_netcdf_io.F"// &
                                         " READFORC_HRLDAS() - MPI_COMM_RANK"
           if (rank == 0) then
@@ -2047,7 +2047,7 @@ contains
     ! Open the NetCDF file.
 
 #ifdef _PARALLEL_
-    ierr = nf90_open_par(flnm, NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(flnm, NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     ierr = nf90_open(flnm, NF90_NOWRITE, ncid)
 #endif
@@ -2214,7 +2214,7 @@ contains
        endif
 #ifdef _PARALLEL_
        iret = nf90_create(trim(output_flnm), &
-            OR(NF90_CLOBBER, NF90_NETCDF4), ncid, comm=MPI_COMM_WORLD, info=MPI_INFO_NULL)
+            OR(NF90_CLOBBER, NF90_NETCDF4), ncid, comm=HYDRO_COMM_WORLD, info=MPI_INFO_NULL)
 #else
        iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
 #endif
@@ -2827,7 +2827,7 @@ contains
 
 #ifdef _PARALLEL_
 
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In module_hrldas_netcdf_io.F"// &
                                   " prepare_restart_file_seq() - MPI_COMM_RANK problem"
 
@@ -2854,7 +2854,7 @@ contains
 #ifdef _PARALLEL_
 
     ierr = nf90_create(trim(output_flnm), &
-         OR(NF90_CLOBBER, NF90_NETCDF4), ncid, comm=MPI_COMM_WORLD, info=MPI_INFO_NULL)
+         OR(NF90_CLOBBER, NF90_NETCDF4), ncid, comm=HYDRO_COMM_WORLD, info=MPI_INFO_NULL)
 #else
     ierr = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
 #endif
@@ -3159,11 +3159,11 @@ contains
     restart_filename_remember = restart_flnm
 
 #ifdef _PARALLEL_
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In module_hrldas_netcdf_io.F "// &
                                   "read_restart() - MPI_COMM_RANK"
 
-    ierr = nf90_open_par(trim(restart_flnm), NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(trim(restart_flnm), NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     rank = 0
     ierr = nf90_open(trim(restart_flnm), NF90_NOWRITE, ncid)
@@ -3341,11 +3341,11 @@ contains
 
 #ifdef _PARALLEL_
 
-    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In module_hrldas_netcdf_io.F "// &
                                   "get_from_restart_2d_float() - MPI_COMM_RANK"
 
-    ierr = nf90_open_par(trim(restart_filename_remember), NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(trim(restart_filename_remember), NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 
 #else
     rank = 0
@@ -3405,7 +3405,7 @@ contains
     integer, dimension(4) :: ncount
 
 #ifdef _PARALLEL_
-    ierr = nf90_open_par(trim(restart_filename_remember), NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(trim(restart_filename_remember), NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     ierr = nf90_open(trim(restart_filename_remember), NF90_NOWRITE, ncid)
 #endif
@@ -3464,7 +3464,7 @@ contains
     integer, dimension(4) :: ncount
 
 #ifdef _PARALLEL_
-    ierr = nf90_open_par(trim(restart_filename_remember), NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(trim(restart_filename_remember), NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     ierr = nf90_open(trim(restart_filename_remember), NF90_NOWRITE, ncid)
 #endif
@@ -3579,7 +3579,7 @@ contains
 
 #endif
 #ifdef _PARALLEL_
-    ierr = nf90_open_par(trim(flnm), NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+    ierr = nf90_open_par(trim(flnm), NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
     ierr = nf90_open(trim(flnm), NF90_NOWRITE, ncid)
 #endif

--- a/trunk/NDHMS/MPP/CPL_WRF.F
+++ b/trunk/NDHMS/MPP/CPL_WRF.F
@@ -71,8 +71,6 @@ MODULE MODULE_CPL_LAND
       if ( .NOT. mpi_inited ) then
         call mpi_init(ierr)
         if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_INIT failed")
-      endif
-      if (HYDRO_COMM_WORLD == MPI_COMM_NULL) then
         call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
         if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_COMM_DUP failed")
       endif

--- a/trunk/NDHMS/MPP/mpp_land.F
+++ b/trunk/NDHMS/MPP/mpp_land.F
@@ -153,12 +153,10 @@ MODULE MODULE_MPP_LAND
 
     call mpi_initialized( mpi_inited, ierr )
     if ( .not. mpi_inited ) then
-       call MPI_INIT_THREAD( MPI_THREAD_FUNNELED, provided, ierr )
-       if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_INIT failed")
-    endif
-    if (HYDRO_COMM_WORLD == MPI_COMM_NULL) then
-       call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
-       if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_COMM_DUP failed")
+      call MPI_INIT_THREAD( MPI_THREAD_FUNNELED, provided, ierr )
+      if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_INIT failed")
+      call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
+      if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_COMM_DUP failed")
     endif
 
     call MPI_COMM_RANK( HYDRO_COMM_WORLD, my_id, ierr )

--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -168,7 +168,7 @@ subroutine output_chrt_NWM(domainId)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( MPI_COMM_WORLD, myId, ierr )
+      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -1110,7 +1110,7 @@ subroutine output_NoahMP_NWM(outDir,iGrid,output_timestep,itime,startdate,date,i
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( MPI_COMM_WORLD, myId, ierr )
+      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -1783,7 +1783,7 @@ subroutine output_rt_NWM(domainId,iGrid)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( MPI_COMM_WORLD, myId, ierr )
+      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -2378,7 +2378,7 @@ subroutine output_lakes_NWM(domainId,iGrid)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( MPI_COMM_WORLD, myId, ierr )
+      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -3097,7 +3097,7 @@ subroutine output_chrtout_grd_NWM(domainId,iGrid)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( MPI_COMM_WORLD, myId, ierr )
+      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -3597,7 +3597,7 @@ subroutine output_lsmOut_NWM(domainId)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( MPI_COMM_WORLD, myId, ierr )
+      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -4082,7 +4082,7 @@ implicit none
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( MPI_COMM_WORLD, myId, ierr )
+      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -4399,7 +4399,7 @@ subroutine output_chanObs_NWM(domainId)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( MPI_COMM_WORLD, myId, ierr )
+      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -5093,7 +5093,7 @@ subroutine output_gw_NWM(domainId,iGrid)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( MPI_COMM_WORLD, myId, ierr )
+      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else

--- a/trunk/NDHMS/Routing/module_reservoir_routing.F
+++ b/trunk/NDHMS/Routing/module_reservoir_routing.F
@@ -83,7 +83,7 @@ subroutine read_reservoir_obs(domainId)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( MPI_COMM_WORLD, myId, ierr )
+      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: Coupling, ESMF, NUOPC

SOURCE: Daniel Rosen, NOAA

DESCRIPTION OF CHANGES: Update WRF-Hydro

TESTS CONDUCTED: Offline (uncoupled using internal driver) regression test produced bit-for-bit results when compared to v5.2.0. Standalone (uncoupled using NUOPC driver) regression test using forcing type 8 ran successfully and produced similar results to an offline test. Coupled to land surface model produced similar results to previous coupling.

NOTES: This work updates the existing NUOPC cap to a v5.2.0 model revision. All work has been rebased onto v.5.2.0 for a streamlined pull request. Conflicts were resolved during the rebase and include HYDRO_COMM_WORLD cleanup.

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
The NUOPC cap coupling feature is not tracked in an issue.
 - [ ] Tests added (unit tests and/or regression/integration tests)
At this time we don't have NUPC cap specific testing. Testing is done through the LIS/WRF-Hydro coupling system and requires coupling system specific setup.
 - [X] Backwards compatible
 - [X] Requires new files? If so, how to generate them.
 - [] Fully documented
Documentation for cap is not included in the main documentation but a Doxygen file can be built from within the CPL/NUOPC_cpl folder. 
 - [ ] Short description in the Development section of `NEWS.md`
The NUOPC cap is not part of the main development.
