### PR TITLE
Read ZSOIL8 from HYDRO_nlist if sys_cpl ne 1

### DIFF
--- a/trunk/NDHMS/OrchestratorLayer/config.f90
+++ b/trunk/NDHMS/OrchestratorLayer/config.f90
@@ -632,10 +632,13 @@ contains
 
     if(CHANRTSWCRT .eq. 0 .and. channel_option .lt. 3) channel_option = 3
 
-    !used to be broadcasted with MPI
-    !nlst(did)%NSOIL = NSOIL
-    !allocate(nlst(did)%ZSOIL8(NSOIL))
-    !nlst(did)%ZSOIL8 = ZSOIL8
+    ! sys_cpl .eq. 1 reads soil_thick_input from NOAHLSM_OFFLINE
+    if(sys_cpl .ne. 1) then
+      nlst(did)%NSOIL = NSOIL
+      if (allocated(nlst(did)%ZSOIL8)) deallocate(nlst(did)%ZSOIL8)
+      allocate(nlst(did)%ZSOIL8(NSOIL))
+      nlst(did)%ZSOIL8 = ZSOIL8
+    end if
 
     nlst(did)%RESTART_FILE = RESTART_FILE
     nlst(did)%hydrotbl_f = trim(hydrotbl_f)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: ZSOIL8, HYDRO_nlist, config

SOURCE: @danrosen25 NCAR 

DESCRIPTION OF CHANGES: This fixes an issue where the user cannot specify the soil depths (a.k.a. soil layer thickness) in configuration files during coupled runs. If the sys_cpl type does not equal 1 the initialization routine will read ZSOIL8 from the HYDRO_nlist namelist in the hydro.namelist file. This may is not fully backwards compatible because previous coupling applications may have relied on hardcoded soil depths.

ISSUE: #571 

TESTS CONDUCTED: I tested using sys_cpl=2 in a coupled LIS-WRFHYDRO application using NUOPC infrastructure.

### Checklist

 - [x] Closes issue #571 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [ ] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
