### PR TITLE
Add -std=legacy to macros to support gnu >= 10.0.1

### DIFF
--- a/trunk/NDHMS/arc/macros.mpp.gfort
+++ b/trunk/NDHMS/arc/macros.mpp.gfort
@@ -55,13 +55,13 @@ endif
 
 
 RMD		=	rm -f
-COMPILER90=	mpif90  
-F90FLAGS  =       -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 
-MODFLAG	=	-I"./" -I"../../MPP" -I"../MPP" -I"../mod"
-LDFLAGS	=	
-CPPINVOKE	=   -cpp
-CPPFLAGS	=   -DMPP_LAND -I"../Data_Rec" $(HYDRO_D) $(SPATIAL_SOIL) $(NWM_META) $(WRF_HYDRO_NUDGING) $(OUTPUT_CHAN_CONN) $(PRECIP_DOUBLE)
+COMPILER90      =	mpif90  
+F90FLAGS        =       -w -c -O2 -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -std=legacy
+MODFLAG      	=	-I"./" -I"../../MPP" -I"../MPP" -I"../mod"
+LDFLAGS	        =	
+CPPINVOKE	=       -cpp
+CPPFLAGS	=       -DMPP_LAND -I"../Data_Rec" $(HYDRO_D) $(SPATIAL_SOIL) $(NWM_META) $(WRF_HYDRO_NUDGING) $(OUTPUT_CHAN_CONN) $(PRECIP_DOUBLE)
 
-LIBS 	=	
+LIBS 	        =	
 NETCDFINC       =       $(NETCDF_INC)
 NETCDFLIB       =       -L$(NETCDF_LIB) -lnetcdff -lnetcdf


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: gfortran, gnu

SOURCE: Ryan@NCAR

DESCRIPTION OF CHANGES: Add -std=legacy flag to macros.mpp.gfort to support gfortran >= 10.0.1

ISSUE: 
```
Fixes #523 "Build fails with gfortran >= 10.0.1"
```
