### PR TITLE
Remove no longer relevant namelist check for reach lakes

### DIFF
--- a/trunk/NDHMS/OrchestratorLayer/config.f90
+++ b/trunk/NDHMS/OrchestratorLayer/config.f90
@@ -390,14 +390,6 @@ contains
       inquire(file=trim(self%route_lake_f),exist=fileExists)
       if (.not. fileExists) call hydro_stop('hydro.namelist ERROR: route_lake_f not found.')
    endif
-   ! Only allow lakes to be ran with gridded routing or NWM routing
-   if(len(trim(self%route_lake_f)) .ne. 0) then
-      if(self%channel_option .ne. 3) then
-         if(self%UDMP_OPT .ne. 1) then
-            call hydro_stop('hydro.namelist ERROR: Currently lakes only work with gridded channel routing or UDMP=1. Please change your namelist settings.')
-         endif
-      endif
-   endif
 
    if((self%channel_option .eq. 3) .and. (self%compound_channel)) then
       call hydro_stop("Compound channel option not available for diffusive wave routing. ")


### PR DESCRIPTION
Addresses issue #521 by removing an old namelist check that was added back in with the orchestrator.