### PR TITLE
Correct a few Fortran standards-compliance issues

### DIFF
--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -404,10 +404,10 @@ module module_NoahMP_hrldas_driver
      use module_hrldas_HYDRO, only: open_print_mpp
      use state_module, only: state_type
      implicit  none
-     integer:: NTIME_out
+     integer, intent(out) :: NTIME_out
      integer, parameter :: did=1
      integer :: khour
-     type(state_type) :: state
+     type(state_type), intent(out) :: state
 
     ! initilization for stand alone parallel code.
     integer, optional, intent(in) :: wrfits,wrfite,wrfjts,wrfjte

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -426,7 +426,7 @@ contains
 #ifdef _PARALLEL_
     real, pointer,   dimension(:,:)   :: dum2d_ptr
 #endif
-    integer :: ncid, dimid, varid, ierr
+    integer, volatile :: ncid, dimid, varid, ierr
     real, allocatable, dimension(:,:) :: dum2d
     character(len=256) :: units
     integer :: i
@@ -1105,16 +1105,16 @@ contains
     !      .TRUE. if an error in reading the data should stop the program.
     !      Otherwise the, IERR error flag is set, but the program continues.
     logical, intent(in) :: fatal_if_error
-    integer, intent(out) :: ierr
+    integer, intent(out), volatile :: ierr
 #ifdef MPP_LAND
     real:: g_array(global_nx,global_ny)
 #endif
-    units = " "
+
+    ierr = 0
 
 #ifdef MPP_LAND
     if(my_id .eq. 0) then
 #endif
-
     iret = nf90_inq_varid(ncid,  name,  varid)
     if (iret /= 0) then
        if (FATAL_IF_ERROR) then

--- a/trunk/NDHMS/Land_models/NoahMP/Utility_routines/module_wrf_utilities.F
+++ b/trunk/NDHMS/Land_models/NoahMP/Utility_routines/module_wrf_utilities.F
@@ -37,7 +37,7 @@ SUBROUTINE wrf_error_fatal( str )
   call flush(78)
   close(78)
 #else 
-  write(6,*),'FATAL ERROR: ',trim(str)
+  write(6,*) 'FATAL ERROR: ',trim(str)
   call flush(6)
 #endif
 

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
@@ -1444,7 +1444,7 @@ SUBROUTINE PEDOTRANSFER_SR2006(nsoil,sand,clay,orgm,parameters)
     REAL, DIMENSION(ims:ime,jms:jme), INTENT(IN) , OPTIONAL :: RIVERCONDXY !river conductance
     REAL, DIMENSION(ims:ime,jms:jme), INTENT(IN) , OPTIONAL :: PEXPXY      !factor for river conductance
 
-    INTEGER,  INTENT(OUT) , OPTIONAL :: STEPWTD
+    INTEGER,  INTENT(INOUT) , OPTIONAL :: STEPWTD
     REAL, INTENT(IN) , OPTIONAL :: DT, WTDDT
 
 !jref:start

--- a/trunk/NDHMS/Routing/Reservoirs/module_reservoir_read_rfc_time_series_data.F
+++ b/trunk/NDHMS/Routing/Reservoirs/module_reservoir_read_rfc_time_series_data.F
@@ -223,7 +223,7 @@ contains
 
         call read_timeslice_netcdf_integer_1D_variables(ncid, 'synthetic_values', time_series_file, this%synthetic_values)
 
-        this%synthetic_values_logical = merge(.true., .false., this%synthetic_values /= 0)
+        this%synthetic_values_logical = (this%synthetic_values /= 0)
 
         this%forecast_found = .true.
 

--- a/trunk/NDHMS/Routing/Reservoirs/module_reservoir_read_rfc_time_series_data.F
+++ b/trunk/NDHMS/Routing/Reservoirs/module_reservoir_read_rfc_time_series_data.F
@@ -159,7 +159,7 @@ contains
         write(forecast_file_resolution_string, "(I2)") forecast_file_resolution_minutes
 
         ! Negative for going back in time
-        forecast_file_resolution_seconds = forecast_file_resolution_minutes * 60 * -1
+        forecast_file_resolution_seconds = forecast_file_resolution_minutes * 60 * (-1)
 
         ! Loop through the total time series periods to look for and read time series files
         do time_series_file_index = 1, total_time_series_file_periods
@@ -223,7 +223,7 @@ contains
 
         call read_timeslice_netcdf_integer_1D_variables(ncid, 'synthetic_values', time_series_file, this%synthetic_values)
 
-        this%synthetic_values_logical = this%synthetic_values
+        this%synthetic_values_logical = merge(.true., .false., this%synthetic_values /= 0)
 
         this%forecast_found = .true.
 

--- a/trunk/NDHMS/Routing/Reservoirs/module_reservoir_read_timeslice_data.F
+++ b/trunk/NDHMS/Routing/Reservoirs/module_reservoir_read_timeslice_data.F
@@ -218,7 +218,7 @@ contains
             write(observation_resolution_string, "(I2)") observation_resolution_minutes
 
             ! Negative for going back in time
-            observation_resolution_seconds = observation_resolution_minutes * 60 * -1
+            observation_resolution_seconds = observation_resolution_minutes * 60 * (-1)
 
             ! Loop through the total timeslice periods to look for and read timeslice files
             do timeslice_file_index = 1, total_timeslice_time_periods

--- a/trunk/NDHMS/Routing/Reservoirs/module_reservoir_utilities.F
+++ b/trunk/NDHMS/Routing/Reservoirs/module_reservoir_utilities.F
@@ -624,7 +624,7 @@ contains
         lake_number_string_trimmed = ADJUSTL(trim(lake_number_string))
         filename_string = "hybrid_logs_"//ADJUSTL(trim(lake_number_string_trimmed))//".csv"
 
