### PR TITLE
Fix CMake build when NWM_META=1

### DIFF
--- a/trunk/NDHMS/utils/CMakeLists.txt
+++ b/trunk/NDHMS/utils/CMakeLists.txt
@@ -3,11 +3,11 @@ cmake_minimum_required (VERSION 2.8)
 # read version numbers for wrf_hydro_version and nwm_version from 
 # ../.version and ../.nwm_version
 file (STRINGS "../.version" WRF_HYDRO_VERSION)
-if (NWM_META)
+if (NWM_META AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../.nwm_version)
 	file (STRINGS "../.nwm_version"  NWM_VERSION)
-else (NWM_META)
-	set(NWM_VERSION "none")
-endif (NWM_META)
+else (NWM_META AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../.nwm_version)
+	set(NWM_VERSION "undefined")
+endif (NWM_META AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../.nwm_version)
 
 # add the preprocessor definitions for NWM_VERSION and WRF_HYDRO_VERSION
 # needed to compile module_version.F


### PR DESCRIPTION
TYPE: bug_fix

KEYWORDS: cmake, NWM_META

SOURCE:
Dan Rosen @danrosen25
ESMF/CGD/UCAR

DESCRIPTION OF CHANGES:
Fix cmake reference to missing .nwm_version file for when NWM_META=1. First checks if file exists. If the file does not exist then NWM_VERSION is set to undefined.

ISSUE:
```
Fixes #572
```

TESTS CONDUCTED:
Built on Jet within UFS application with NWM_META=1. Ran coupled UFSATM-WRFHYDRO configuration

### Checklist
 - [X] Closes issue #572 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
