### PR TITLE
Fix NUOPC cap for GNU compilers

### DIFF
--- a/trunk/NDHMS/CPL/NUOPC_cpl/WRFHydro_NUOPC_Cap.F90
+++ b/trunk/NDHMS/CPL/NUOPC_cpl/WRFHydro_NUOPC_Cap.F90
@@ -365,15 +365,15 @@ module WRFHydro_NUOPC
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65535, 65535,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65281,  8193,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query Component for its internal State
@@ -613,15 +613,15 @@ module WRFHydro_NUOPC
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65535, 65535,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65281,  8193,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query Component for its internal State
@@ -769,15 +769,15 @@ module WRFHydro_NUOPC
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65535, 65535,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65281,  8193,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query Component for its internal State
@@ -988,15 +988,15 @@ module WRFHydro_NUOPC
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65535, 65535,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65281,  8193,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query Component for its internal State
@@ -1139,15 +1139,15 @@ module WRFHydro_NUOPC
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65535, 65535,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65281,  8193,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query Component for its internal State
@@ -1258,15 +1258,15 @@ subroutine CheckImport(gcomp, rc)
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65535, 65535,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65281,  8193,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query Component for its internal State
@@ -1325,15 +1325,15 @@ subroutine CheckImport(gcomp, rc)
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65535, 65535,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65281,  8193,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query component for its internal State
@@ -1485,15 +1485,15 @@ subroutine CheckImport(gcomp, rc)
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65535, 65535,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
       defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
     verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+      specialStringList=(/"max ","high","low ","off "/), &
+      specialValueList= (/ 65535, 65281,  8193,     0/), rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query Component for its internal State

--- a/trunk/NDHMS/CPL/NUOPC_cpl/WRFHydro_NUOPC_Gluecode.F90
+++ b/trunk/NDHMS/CPL/NUOPC_cpl/WRFHydro_NUOPC_Gluecode.F90
@@ -315,11 +315,11 @@ contains
     call orchestrator%init()
 
     ! Set default namelist values
-    read (startTimeStr(1:4),"(I)")   nlst(did)%START_YEAR
-    read (startTimeStr(6:7),"(I)")   nlst(did)%START_MONTH
-    read (startTimeStr(9:10),"(I)")  nlst(did)%START_DAY
-    read (startTimeStr(12:13),"(I)") nlst(did)%START_HOUR
-    read (startTimeStr(15:16),"(I)") nlst(did)%START_MIN
+    read (startTimeStr(1:4),"(I4)")   nlst(did)%START_YEAR
+    read (startTimeStr(6:7),"(I2)")   nlst(did)%START_MONTH
+    read (startTimeStr(9:10),"(I2)")  nlst(did)%START_DAY
+    read (startTimeStr(12:13),"(I2)") nlst(did)%START_HOUR
+    read (startTimeStr(15:16),"(I2)") nlst(did)%START_MIN
     nlst(did)%startdate(1:19) = startTimeStr(1:19)
     nlst(did)%olddate(1:19)   = startTimeStr(1:19)
     nlst(did)%dt = dt
@@ -461,11 +461,11 @@ contains
 #endif
 
     ! Override the clock configuration in hyro.namelist
-    read (startTimeStr(1:4),"(I)")   nlst(did)%START_YEAR
-    read (startTimeStr(6:7),"(I)")   nlst(did)%START_MONTH
-    read (startTimeStr(9:10),"(I)")  nlst(did)%START_DAY
-    read (startTimeStr(12:13),"(I)") nlst(did)%START_HOUR
-    read (startTimeStr(15:16),"(I)") nlst(did)%START_MIN
+    read (startTimeStr(1:4),"(I4)")   nlst(did)%START_YEAR
+    read (startTimeStr(6:7),"(I2)")   nlst(did)%START_MONTH
+    read (startTimeStr(9:10),"(I2)")  nlst(did)%START_DAY
+    read (startTimeStr(12:13),"(I2)") nlst(did)%START_HOUR
+    read (startTimeStr(15:16),"(I2)") nlst(did)%START_MIN
     nlst(did)%startdate(1:19) = startTimeStr(1:19)
     nlst(did)%olddate(1:19)   = startTimeStr(1:19)
     nlst(did)%dt = dt


### PR DESCRIPTION
TYPE: fix

KEYWORDS: NUOPC, GNU

SOURCE: Daniel Rosen (drosen@ucar.edu) - NCAR/ESMF

DESCRIPTION OF CHANGES: Fix GNU compiling issues

ISSUE: `none`

TESTS CONDUCTED: Explicitly state if regression, integration, or unit tests were run before submitting (do not include the CI tests automatically run by GitHub)