### PR TITLE
Make arguments optional for MPP_LAND_INIT so that we don't break non-…

### DIFF
--- a/trunk/NDHMS/MPP/mpp_land.F
+++ b/trunk/NDHMS/MPP/mpp_land.F
@@ -144,7 +144,7 @@ MODULE MODULE_MPP_LAND
 !    ### initialize the land model logically based on the two D method. 
 !    ### Call this function directly if it is nested with WRF.
     implicit none
-    integer in_global_nx, in_global_ny
+    integer, optional :: in_global_nx, in_global_ny
     integer :: ierr, provided
     integer :: ew_numprocs, sn_numprocs  ! input the processors in x and y direction.
     logical mpi_inited


### PR DESCRIPTION
Make arguments optional for `MPP_LAND_INIT()` so that we don't break non-NoahMP couplings

Closes issue #527

This allows for a WRF-Hydro standalone w/ Noah build, but some issues there remain (likely wrt the orchestrator update).  