-        open (113, file=filename_string, status="unknown", access = 'append')
+        open (113, file=filename_string, status="unknown", position = 'append')
 
         write (113, "(I20, A1, I20, A1, I20, A1, I20, A1, A15, A1, I20, A1, F15.5, A1, F15.5, &
         A1, F15.15, A1, F15.5, A1, F15.5, A1, F15.5, A1, F15.5, A1, F15.5)") &
@@ -675,7 +675,7 @@ contains
         lake_number_string_trimmed = ADJUSTL(trim(lake_number_string))
         filename_string = "rfc_forecasts_logs_"//ADJUSTL(trim(lake_number_string_trimmed))//".csv"
 
-        open (113, file=filename_string, status="unknown", access = 'append')
+        open (113, file=filename_string, status="unknown", position = 'append')
 
         write (113, "(I20, A1, I20, A1, I20, A1, I20, A1, I20, A1, A5, A1, F15.5, A1, &
         F15.5, A1, F15.5, A1, F15.5)") &
@@ -721,7 +721,7 @@ contains
         lake_number_string_trimmed = ADJUSTL(trim(lake_number_string))
         filename_string = "levelpool_logs_"//ADJUSTL(trim(lake_number_string_trimmed))//".csv"
 
-        open (113, file=filename_string, status="unknown", access = 'append')
+        open (113, file=filename_string, status="unknown", position = 'append')
 
         write (113, "(F15.8, A1, F15.8, A1, F15.8)") &
         inflow, ',', water_elevation, ',', outflow

--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -168,7 +168,7 @@ type ldasMeta
    character(len=1024), dimension(20) :: crsCharAttNames,crsFloatAttNames
    character(len=1024), dimension(20) :: crsCharAttVals
    real, dimension(20,20) :: crsRealAttVals
-   real, dimension(20) :: crsRealAttLen
+   integer, dimension(20) :: crsRealAttLen
    integer :: nCrsRealAtts, nCrsCharAtts
    ! Establish x/y related variables.
    character(len=1024), dimension(20) :: xCharAttNames,xFloatAttNames
@@ -239,7 +239,7 @@ type rtDomainMeta
    character(len=1024), dimension(20) :: crsCharAttNames,crsFloatAttNames
    character(len=1024), dimension(20) :: crsCharAttVals
    real, dimension(20,20) :: crsRealAttVals
-   real, dimension(20) :: crsRealAttLen
+   integer, dimension(20) :: crsRealAttLen
    integer :: nCrsRealAtts, nCrsCharAtts
    ! Establish x/y related variables.
    character(len=1024), dimension(20) :: xCharAttNames,xFloatAttNames
@@ -393,7 +393,7 @@ type chrtGrdMeta
    character(len=1024), dimension(20) :: crsCharAttNames,crsFloatAttNames
    character(len=1024), dimension(20) :: crsCharAttVals
    real, dimension(20,20) :: crsRealAttVals
-   real, dimension(20) :: crsRealAttLen
+   integer, dimension(20) :: crsRealAttLen
    integer :: nCrsRealAtts, nCrsCharAtts
    ! Establish x/y related variables.
    character(len=1024), dimension(20) :: xCharAttNames,xFloatAttNames
@@ -468,7 +468,7 @@ type lsmMeta
    character(len=1024), dimension(20) :: crsCharAttNames,crsFloatAttNames
    character(len=1024), dimension(20) :: crsCharAttVals
    real, dimension(20,20) :: crsRealAttVals
-   real, dimension(20) :: crsRealAttLen
+   integer, dimension(20) :: crsRealAttLen
    integer :: nCrsRealAtts, nCrsCharAtts
    ! Establish x/y related variables.
    character(len=1024), dimension(20) :: xCharAttNames,xFloatAttNames

--- a/trunk/NDHMS/Routing/module_channel_routing.F
+++ b/trunk/NDHMS/Routing/module_channel_routing.F
@@ -1707,7 +1707,7 @@ end subroutine drive_CHANNEL
 !---------------------------------------------
 if(channel_only .eq. 1 .or. channelBucket_only .eq. 1) then
 #ifdef HYDRO_D
-   write(6,*), "channel_only or channelBucket_only is not zero. Special flux calculations."
+   write(6,*)  "channel_only or channelBucket_only is not zero. Special flux calculations."
    call flush(6)
 #endif /* HYDRO_D */
 
@@ -1815,7 +1815,7 @@ endif !! (channel_only .eq. 1 .or. channelBucket_only .eq. 1) then; else; endif
 !! If not running channelOnly, here is where the bucket model is picked up
 if(channel_only .eq. 1) then
 #ifdef HYDRO_D
-   write(6,*), "channel_only is not zero. No bucket."
+   write(6,*)  "channel_only is not zero. No bucket."
    call flush(6)
 #endif /* HYDRO_D */
 else


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: fortran

SOURCE: WRF-Hydro Internal

DESCRIPTION OF CHANGES: Various small non-standards-compliant code issues were discovered when updating WRF-Hydro to build on Cray. The Cray Fortran compiler is particularly picky about code meeting the published spec and there were a few places where Intel and GNU Fortran allowed minor deviations from the standard. This PR addresses those so that the code will build without error (though with a few warnings) on Cray Fortran 9.1.1

ISSUE: 
```
Fixes #538 Support Cray Fortran compilers
```

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [X] Fixes issue #538
 - [X] Backwards compatible
 - [ ] Fully documented
 - [ ] Short description in the Development section of `NEWS.md`
