### PR TITLE
CMAKE changes for NWM integration into UFS applications.

### DIFF
--- a/trunk/NDHMS/CMakeLists.txt
+++ b/trunk/NDHMS/CMakeLists.txt
@@ -1,8 +1,14 @@
 cmake_minimum_required (VERSION 2.8)
 
-set (CMAKE_C_COMPILER "mpicc")
-set (CMAKE_CXX_COMPILER "mpicxx")
-set (CMAKE_Fortran_COMPILER "mpif90")
+if (NOT CMAKE_C_COMPILER)
+	set (CMAKE_C_COMPILER "mpicc")
+endif (NOT CMAKE_C_COMPILER)
+if (NOT CMAKE_CXX_COMPILER)
+	set (CMAKE_CXX_COMPILER "mpicxx")
+endif (NOT CMAKE_CXX_COMPILER)
+if (NOT CMAKE_Fortran_COMPILER)
+	set (CMAKE_Fortran_COMPILER "mpif90")
+endif (NOT CMAKE_Fortran_COMPILER)
 
 project (WRF_Hydro)
 
@@ -34,7 +40,7 @@ enable_language (Fortran)
 
 # netcdf does not have a built in package locator so add custom module directory
 # that contains FindNetCDF.cmake
-set (CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake-modules)
+set (CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-modules)
 
 #try to find the installed NETCDF library
 set (NETCDF_F90 "YES")
