### PR TITLE
Update definitions of sum_real8 and sumreal1d.

### DIFF
--- a/trunk/NDHMS/MPP/mpp_land.F
+++ b/trunk/NDHMS/MPP/mpp_land.F
@@ -2061,35 +2061,45 @@ MODULE MODULE_MPP_LAND
 
     subroutine sum_real1d(vin,nsize)
        implicit none
-       integer  :: nsize
-       real,dimension(nsize) :: vin
-       real*8,dimension(nsize) :: vin8
-       vin8=vin
-       call sum_real8(vin8,nsize)
-       vin=vin8
+       integer  :: nsize, tag, ierr
+       real,dimension(nsize) :: vin, recv
+       !real*8,dimension(nsize) :: vin8
+       
+        tag = 319
+        call MPI_ALLREDUCE(vin, recv, nsize, MPI_REAL, MPI_SUM,HYDRO_COMM_WORLD, ierr)
+        vin(:) = recv(:)
+
+       !vin8=vin
+       !call sum_real8(vin8,nsize)
+       !vin=vin8
     end subroutine sum_real1d
 
     subroutine sum_real8(vin,nsize)
        implicit none
-       integer nsize,i,j,tag,ierr
+       integer nsize,tag,ierr
+       !integer i,j
        real*8, dimension(nsize):: vin,recv
        real, dimension(nsize):: v
+
        tag = 319
-       if(my_id .eq. IO_id) then
-          do i = 0, numprocs - 1
-             if(i .ne. my_id) then
-               call mpi_recv(recv,nsize,MPI_DOUBLE_PRECISION,i,  &
-                    tag,HYDRO_COMM_WORLD,mpp_status,ierr)
-               vin(:) = vin(:) + recv(:)
-             endif
-          end do
-          v = vin
-       else
-             call mpi_send(vin,nsize,MPI_DOUBLE_PRECISION,IO_id,   &
-                  tag,HYDRO_COMM_WORLD,ierr)
-       endif
-       call mpp_land_bcast_real(nsize,v)
-       vin = v
+       call MPI_ALLREDUCE(vin, recv, nsize, MPI_DOUBLE_PRECISION, MPI_SUM, HYDRO_COMM_WORLD, ierr)
+       vin(:) = recv(:)
+
+       !if(my_id .eq. IO_id) then
+       !   do i = 0, numprocs - 1
+       !      if(i .ne. my_id) then
+       !        call mpi_recv(recv,nsize,MPI_DOUBLE_PRECISION,i,  &
+       !             tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+       !        vin(:) = vin(:) + recv(:)
+       !      endif
+       !   end do
+       !   v = vin
+       !else
+       !      call mpi_send(vin,nsize,MPI_DOUBLE_PRECISION,IO_id,   &
+       !           tag,HYDRO_COMM_WORLD,ierr)
+       !endif
+       !call mpp_land_bcast_real(nsize,v)
+       !vin = v
        return
     end subroutine sum_real8
 


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: approximately 3 to 6 words (more is always better) related to your commit, separated by commas

SOURCE: Donald W Johnson, NWC (National Water Center)

DESCRIPTION OF CHANGES: This pull request is intended to replace mpi code in mpp_land.F and other mpp files where mpi_send and mpi_recv are being used for tasks better suited to higher level mpi constructs (mpi_gather[v], mpi_scatter[v], mpi_reduce, mpi_allreduce). The intent is to not change the current behavior of any functions but to improve the efficiency of the underling communication.  In some cases this means that internal unit conversions (for example unneeded changes form real*8 to real) will be eliminated and this may slightly change final answers.

ISSUE: 
```
Fixes #551
```

TESTS CONDUCTED: Explicitly state if regression, integration, or unit tests were run before submitting (do not include the CI tests automatically run by GitHub)

####################################
### TESTING:  ---  nwm_ana  ---  ###
####################################

echo; echo "Using the following modules for testing:" ; module list; echo;pytest -vv --tb=no --ignore=local -p no:cacheprovider  --html=/glade/scratch/donaldj/take_test_croton_NY_mpi_updates/wrfhydro_testing-ifort-nwm_ana.html --self-contained-html --config=nwm_ana --compiler=ifort --domain_dir=/glade/work/jamesmcc/domains/public/croton_NY --candidate_dir=/glade/scratch/donaldj/take_test_croton_NY_mpi_updates/dwj_wrf_hydro_nwm_can_pytest/trunk/NDHMS --reference_dir=/glade/scratch/donaldj/take_test_croton_NY_mpi_updates/reference_ref_pytest/trunk/NDHMS --output_dir=/glade/scratch/donaldj/take_test_croton_NY_mpi_updates --exe_cmd='mpirun -np 6 ./wrf_hydro.exe' --ncores=6 --xrcmp_n_cores=0 --scheduler  --nnodes=1 --account=NRAL0017 --walltime=01:00:00 --queue=share

Using the following modules for testing:

Currently Loaded Modules:
  1) intel/18.0.5   2) impi/2018.4.274   3) ncarcompilers/0.5.0   4) netcdf/4.7.4   5) ncarenv/1.3   6) nccmp/1.8.2.1

 


