### PR TITLE
Add Cray Fortran compiler support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.mod
+*.lst
 *~
 Makefile.comm
 trunk/NDHMS/lib/*

--- a/trunk/NDHMS/Land_models/NoahMP/data_structures/Makefile
+++ b/trunk/NDHMS/Land_models/NoahMP/data_structures/Makefile
@@ -24,7 +24,7 @@ all:	$(OBJS)
 .f90.o:
 	@echo "Data structures Makefile:"
 #	$(COMPILER90) -o $(@) $(F90FLAGS) $(MODFLAG) $(*).f
-	$(COMPILER90) $(PREPROC) -o $(@) $(FPPFLAGS) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) -I../../../OrchestratorLayer $(*).f90
+	$(COMPILER90) $(CPPINVOKE) -o $(@) $(FPPFLAGS) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) -I../../../OrchestratorLayer $(*).f90
 #	$(RMD) $(*).f
 	@echo ""
 	ar -r ../../../lib/libHYDRO.a $(@)

--- a/trunk/NDHMS/MPP/Makefile
+++ b/trunk/NDHMS/MPP/Makefile
@@ -12,7 +12,7 @@ all:	$(OBJS)
 hashtable.o: hashtable.F
 	@echo ""
 	$(RMD) $(*).o $(*).mod $(*).stb *~
-	$(COMPILER90) -O3 -g $(F90FLAGS) $(LDFLAGS) -c $(*).F
+	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $(*).F
 	cp hashtable.mod ../mod
 	ar -r ../lib/libHYDRO.a $(@)
 

--- a/trunk/NDHMS/arc/macros.mpp.cray_fortran
+++ b/trunk/NDHMS/arc/macros.mpp.cray_fortran
@@ -59,14 +59,15 @@ else
 NCEP_WCOSS =
 endif
 
-RMD	    = rm -f
+RMD	        = rm -f
 COMPILER90  = ftn
-FORMAT_FREE = -FR
-BYTESWAPIO  = -convert big_endian
-F90FLAGS    = -O2 -g -w -c -ftz -align all -fno-alias -fp-model precise $(FORMAT_FREE) $(BYTESWAPIO)
-MODFLAG	    = -I./ -I ../../MPP -I ../MPP -I ../mod
-LDFLAGS	    =
-CPPINVOKE   = -fpp
+FORMAT_FREE = -f free
+BYTESWAPIO  = -h byteswapio
+F90FLAGS    = -O2 -c -ef -h alias=none -h fp1 $(FORMAT_FREE) $(BYTESWAPIO)
+#F90FLAGS    = -O0 -eD -g -c -ef -h alias=tolerant $(FORMAT_FREE) $(BYTESWAPIO)   # CRAY DEBUG OPTIONS
+MODFLAG     = -I./ -I ../../MPP -I ../MPP -I ../mod
+LDFLAGS     =
+CPPINVOKE   = -eT
 CPPFLAGS    = -DMPP_LAND -I ../Data_Rec $(HYDRO_D) $(SPATIAL_SOIL) $(NWM_META) $(WRF_HYDRO_NUDGING) $(OUTPUT_CHAN_CONN) $(PRECIP_DOUBLE) $(NCEP_WCOSS)
 LIBS 	    =	
 NETCDFINC   = $(NETCDF_INC)

--- a/trunk/NDHMS/configure
+++ b/trunk/NDHMS/configure
@@ -12,8 +12,14 @@ fi
 
 ###################################
 ## Setup the NetCDF include and LIB variables.
-## If Neither is set and $NETCDF is not set,
+## If Neither is set and neither $NETCDF nor $NETCDF_DIR is not set,
 ## then try nc-config. If that fails, all fails.
+
+if [[ -z $NETCDF ]]; then
+    if [[ -n $NETCDF_DIR ]]; then
+	NETCDF=$NETCDF_DIR
+    fi
+fi
 
 if [[ -z $NETCDF_INC ]]; then
     if [[ -z $NETCDF ]]; then
@@ -66,6 +72,7 @@ if [[ -z $theArgument ]]; then
     echo "     4          luna  intel parallel (WCOSS Luna)"
     echo "     5     ifort_omp  intel openmp"
     echo "     6 intel.cray_xc  intel parallel (cray_xc)"
+    echo "     7  cray_fortran  Cray Fortran PE (ftn)"
     echo "     0          exit  exit"
     echo 
     read -p "Enter selection: " theArgument
@@ -138,6 +145,13 @@ if [[ "$theArgument" == "6" ]] || [[ "$theArgument" == "intel.cray_xc" ]]; then
     cp arc/Makefile.mpp Makefile.comm
     echo "Configured: ifort on cray_xc"
 fi
+
+if [[ "$theArgument" == "7" ]] || [[ "$theArgument" == "cray_fortran" ]]; then
+    cp arc/macros.mpp.cray_fortran macros
+    cp arc/Makefile.mpp Makefile.comm
+    echo "Configured: Cray Fortran PrgEnv"
+fi
+
 
 ## The above result in a new macros file which was
 ## previously deleted. If it does not exist, none


### PR DESCRIPTION
TYPE: bug fix / enhancement

KEYWORDS: cray, fortran

SOURCE: WRF-Hydro Internal

DESCRIPTION OF CHANGES: Add support for Cray Fortran and Intel Fortran compilers on Cray systems by fixing the existing Cray-Intel macros file and adding a new Cray Fortran macros file.

ISSUE: 
```
Fixes #538 Support Cray Fortran compilers
```

TESTS CONDUCTED: Code now builds on Cray systems using both Intel Fortran and Cray Fortran

NOTE:
This PR goes hand-in-hand with #540, which addresses specific places in the code where deviations from the official Fortran standard are allowed by the Intel and GNU Fortran compilers but not by the Cray Fortran compiler.

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [X] Fixes issue #538
 - [X] Backwards compatible
 - [ ] Fully documented
 - [ ] Short description in the Development section of `NEWS.md`