@@ -312,14 +318,14 @@ if (HYDRO_LSM MATCHES "NoahMP")
 	add_custom_command(TARGET wrfhydro.exe POST_BUILD
 		COMMAND mkdir -p ${CMAKE_BINARY_DIR}/Run
 		COMMAND rm -f ${CMAKE_BINARY_DIR}/Run/*
-		COMMAND cp ${CMAKE_BINARY_DIR}/wrfhydro.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro_NoahMP.exe
-		COMMAND cp ${CMAKE_SOURCE_DIR}/template/NoahMP/* ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${CMAKE_SOURCE_DIR}/template/HYDRO/CHANPARM.TBL ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${CMAKE_SOURCE_DIR}/template/HYDRO/hydro.namelist ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${CMAKE_SOURCE_DIR}/template/HYDRO/HYDRO.TBL ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${CMAKE_SOURCE_DIR}/Land_models/NoahMP/run/*.TBL ${CMAKE_BINARY_DIR}/Run
+		COMMAND cp ${PROJECT_BINARY_DIR}/wrfhydro.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro_NoahMP.exe
+		COMMAND cp ${PROJECT_SOURCE_DIR}/template/NoahMP/* ${CMAKE_BINARY_DIR}/Run
+		COMMAND cp ${PROJECT_SOURCE_DIR}/template/HYDRO/CHANPARM.TBL ${CMAKE_BINARY_DIR}/Run
+		COMMAND cp ${PROJECT_SOURCE_DIR}/template/HYDRO/hydro.namelist ${CMAKE_BINARY_DIR}/Run
+		COMMAND cp ${PROJECT_SOURCE_DIR}/template/HYDRO/HYDRO.TBL ${CMAKE_BINARY_DIR}/Run
+		COMMAND cp ${PROJECT_SOURCE_DIR}/Land_models/NoahMP/run/*.TBL ${CMAKE_BINARY_DIR}/Run
 		COMMAND ln -s wrf_hydro_NoahMP.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro.exe
-		COMMAND rm ${CMAKE_BINARY_DIR}/wrfhydro.exe
+		COMMAND rm ${PROJECT_BINARY_DIR}/wrfhydro.exe
 	)
 
 elseif(HYDRO_LSM MATCHES "Noah")
@@ -367,14 +373,14 @@ elseif(HYDRO_LSM MATCHES "Noah")
         add_custom_command(TARGET wrfhydro.exe POST_BUILD
 		COMMAND mkdir -p ${CMAKE_BINARY_DIR}/Run
 		COMMAND rm -f ${CMAKE_BINARY_DIR}/Run/*
-		COMMAND cp ${CMAKE_BINARY_DIR}/wrfhydro.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro_Noah.exe
-		COMMAND cp ${CMAKE_SOURCE_DIR}/template/Noah/* ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${CMAKE_SOURCE_DIR}/template/HYDRO/CHANPARM.TBL ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${CMAKE_SOURCE_DIR}/template/HYDRO/hydro.namelist ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${CMAKE_SOURCE_DIR}/template/HYDRO/HYDRO.TBL ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${CMAKE_SOURCE_DIR}/Land_models/Noah/Run/*.TBL ${CMAKE_BINARY_DIR}/Run
+		COMMAND cp ${PROJECT_BINARY_DIR}/wrfhydro.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro_Noah.exe
+		COMMAND cp ${PROJECT_SOURCE_DIR}/template/Noah/* ${CMAKE_BINARY_DIR}/Run
+		COMMAND cp ${PROJECT_SOURCE_DIR}/template/HYDRO/CHANPARM.TBL ${CMAKE_BINARY_DIR}/Run
+		COMMAND cp ${PROJECT_SOURCE_DIR}/template/HYDRO/hydro.namelist ${CMAKE_BINARY_DIR}/Run
+		COMMAND cp ${PROJECT_SOURCE_DIR}/template/HYDRO/HYDRO.TBL ${CMAKE_BINARY_DIR}/Run
+		COMMAND cp ${PROJECT_SOURCE_DIR}/Land_models/Noah/Run/*.TBL ${CMAKE_BINARY_DIR}/Run
 		COMMAND ln -s wrf_hydro_Noah.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro.exe
-		COMMAND rm ${CMAKE_BINARY_DIR}/wrfhydro.exe
+		COMMAND rm ${PROJECT_BINARY_DIR}/wrfhydro.exe
         )
 
 

--- a/trunk/NDHMS/cmake-modules/FindNetCDF.cmake
+++ b/trunk/NDHMS/cmake-modules/FindNetCDF.cmake
@@ -63,6 +63,21 @@ NetCDF_check_interface (CXX netcdfcpp.h netcdf_c++)
 NetCDF_check_interface (F77 netcdf.inc  netcdff)
 NetCDF_check_interface (F90 netcdf.mod  netcdff)
 
+# Add links to library dependencies (e.g. -lhdf5 -lm -lz )
+find_program (NETCDF_CONFIG_EXE NAMES nc-config PATHS "$ENV{NETCDF}/bin" ENV NETCDF_DIR)
+if (NETCDF_CONFIG_EXE)
+  execute_process( COMMAND ${NETCDF_CONFIG_EXE} --libs RESULT_VARIABLE nc_config_ret OUTPUT_VARIABLE nc_config_libs)
+  if (nc_config_ret EQUAL 0)
+    string( STRIP ${nc_config_libs} nc_config_libs )
+    list (APPEND NetCDF_libs ${nc_config_libs})
+    list (REMOVE_DUPLICATES NetCDF_libs)
+  else (nc_config_ret EQUAL 0)
+    message(WARNING "nc-config --libs not found, library dependencies may not link.")
+  endif (nc_config_ret EQUAL 0)
+else (NETCDF_CONFIG_EXE)
+  message(WARNING "nc-config not found, library dependencies may not link.")
+endif (NETCDF_CONFIG_EXE)
+
 set (NETCDF_LIBRARIES ${NetCDF_libs} CACHE INTERNAL "All NetCDF libraries required for interface level")
 
 # handle the QUIETLY and REQUIRED arguments and set NETCDF_FOUND to TRUE if

--- a/trunk/NDHMS/utils/CMakeLists.txt
+++ b/trunk/NDHMS/utils/CMakeLists.txt
@@ -3,7 +3,11 @@ cmake_minimum_required (VERSION 2.8)
 # read version numbers for wrf_hydro_version and nwm_version from 
 # ../.version and ../.nwm_version
 file (STRINGS "../.version" WRF_HYDRO_VERSION)
-file (STRINGS "../.nwm_version"  NWM_VERSION)
+if (NWM_META)
+	file (STRINGS "../.nwm_version"  NWM_VERSION)
+else (NWM_META)
+	set(NWM_VERSION "none")
+endif (NWM_META)
 
 # add the preprocessor definitions for NWM_VERSION and WRF_HYDRO_VERSION
 # needed to compile module_version.F


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: CMake, UFS, RRFS

SOURCE: Daniel Rosen (drosen@ucar.edu) - NCAR/ESMF 

DESCRIPTION OF CHANGES:

1. Add support for calling CMake build from another project.
2. Fix CMake reference to .nwm_version for non NWM_META builds.
3. Update FindNetCDF.cmake to include --libs from nc-config in NETCDF_LIBRARIES.

ISSUE:
```
none
```

TESTS CONDUCTED:

1. Built wrfhydro.exe from CMakeLists.txt in NWM/trunk/NDHMS with NWM_META=0
2. Built wrfhydro.exe from CMakeLists.txt in NWM/trunk/NDHMS with NWM_META=1
3. Added NWM/trunk/NDHMS as subdirectory in UFS weather model CMakeLists.txt file. Built with NWM_META=0

NOTES:
NWM_META is cached in CMake. The cached value must be cleared when switching NWM_META values

### Checklist
 - [ ] Closes issue #xxxx
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
 - [ ] Short description in the Development section of `NEWS.md`