=========================================================== test session starts ===========================================================
platform linux -- Python 3.6.8, pytest-5.1.2, py-1.8.0, pluggy-0.12.0 -- /glade/p/cisl/nwc/model_testing_env/wrf_hydro_nwm_test/bin/python
metadata: {'Python': '3.6.8', 'Platform': 'Linux-4.12.14-95.51-default-x86_64-with-SuSE-12-x86_64', 'Packages': {'pytest': '5.1.2', 'py': '1.8.0', 'pluggy': '0.12.0'}, 'Plugins': {'html': '1.19.0', 'datadir-ng': '1.1.0', 'metadata': '1.8.0'}, 'JAVA_HOME': '/usr/lib64/jvm/java'}
rootdir: /glade/scratch/donaldj/take_test_croton_NY_mpi_updates/dwj_wrf_hydro_nwm_can_pytest
plugins: html-1.19.0, datadir-ng-1.1.0, metadata-1.8.0
collected 16 items                                                                                                                        

tests/test_1_fundamental.py::test_compile_candidate PASSED                                                                         [  6%]
tests/test_1_fundamental.py::test_compile_reference PASSED                                                                          [ 12%]
tests/test_1_fundamental.py::test_run_candidate PASSED                                                                                [ 18%]
tests/test_1_fundamental.py::test_run_reference PASSED                                                                                 [ 25%]
tests/test_1_fundamental.py::test_ncores_candidate PASSED                                                                           [ 31%]
tests/test_1_fundamental.py::test_perfrestart_candidate PASSED                                                                     [ 37%]
tests/test_2_regression.py::test_regression_data PASSED                                                                                 [ 43%]
tests/test_2_regression.py::test_regression_metadata PASSED                                                                         [ 50%]
tests/test_3_outputs.py::test_output_has_nans PASSED                                                                                    [ 56%]
tests/test_supp_1_channel_only.py::test_run_candidate_channel_only PASSED                                                [ 62%]
tests/test_supp_1_channel_only.py::test_channel_only_matches_full PASSED                                                   [ 68%]
tests/test_supp_1_channel_only.py::test_ncores_candidate_channel_only PASSED                                           [ 75%]
tests/test_supp_1_channel_only.py::test_perfrestart_candidate_channel_only PASSED                                     [ 81%]
tests/test_supp_2_nwm_output.py::test_run_reference_nwm_output_sim PASSED                                           [ 87%]
tests/test_supp_2_nwm_output.py::test_run_candidate_nwm_output_sim PASSED                                           [ 93%]
tests/test_supp_2_nwm_output.py::test_regression_metadata_nwm_output PASSED                                       [100%]


NOTES: 

This pull request will be updated periodically. I intend to only change one or two functions per commit. I am currently keeping the original function definitions in comments below changes, should this be maintained?


### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
 - [ ] Short description in the Development section of `NEWS.md`
