### PR TITLE
Change snow NIR albedo to use correct BATS NIR parameter.

### DIFF
--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -2955,7 +2955,7 @@ ENDIF   ! CROPTYPE == 0
         ALBSNI(2)=parameters%BATS_NIR_NEW*(1.-parameters%BATS_NIR_AGE*FAGE)        
 
         ALBSND(1)=ALBSNI(1)+parameters%BATS_VIS_DIR*FZEN*(1.-ALBSNI(1))    !  vis direct
-        ALBSND(2)=ALBSNI(2)+parameters%BATS_VIS_DIR*FZEN*(1.-ALBSNI(2))    !  nir direct
+        ALBSND(2)=ALBSNI(2)+parameters%BATS_NIR_DIR*FZEN*(1.-ALBSNI(2))    !  nir direct
 
   END SUBROUTINE SNOWALB_BATS
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: snow, albedo, parameters

SOURCE: Aubrey D, NCAR 

DESCRIPTION OF CHANGES: Fix what I think is a typo in the NIR snow albedo calculation. Should not result in answer changes if using default parameters (since BATS_VIS_DIR = BATS_NIR_DIR in default).

TESTS CONDUCTED: Sample basin tested to confirm no answer changes with default params and answer changes when BATS_VIS_DIR != BATS_NIR_DIR

 