### PR TITLE
Update reach / lake IDs to 64-bit

### DIFF
--- a/trunk/NDHMS/Data_Rec/module_RT_data.F
+++ b/trunk/NDHMS/Data_Rec/module_RT_data.F
@@ -25,6 +25,7 @@ Module module_RT_data
    use module_subsurface_input
    use module_subsurface_output
    use module_reservoir, only: reservoir_container
+   use iso_fortran_env, only: int64
    IMPLICIT NONE
    INTEGER, PARAMETER :: max_domain=5
 

--- a/trunk/NDHMS/Data_Rec/rt_include.inc
+++ b/trunk/NDHMS/Data_Rec/rt_include.inc
@@ -42,10 +42,10 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !DJG   VARIABLES FOR ROUTING
   !INTEGER, allocatable, DIMENSION(:,:)      :: CH_NETRT !-- keeps track of the 0-1 channel network ! moved to overland%streams_and_lakes
-  INTEGER, allocatable, DIMENSION(:,:)      :: CH_LNKRT !-- linked routing grid (should combine with CH_NETRT.. redundant Gochis!)
+  INTEGER(kind=int64), allocatable, DIMENSION(:,:)      :: CH_LNKRT !-- linked routing grid (should combine with CH_NETRT.. redundant Gochis!)
 
 
-  INTEGER, allocatable, DIMENSION(:,:)      :: CH_NETLNK, GCH_NETLNK !-- assigns a unique value to each channel gridpoint, called links
+  INTEGER(kind=int64), allocatable, DIMENSION(:,:)      :: CH_NETLNK, GCH_NETLNK !-- assigns a unique value to each channel gridpoint, called links
   REAL,    allocatable, DIMENSION(:,:)      :: LATVAL,LONVAL !-- lat lon
   REAL,    allocatable, DIMENSION(:,:)      :: TERRAIN
   REAL,    allocatable, DIMENSION(:,:)      :: landRunOff   ! used for NHDPLUS only
@@ -73,7 +73,7 @@
 
   INTEGER :: nToInd
   INTEGER,    allocatable, DIMENSION(:)      :: toNodeInd
-  INTEGER,    allocatable, DIMENSION(:,:)      :: gtoNode
+  INTEGER(kind=int64),    allocatable, DIMENSION(:,:)      :: gtoNode
 
 ! temp arrary cwatavail
   !real, allocatable, DIMENSION(:,:,:)      :: SMCREFRT  ! SMCREFRT moved to subsurface grid_transform module
@@ -81,7 +81,7 @@
 !DJG   VARIABLES FOR GW/Baseflow
   INTEGER :: numbasns
   INTEGER :: gnumbasns
-  INTEGER, allocatable, DIMENSION(:)     :: basnsInd ! basin index for tile
+  integer(kind=int64), allocatable, dimension(:)     :: basnsInd ! basin index for tile
   INTEGER, allocatable, DIMENSION(:,:)   :: GWSUBBASMSK  !GW basin mask grid
   REAL,    allocatable, DIMENSION(:,:)   :: qinflowbase  !strm inflow/baseflow from GW
   REAL,    allocatable, DIMENSION(:,:)   :: SOLDRAIN     !time-step drainage
@@ -115,9 +115,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !DJG,DNY   VARIABLES FOR CHANNEL ROUTING
 !-- channel params
-  INTEGER, allocatable, DIMENSION(:)   :: LINK       !channel link
-  INTEGER, allocatable, DIMENSION(:)   :: TO_NODE    !link's to node
-  INTEGER, allocatable, DIMENSION(:)   :: FROM_NODE  !link's from node
+  INTEGER(kind=int64), allocatable, DIMENSION(:)   :: LINK       !channel link
+  INTEGER(kind=int64), allocatable, DIMENSION(:)   :: TO_NODE    !link's to node
+  INTEGER(kind=int64), allocatable, DIMENSION(:)   :: FROM_NODE  !link's from node
   INTEGER, allocatable, DIMENSION(:)   :: ORDER      !link's order
   INTEGER, allocatable, DIMENSION(:)   :: STRMFRXSTPTS      !frxst point flag
   CHARACTER(len=15), allocatable, DIMENSION(:) :: gages
@@ -130,10 +130,10 @@
   INTEGER, allocatable, DIMENSION(:)   :: TYPEN      !type of link 0 strm 1 lake
   REAL, allocatable, DIMENSION(:)      :: QLAKEI      !lake inflow in difussion scheme
   REAL, allocatable, DIMENSION(:)      :: QLAKEO      !lake outflow in difussion scheme
-  INTEGER, allocatable, DIMENSION(:)   :: LAKENODE   !which nodes flow into which lakes
-  INTEGER, allocatable, DIMENSION(:)   :: LINKID     ! id of links on linked routing
+  INTEGER(kind=int64), allocatable, DIMENSION(:)   :: LAKENODE   !which nodes flow into which lakes
+  integer(kind=int64), allocatable, dimension(:)   :: LINKID     ! id of links on linked routing
   REAL, allocatable, DIMENSION(:)      :: CVOL       ! channel volume
-  INTEGER, allocatable, DIMENSION(:,:)   :: pnode    !parent nodes : start from 2
+  INTEGER(kind=int64), allocatable, DIMENSION(:,:)   :: pnode    !parent nodes : start from 2
   integer :: maxv_p              ! array size for  second column of the pnode
 
   REAL, allocatable, DIMENSION(:)      :: MUSK, MUSX !muskingum params
@@ -160,8 +160,8 @@
   ! VARIABLES FOR  RESERVOIRS
   REAL, allocatable, DIMENSION(:)      :: RESHT  !reservoir height
 !-- lake params
-  INTEGER, allocatable, DIMENSION(:) :: LAKEIDA     !id of lakes in routlink file
-  INTEGER, allocatable, DIMENSION(:) :: LAKEIDM     !id of LAKES Modeled in LAKEPARM.nc or tbl
+  integer(kind=int64), allocatable, dimension(:) :: LAKEIDA     !id of lakes in routlink file
+  integer(kind=int64), allocatable, dimension(:) :: LAKEIDM     !id of LAKES Modeled in LAKEPARM.nc or tbl
   REAL, allocatable, DIMENSION(:)    :: HRZAREA    !horizontal extent of lake, km^2
   REAL, allocatable, DIMENSION(:)    :: WEIRL      !overtop weir length (m)
   REAL, allocatable, DIMENSION(:)    :: DAML      !overtop weir length (m)
@@ -181,11 +181,11 @@
 
 #ifdef MPP_LAND
   INTEGER, allocatable, DIMENSION(:)    :: lake_index,nlinks_index
-  INTEGER, allocatable, DIMENSION(:,:)  :: Link_location
-  INTEGER, allocatable, DIMENSION(:)  :: LLINKID
+  INTEGER(kind=int64), allocatable, DIMENSION(:,:)  :: Link_location
+  integer(kind=int64), allocatable, dimension(:)  :: LLINKID
   integer mpp_nlinks, yw_mpp_nlinks, LNLINKSL
 #endif
-  INTEGER, allocatable, DIMENSION(:,:)      :: CH_LNKRT_SL !-- reach based links used for mapping
+  INTEGER(kind=int64), allocatable, DIMENSION(:,:)      :: CH_LNKRT_SL !-- reach based links used for mapping
 
 
   REAL,    allocatable, DIMENSION(:,:)      :: OVROUGHRTFAC,RETDEPRTFAC

--- a/trunk/NDHMS/MPP/hashtable.F
+++ b/trunk/NDHMS/MPP/hashtable.F
@@ -1,10 +1,10 @@
 module hashtable
-
+    use iso_fortran_env, only: int64
   implicit none
 
   type kv_type
-     integer :: key
-     integer :: value
+     integer(kind=int64) :: key
+     integer(kind=int64) :: value
   end type kv_type
 
   type node_type
@@ -41,8 +41,8 @@ module hashtable
 
   public
   type hash_t
-     integer :: n_buckets = 0
-     integer :: n_keys = 0
+     integer(kind=int64) :: n_buckets = 0
+     integer(kind=int64) :: n_keys = 0
      type(node_type), allocatable :: buckets(:)
    contains
      procedure, public :: bucket_count
@@ -66,8 +66,8 @@ contains
   function hash(this,key_value) result(bucket)
 
     class(hash_t), intent(inout) :: this
-    integer, intent(in) :: key_value
-    integer :: bucket
+    integer(kind=int64), intent(in) :: key_value
+    integer(kind=int64) bucket
 
     bucket = key_value
 
@@ -75,15 +75,15 @@ contains
 
   function bucket_count(this)
     class(hash_t), intent(inout) :: this
-    integer :: bucket_count
+    integer(kind=int64) bucket_count
 
     bucket_count = this%n_buckets
   end function bucket_count
 
   function n_collisions(this)
     class(hash_t), intent(inout) :: this
-    integer :: n_collisions
-    integer :: i
+    integer(kind=int64) n_collisions
+    integer(kind=int64) i
 
     n_collisions = 0
     do i = 1, this%n_buckets
@@ -93,7 +93,7 @@ contains
 
   recursive function node_depth(this) result(depth)
     class(node_type), intent(inout) :: this
-    integer :: depth
+    integer(kind=int64) depth
 
     if (.not. associated(this%next)) then
        depth = 1
@@ -104,16 +104,16 @@ contains
 
   pure function key_count(this)
     class(hash_t), intent(in) :: this
-    integer :: key_count
+    integer(kind=int64) key_count
 
     key_count = this%n_keys
   end function key_count
 
   subroutine set(this, key, value)
     class(hash_t), intent(inout) :: this
-    integer, intent(in) :: key
-    integer, intent(in) :: value
-    integer :: bucket_id
+    integer(kind=int64), intent(in) :: key
+    integer(kind=int64), intent(in) :: value
+    integer(kind=int64) bucket_id
     logical :: is_new
 
     bucket_id = modulo(this%hash(key), this%n_buckets) + 1
@@ -125,9 +125,10 @@ contains
 
   subroutine set_all_idx(this, keys, length)
     class(hash_t), intent(inout) :: this
-    integer, intent(in) :: keys(:)
+    integer(kind=int64), intent(in) :: keys(:)
     integer, optional, intent(in) :: length
-    integer :: bucket_id, i, n
+    integer(kind=int64) :: i
+    integer(kind=int64) bucket_id, n
 
     if(present(length)) then
        n = length
@@ -147,9 +148,9 @@ contains
 
   subroutine set_all(this, keys, values)
     class(hash_t), intent(inout) :: this
-    integer, intent(in) :: keys(:)
-    integer, intent(in) :: values(:)
-    integer :: bucket_id, i, n
+    integer(kind=int64), intent(in) :: keys(:)
+    integer(kind=int64), intent(in) :: values(:)
+    integer(kind=int64) bucket_id, i, n
 
     n = size(keys)
 
@@ -165,8 +166,8 @@ contains
 
   recursive subroutine node_set(this, key, value)
     class(node_type), intent(inout) :: this
-    integer, intent(in) :: key
-    integer, intent(in) :: value
+    integer(kind=int64), intent(in) :: key
+    integer(kind=int64), intent(in) :: value
 
     if (.not. allocated(this%kv)) then
        allocate(this%kv)
@@ -184,10 +185,10 @@ contains
 
   subroutine get(this, key, value, success)
     class(hash_t), intent(inout) :: this
-    integer, intent(in) :: key
-    integer, intent(out) :: value
+    integer(kind=int64), intent(in) :: key
+    integer(kind=int64), intent(out) :: value
     logical, intent(out) :: success
-    integer :: bucket_id
+    integer(kind=int64) bucket_id
 
     success = .false.
     if(this%n_buckets == 0) return
@@ -197,8 +198,8 @@ contains
 
   recursive subroutine node_get(this, key, value, success)
     class(node_type), intent(inout) :: this
-    integer, intent(in) :: key
-    integer, intent(out) :: value
+    integer(kind=int64), intent(in) :: key
+    integer(kind=int64), intent(out) :: value
     logical, intent(out) :: success
 
     success = .false.
@@ -218,7 +219,7 @@ contains
 
   subroutine clear(this)
     class(hash_t), intent(inout) :: this
-    integer :: i
+    integer(kind=int64) i
 
     if (.not. allocated(this%buckets)) return
 

--- a/trunk/NDHMS/MPP/module_mpp_GWBUCKET.F
+++ b/trunk/NDHMS/MPP/module_mpp_GWBUCKET.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !   This is used as a coupler with the WRF model.
@@ -27,7 +27,7 @@ MODULE MODULE_mpp_GWBUCKET
   use iso_fortran_env, only: int64
   implicit none
 
-  
+
 
   include "mpif.h"
 
@@ -45,24 +45,24 @@ MODULE MODULE_mpp_GWBUCKET
      maxSizeInd = 0
   end subroutine gwbucket_ini
 
- 
+
   subroutine collectSizeInd(numbasns)
      implicit none
      integer, intent(in) :: numbasns
-     integer :: i, ierr, tag, rcv 
+     integer :: i, ierr, tag, rcv
 
       call mpp_land_sync()
 
      if(gw_ini .ne. 99) call gwbucket_ini()
 
      if(my_id .ne. IO_id) then
-          tag = 66 
+          tag = 66
           call mpi_send(numbasns,1,MPI_INTEGER, IO_id,     &
                 tag,HYDRO_COMM_WORLD,ierr)
      else
           do i = 0, numprocs - 1
               if(i .eq. IO_id) then
-                 sizeInd(i+1) = numbasns 
+                 sizeInd(i+1) = numbasns
               else
                  tag = 66
                  call mpi_recv(rcv,1,&
@@ -86,8 +86,8 @@ MODULE MODULE_mpp_GWBUCKET
      integer(kind=int64), allocatable,dimension(:) :: ibuff
 
      if(gw_ini .ne. 99) then
-        stop "FATAL ERROR: mpp_GWBUCKET not initialized."        
-     endif 
+        stop "FATAL ERROR: mpp_GWBUCKET not initialized."
+     endif
 
      if(my_id .eq. IO_id) then
          outV = 0.0
@@ -110,7 +110,7 @@ MODULE MODULE_mpp_GWBUCKET
       else
 
           do k = 1, numbasns
-              outV(ind(k)) = inV(k)  
+              outV(ind(k)) = inV(k)
           end do
 
           do i = 0, numprocs - 1
@@ -122,11 +122,11 @@ MODULE MODULE_mpp_GWBUCKET
                   tag2 = 63
                   call mpi_recv(ibuff(1:sizeInd(i+1)),sizeInd(i+1),&
                       MPI_INTEGER8,i,tag2,HYDRO_COMM_WORLD,mpp_status,ierr)
-   
+
                   do k = 1, sizeInd(i+1)
-                     outV(ibuff(k)) = vbuff(k) 
+                     outV(ibuff(k)) = vbuff(k)
                   end do
-               endif 
+               endif
              end if
            end do
       end if
@@ -141,13 +141,13 @@ MODULE MODULE_mpp_GWBUCKET
       integer(kind=int64),intent(in), dimension(numbasns) :: inV
       integer(kind=int64),intent(in), dimension(numbasns) :: ind
       integer(kind=int64), dimension(:) :: outV
-      integer, allocatable,dimension(:) :: vbuff
-      integer, allocatable,dimension(:) :: ibuff
- 
+      integer(kind=int64), allocatable,dimension(:) :: vbuff
+      integer(kind=int64), allocatable,dimension(:) :: ibuff
+
       if(gw_ini .ne. 99) then
-         stop "FATAL ERROR: mpp_GWBUCKET not initialized."        
-      endif 
- 
+         stop "FATAL ERROR: mpp_GWBUCKET not initialized."
+      endif
+
       if(my_id .eq. IO_id) then
           outV = 0.0
           allocate(vbuff(maxSizeInd))
@@ -156,7 +156,7 @@ MODULE MODULE_mpp_GWBUCKET
           allocate(vbuff(1))
           allocate(ibuff(1))
       endif
- 
+
       if(my_id .ne. IO_id) then
          if(numbasns .gt. 0) then
            tag = 62
@@ -167,11 +167,11 @@ MODULE MODULE_mpp_GWBUCKET
                  tag2,HYDRO_COMM_WORLD,ierr)
          endif
        else
- 
+
            do k = 1, numbasns
-               outV(ind(k)) = inV(k)  
+               outV(ind(k)) = inV(k)
            end do
- 
+
            do i = 0, numprocs - 1
              if(i .ne. IO_id) then
                 if(sizeInd(i+1) .gt. 0) then
@@ -181,11 +181,11 @@ MODULE MODULE_mpp_GWBUCKET
                    tag2 = 63
                    call mpi_recv(ibuff(1:sizeInd(i+1)),sizeInd(i+1),&
                        MPI_INTEGER8,i,tag2,HYDRO_COMM_WORLD,mpp_status,ierr)
-    
+
                    do k = 1, sizeInd(i+1)
-                      outV(ibuff(k)) = vbuff(k) 
+                      outV(ibuff(k)) = vbuff(k)
                    end do
-                endif 
+                endif
               end if
             end do
        end if
@@ -223,16 +223,14 @@ MODULE MODULE_mpp_GWBUCKET
 
        vbuff = 0
        do k = 1, nsize
-          vbuff(ind(k)) = vinout(k) 
+          vbuff(ind(k)) = vinout(k)
        end do
        call sum_real8(vbuff,gsize)
        do k = 1, nsize
-          vinout(k) = vbuff(ind(k)) 
+          vinout(k) = vbuff(ind(k))
        end do
     end subroutine gw_sum_real
-  
+
 
 
 end MODULE MODULE_mpp_GWBUCKET
-
-

--- a/trunk/NDHMS/MPP/module_mpp_GWBUCKET.F
+++ b/trunk/NDHMS/MPP/module_mpp_GWBUCKET.F
@@ -24,6 +24,7 @@ MODULE MODULE_mpp_GWBUCKET
   use MODULE_CPL_LAND, only: HYDRO_COMM_WORLD
   use module_mpp_land, only:  io_id, my_id, mpp_status, mpp_land_max_int1, numprocs, &
                  mpp_land_bcast_real, sum_real8,  mpp_land_sync
+  use iso_fortran_env, only: int64
   implicit none
 
   
@@ -79,10 +80,10 @@ MODULE MODULE_mpp_GWBUCKET
      integer, intent(in) :: numbasns
      integer :: i, ierr, tag, tag2,k
      real,intent(in), dimension(numbasns) :: inV
-     integer,intent(in), dimension(numbasns) :: ind
+     integer(kind=int64), intent(in), dimension(numbasns) :: ind
      real, dimension(:) :: outV
      real, allocatable,dimension(:) :: vbuff
-     integer, allocatable,dimension(:) :: ibuff
+     integer(kind=int64), allocatable,dimension(:) :: ibuff
 
      if(gw_ini .ne. 99) then
         stop "FATAL ERROR: mpp_GWBUCKET not initialized."        
@@ -103,7 +104,7 @@ MODULE MODULE_mpp_GWBUCKET
           call mpi_send(inV,numbasns,MPI_REAL, IO_id,     &
                 tag,HYDRO_COMM_WORLD,ierr)
           tag2 = 63
-          call mpi_send(ind,numbasns,MPI_INTEGER, IO_id,     &
+          call mpi_send(ind,numbasns,MPI_INTEGER8, IO_id,     &
                 tag2,HYDRO_COMM_WORLD,ierr)
         endif
       else
@@ -120,7 +121,7 @@ MODULE MODULE_mpp_GWBUCKET
                       MPI_REAL,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                   tag2 = 63
                   call mpi_recv(ibuff(1:sizeInd(i+1)),sizeInd(i+1),&
-                      MPI_INTEGER,i,tag2,HYDRO_COMM_WORLD,mpp_status,ierr)
+                      MPI_INTEGER8,i,tag2,HYDRO_COMM_WORLD,mpp_status,ierr)
    
                   do k = 1, sizeInd(i+1)
                      outV(ibuff(k)) = vbuff(k) 
@@ -137,9 +138,9 @@ MODULE MODULE_mpp_GWBUCKET
       implicit none
       integer, intent(in) :: numbasns
       integer :: i, ierr, tag, tag2,k
-      integer,intent(in), dimension(numbasns) :: inV
-      integer,intent(in), dimension(numbasns) :: ind
-      integer, dimension(:) :: outV
+      integer(kind=int64),intent(in), dimension(numbasns) :: inV
+      integer(kind=int64),intent(in), dimension(numbasns) :: ind
+      integer(kind=int64), dimension(:) :: outV
       integer, allocatable,dimension(:) :: vbuff
       integer, allocatable,dimension(:) :: ibuff
  
@@ -159,10 +160,10 @@ MODULE MODULE_mpp_GWBUCKET
       if(my_id .ne. IO_id) then
          if(numbasns .gt. 0) then
            tag = 62
-           call mpi_send(inV,numbasns,MPI_INTEGER, IO_id,     &
+           call mpi_send(inV,numbasns,MPI_INTEGER8, IO_id,     &
                  tag,HYDRO_COMM_WORLD,ierr)
            tag2 = 63
-           call mpi_send(ind,numbasns,MPI_INTEGER, IO_id,     &
+           call mpi_send(ind,numbasns,MPI_INTEGER8, IO_id,     &
                  tag2,HYDRO_COMM_WORLD,ierr)
          endif
        else
@@ -176,10 +177,10 @@ MODULE MODULE_mpp_GWBUCKET
                 if(sizeInd(i+1) .gt. 0) then
                    tag = 62
                    call mpi_recv(vbuff(1:sizeInd(i+1)),sizeInd(i+1),&
-                       MPI_INTEGER,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+                       MPI_INTEGER8,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                    tag2 = 63
                    call mpi_recv(ibuff(1:sizeInd(i+1)),sizeInd(i+1),&
-                       MPI_INTEGER,i,tag2,HYDRO_COMM_WORLD,mpp_status,ierr)
+                       MPI_INTEGER8,i,tag2,HYDRO_COMM_WORLD,mpp_status,ierr)
     
                    do k = 1, sizeInd(i+1)
                       outV(ibuff(k)) = vbuff(k) 
@@ -197,7 +198,7 @@ MODULE MODULE_mpp_GWBUCKET
      integer, intent(in) :: numbasns, gnumbasns
      integer :: i, ierr, tag, bas
      real,intent(in), dimension(:) :: inV
-     integer,intent(in), dimension(:) :: ind
+     integer(kind=int64),intent(in), dimension(:) :: ind
      real, dimension(:) :: outV
      real, dimension(gnumbasns) :: buff
 
@@ -217,7 +218,7 @@ MODULE MODULE_mpp_GWBUCKET
        implicit none
        integer nsize,i,j,tag,ierr,gsize, k
        real*8, dimension(nsize):: vinout
-       integer, dimension(nsize) :: ind
+       integer(kind=int64), dimension(nsize) :: ind
        real*8, dimension(gsize) :: vbuff
 
        vbuff = 0

--- a/trunk/NDHMS/MPP/module_mpp_ReachLS.F
+++ b/trunk/NDHMS/MPP/module_mpp_ReachLS.F
@@ -37,6 +37,7 @@ MODULE MODULE_mpp_ReachLS
      module procedure ReachLS_decompReal
      module procedure ReachLS_decompReal8
      module procedure ReachLS_decompInt
+     module procedure ReachLS_decompInt8
      module procedure ReachLS_decompChar
   end interface
 
@@ -46,6 +47,7 @@ MODULE MODULE_mpp_ReachLS
      module procedure ReachLS_wReal8
      module procedure ReachLS_wInt
      module procedure ReachLS_wInt2
+     module procedure ReachLS_wInt8
      module procedure ReachLS_wChar
   end interface
 
@@ -53,6 +55,7 @@ MODULE MODULE_mpp_ReachLS
      module procedure gbcastReal
      module procedure gbcastInt
      module procedure gbcastReal2
+     module procedure gbcastInt8
   end interface
 
   interface updateLinkV
@@ -341,12 +344,21 @@ MODULE MODULE_mpp_ReachLS
             IO_id,HYDRO_COMM_WORLD,ierr)
   end subroutine gbcastInt
 
+  subroutine gbcastInt8(inV, outV)
+      implicit none
+      integer(kind=int64), dimension(:) :: outV
+      integer(kind=int64), dimension(:) :: inV
+      integer :: ierr
+      call ReachLS_write_io(inV,outV)
+      call mpi_bcast(outV(1:gnlinksl),gnlinksl,MPI_INTEGER8,   &
+              IO_id,HYDRO_COMM_WORLD,ierr)
+  end subroutine gbcastInt8
 
   subroutine getLocalIndx(glinksl,LINKID, LLINKID)
        implicit none
-       integer, dimension(:) :: LINKID, LLINKID
+       integer(kind=int64), dimension(:) :: LINKID, LLINKID
        integer :: i,k, glinksl, ierr
-       integer :: gLinkId(glinksl)
+       integer(kind=int64) :: gLinkId(glinksl)
 
        LLINKLEN = size(LLINKID,1)
        allocate(LLINKIDINDX(LLINKLEN))
@@ -355,7 +367,7 @@ MODULE MODULE_mpp_ReachLS
 
        call ReachLS_write_io(LINKID,gLinkId)
 
-       call mpi_bcast(gLinkId(1:glinksl),glinksl,MPI_INTEGER,   &
+       call mpi_bcast(gLinkId(1:glinksl),glinksl,MPI_INTEGER8,   &
             IO_id,HYDRO_COMM_WORLD,ierr)
 
        ! The following loops are replaced by a hashtable-based algorithm
@@ -371,9 +383,9 @@ MODULE MODULE_mpp_ReachLS
 
        block
          type(hash_t) :: hash_table
-         integer :: val,it
+         integer(kind=int64) :: val,it
          logical :: found
-         
+
          call hash_table%set_all_idx(LLINKID,LLINKLEN)
          do it=1, glinksl
             call hash_table%get(gLinkId(it), val, found)
@@ -561,6 +573,38 @@ MODULE MODULE_mpp_ReachLS
 
   END subroutine ReachLS_decompInt
 
+  subroutine ReachLS_decompInt8(inV,outV)
+      implicit none
+      integer(kind=int64), INTENT(in),  dimension(:) :: inV
+      integer(kind=int64), INTENT(out), dimension(:) :: outV
+      integer ::  i, ierr, tag
+      tag = 11
+      if(my_id .eq. io_id) then
+          do i = 1, numprocs
+              if(i-1 .eq. io_id) then
+                  if(alinksl(i) .gt. 0) then
+                      outV(1:linkls_e(i)-linkls_s(i)+1) = inV(linkls_s(i):linkls_e(i))
+                  endif
+              else
+                  if(aLinksl(i) .gt. 0) then
+                      call mpi_send(inV(linkls_s(i):linkls_e(i)), &
+                              aLinksl(i),                &
+                              MPI_INTEGER8, i-1,tag,HYDRO_COMM_WORLD,ierr)
+                  endif
+              endif
+          end do
+      else
+          if(aLinksl(my_id+1) .gt. 0) then
+              call mpi_recv(outV(1:linkls_e(my_id+1)-linkls_s(my_id+1)+1), &
+                      alinksl(my_id+1),                           &
+                      MPI_INTEGER8, io_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+          endif
+      endif
+
+      call mpp_land_sync()
+
+  END subroutine ReachLS_decompInt8
+
 
   subroutine ReachLS_decompChar(inV,outV)
      implicit none
@@ -698,6 +742,37 @@ MODULE MODULE_mpp_ReachLS
       call mpp_land_sync()
   END subroutine ReachLS_wInt
 
+  subroutine ReachLS_wInt8(inV,outV)
+      implicit none
+      integer(kind=int64), intent(in), dimension(:)  :: inV
+      integer(kind=int64), intent(out), dimension(:) :: outV
+      integer :: i, ierr, tag
+      outV = 0
+      if(my_id .eq. io_id) then
+          do i = 1, numprocs
+              if(i-1 .eq. io_id) then
+                  if(alinksl(i) .gt. 0) then
+                      outV(linkls_s(i):linkls_e(i)) = inV(1:linkls_e(i)-linkls_s(i)+1)
+                  endif
+              else
+                  if(aLinksl(i) .gt. 0) then
+                      tag = 12
+                      call mpi_recv(outV(linkls_s(i):linkls_e(i)), &
+                              aLinksl(i),                             &
+                              MPI_INTEGER8,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+                  endif
+              endif
+          end do
+      else
+          if(aLinksl(my_id+1) .gt. 0) then
+              tag = 12
+              call mpi_send(inV(1:aLinksl(my_id+1) ), &
+                      aLinksl(my_id+1),                      &
+                      MPI_INTEGER8,io_id,tag,HYDRO_COMM_WORLD,ierr)
+          endif
+      endif
+      call mpp_land_sync()
+  END subroutine ReachLS_wInt8
 
   subroutine ReachLS_wInt2(inV,outV,len,glen)
       implicit none
@@ -836,14 +911,16 @@ MODULE MODULE_mpp_ReachLS
   end subroutine getFromInd
 
   subroutine getToInd(from,to,ind,indLen,gToNodeOut)
-    integer,dimension(:) :: from, to
+      implicit none
+
+    integer(kind=int64),dimension(:) :: from, to
     integer, allocatable, dimension(:) ::ind
-    integer, allocatable, dimension(:,:) :: gToNodeOut
+    integer(kind=int64), allocatable, dimension(:,:) :: gToNodeOut
     integer :: k, m, kk, mm,indLen, i, ierr
-    integer, dimension(gnlinksl) :: gto
+    integer(kind=int64), dimension(gnlinksl) :: gto
     integer :: maxNum, num
 
-    call gBcastValue(to,gto)
+    call gBcastValue(to, gto)
 
     !      mm = size(from,1)
     mm = l_nlinksl
@@ -865,8 +942,8 @@ MODULE MODULE_mpp_ReachLS
 
     block
       type(hash_t) :: hash_table
-      integer :: val,it
-      integer, allocatable :: num_a(:)
+      integer(kind=int64) :: val,it
+      integer(kind=int64), allocatable :: num_a(:)
       logical :: found
 
       allocate(num_a(mm))
@@ -927,7 +1004,7 @@ MODULE MODULE_mpp_ReachLS
 
     ToInd(my_id+1) = kk
     do i = 0, numprocs - 1
-       call mpi_bcast(ToInd(i+1),1,MPI_INTEGER,   &
+       call mpi_bcast(ToInd(i+1),1,MPI_INTEGER8,   &
             i,HYDRO_COMM_WORLD,ierr)
     end do
 
@@ -990,6 +1067,63 @@ MODULE MODULE_mpp_ReachLS
 
   END subroutine com_decomp1dInt
 
+  subroutine com_decomp1dInt8(inV,gsize,outV,lsize)
+      !     output outV and lsize
+      implicit none
+      integer(kind=int64),intent(in),dimension(:) :: inV
+      integer(kind=int64),allocatable,dimension(:) :: outV
+      integer ::  i, ierr, tag, imod, ncomsize
+      integer :: lsize, ssize,start, gsize, end
+      tag = 19
+      ncomsize = gsize/numprocs
+      imod = mod(gsize,numprocs)
+
+
+      if(my_id .eq. io_id) then
+          start = 0
+          end = 0
+          do i = 1, numprocs
+              if(i-1 .lt. imod) then
+                  ssize = ncomsize + 1
+              else
+                  ssize = ncomsize
+              endif
+
+              start = end + 1
+              end = start + ssize - 1
+
+              if(i-1 .eq. io_id) then
+                  if(ssize .gt. 0) then
+                      allocate(outV(ssize) )
+                      outV(1:ssize) = inV(1:ssize)
+                      lsize = ssize
+                  else
+                      lsize = 0
+                  endif
+              else
+                  if(ssize .gt. 0 ) then
+                      call mpi_send(inV(start:start+ssize-1), ssize,       &
+                              MPI_INTEGER8, i-1,tag,HYDRO_COMM_WORLD,ierr)
+                  endif
+              endif
+          end do
+      else
+          if(my_id .lt. imod) then
+              lsize = ncomsize + 1
+          else
+              lsize = ncomsize
+          endif
+          if( lsize .gt. 0) then
+              allocate(outV(lsize) )
+              call mpi_recv(outV,lsize,                           &
+                      MPI_INTEGER8, io_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+          endif
+      endif
+      call mpp_land_sync()
+
+
+  END subroutine com_decomp1dInt8
+
   subroutine com_write1dInt(inV,lsize,outV,gsize)
 !     output outV and lsize
       implicit none
@@ -1040,6 +1174,57 @@ MODULE MODULE_mpp_ReachLS
       call mpp_land_sync()
 
   END subroutine com_write1dInt
+
+  subroutine com_write1dInt8(inV,lsize,outV,gsize)
+      !     output outV and lsize
+      implicit none
+      integer(kind=int64), intent(in),dimension(:) :: inV
+      integer(kind=int64), dimension(:) :: outV
+      integer ::  i, ierr, tag, imod, ncomsize
+      integer :: lsize, rsize,start, gsize, end
+      tag = 18
+      ncomsize = gsize/numprocs
+      imod = mod(gsize,numprocs)
+
+      if(my_id .eq. io_id) then
+          start = 0
+          end = 0
+          do i = 1, numprocs
+              if(i-1 .lt. imod) then
+                  rsize = ncomsize + 1
+              else
+                  rsize = ncomsize
+              endif
+
+              start = end + 1
+              end = start + rsize - 1
+
+              if(i-1 .eq. io_id) then
+                  if(rsize .gt. 0) then
+                      outV(1:rsize) = inV(1:rsize)
+                  endif
+              else
+                  if(rsize .gt. 0 ) then
+                      call mpi_recv(outV(start:start+rsize-1), rsize,          &
+                              MPI_INTEGER8, i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+                  endif
+              endif
+          end do
+      else
+          if(my_id .lt. imod) then
+              lsize = ncomsize + 1
+          else
+              lsize = ncomsize
+          endif
+          if( lsize .gt. 0) then
+              call mpi_send(inV, lsize,       &
+                      MPI_INTEGER8, io_id,tag,HYDRO_COMM_WORLD,ierr)
+          endif
+      endif
+
+      call mpp_land_sync()
+
+  END subroutine com_write1dInt8
 
   subroutine pack_decomp_int(g1bufid, ndata, nprocs_map, lnsizes, istart,bufid)
      implicit none
@@ -1096,6 +1281,62 @@ MODULE MODULE_mpp_ReachLS
           if(allocated(buf)) deallocate(buf)
        endif
   end subroutine pack_decomp_int
+
+  subroutine pack_decomp_int8(g1bufid, ndata, nprocs_map, lnsizes, istart,bufid)
+      implicit none
+      integer :: ndata
+      integer, dimension(:) :: nprocs_map, lnsizes
+      integer :: i,j,k, tag, ierr
+      integer(kind=int64), allocatable,dimension(:) :: buf, bufid, g1bufid
+      integer, dimension(:) :: istart
+      integer, dimension(numprocs) :: count
+      ! pack data
+
+
+      if(my_id .eq. io_id) then
+          allocate(buf(ndata))
+          count = 0
+          do i = 1, ndata
+              k = nprocs_map(i)
+              if( k .gt. 0) then
+                  buf(istart(k) + count(k)) = g1bufid(i)
+                  count(k) = count(k) + 1
+              end if
+          end do
+          !         write(6,*) " count = ", count
+          !         write(6,*) " istart = ", istart
+          !         write(6,*) " lnsizes = ", lnsizes
+      end if
+      !finish packing
+
+      call mpp_land_sync()
+      !      call hydro_finish()
+
+      if(my_id .ne. IO_id) then
+          tag = 72
+          if(lnsizes(my_id + 1) .gt. 0) then
+              call mpi_recv(bufid,lnsizes(my_id + 1),&
+                      MPI_INTEGER8,io_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+          endif
+      else
+          do i = 0, numprocs - 1
+              if(i .ne. my_id) then
+                  tag = 72
+                  if(lnsizes(i+1) .gt. 0) then
+                      call mpi_send(buf(istart(i+1):istart(i+1)+lnsizes(i+1)-1),  &
+                              lnsizes(i+1),MPI_INTEGER8,i, tag,HYDRO_COMM_WORLD,ierr)
+                  endif
+              else
+                  if(lnsizes(i+1) .gt. 0) then
+                      bufid = buf(istart(i+1):istart(i+1)+lnsizes(i+1)-1)
+                  endif
+              end if
+          end do
+      end if
+      if(my_id .eq. io_id) then
+          if(allocated(buf)) deallocate(buf)
+      endif
+  end subroutine pack_decomp_int8
 
   subroutine pack_decomp_real8(g1bufid, ndata, nprocs_map, lnsizes, istart,bufid)
      implicit none
@@ -1210,6 +1451,70 @@ MODULE MODULE_mpp_ReachLS
       if(allocated(gvar)) deallocate(gvar)
   end subroutine TONODE2RSL
 
+  subroutine TONODE2RSL8 (ind,inVar,size,gNLINKSL,NLINKSL,ioVar,flag)
+      implicit none
+      integer, intent(in) :: size,gNLINKSL,NLINKSL  !
+      integer, intent(in) , dimension(size) :: ind
+      integer(kind=int64), intent(in) , dimension(size) ::inVar
+      integer(kind=int64), intent(inout), dimension(nlinksl) :: ioVar
+      integer, allocatable, dimension(:) :: tmpInd
+      integer(kind=int64), allocatable, dimension(:) :: gvar, buf
+      integer :: i,j,k, tag, ierr, tmpSize, flag
+
+      if(gNLINKSL .le. 0) return
+
+      if(my_id .eq. io_id) then
+          allocate(gvar(gNLINKSL))
+      else
+          allocate(gvar(1))
+      endif
+      call ReachLS_wInt8(ioVar,gvar)
+
+      if(my_id .eq. io_id) then
+          do i = 1, numprocs
+              if(i-1 .eq. io_id) then
+                  do k = 1, size
+                      if(inVar(k) .ne. flag) then
+                          gvar(ind(k)) = inVar(k)
+                      endif
+                  end do
+              else
+                  tag = 82
+                  call mpi_recv(tmpSize,1,MPI_INTEGER,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+                  if(tmpSize .gt. 0) then
+                      allocate(buf(tmpSize))
+                      allocate(tmpInd(tmpSize))
+                      tag = 83
+                      call mpi_recv(tmpInd, tmpSize , &
+                              MPI_INTEGER,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+                      tag = 84
+                      call mpi_recv(buf, tmpSize , &
+                              MPI_INTEGER8,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+                      do k = 1, tmpSize
+                          if(buf(k) .ne. flag) then
+                              gvar(tmpInd(k)) = buf(k)
+                          endif
+                      end do
+                      if(allocated(buf))  deallocate(buf)
+                      if(allocated(tmpInd)) deallocate(tmpInd)
+                  endif
+              endif
+          end do
+      else
+          tag = 82
+          call mpi_send(size,1,MPI_INTEGER,io_id,tag,HYDRO_COMM_WORLD,ierr)
+          if(size .gt. 0) then
+              tag = 83
+              call mpi_send(ind(1:size),size, &
+                      MPI_INTEGER,io_id,tag,HYDRO_COMM_WORLD,ierr)
+              tag = 84
+              call mpi_send(inVar(1:size),size, &
+                      MPI_INTEGER8,io_id,tag,HYDRO_COMM_WORLD,ierr)
+          endif
+      endif
+      call ReachLS_decomp(gvar, ioVar)
+      if(allocated(gvar)) deallocate(gvar)
+  end subroutine TONODE2RSL8
 
 END MODULE MODULE_mpp_ReachLS
 

--- a/trunk/NDHMS/MPP/mpp_land.F
+++ b/trunk/NDHMS/MPP/mpp_land.F
@@ -2022,7 +2022,8 @@ MODULE MODULE_MPP_LAND
           implicit none
           integer gnlinks,nlinks, map_l2g(nlinks)
           integer(kind=int64) ::  recv(nlinks), v(nlinks)
-          integer(kind=int64), allocatable, dimension(:) :: tmp_map , tmp_v
+          integer(kind=int64), allocatable, dimension(:) :: tmp_v
+          integer, allocatable, dimension(:) :: tmp_map
           integer(kind=int64), dimension(:) :: g_v
           integer i, ierr, tag, k
           integer length, node, message_len
@@ -2048,10 +2049,9 @@ MODULE MODULE_MPP_LAND
                       !block receive  from other node.
 
                       tag = 109
-                      call mpi_recv(tmp_map(1:message_len),message_len,MPI_INTEGER8,i, &
+                      call mpi_recv(tmp_map(1:message_len),message_len,MPI_INTEGER,i, &
                               tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                       tag = 119
-
                       call mpi_recv(tmp_v(1:message_len),message_len,MPI_INTEGER8,i,  &
                               tag,HYDRO_COMM_WORLD,mpp_status,ierr)
 
@@ -2081,7 +2081,7 @@ MODULE MODULE_MPP_LAND
               end do
           else
               tag =  109
-              call mpi_send(map_l2g,nlinks,MPI_INTEGER8, IO_id,     &
+              call mpi_send(map_l2g,nlinks,MPI_INTEGER, IO_id,     &
                       tag,HYDRO_COMM_WORLD,ierr)
               tag = 119
               call mpi_send(v,nlinks,MPI_INTEGER8,IO_id,   &

--- a/trunk/NDHMS/MPP/mpp_land.F
+++ b/trunk/NDHMS/MPP/mpp_land.F
@@ -23,6 +23,7 @@ MODULE MODULE_MPP_LAND
 
   use MODULE_CPL_LAND
   use mpi
+  use iso_fortran_env, only: int64
 
   IMPLICIT NONE
   !integer, public :: HYDRO_COMM_WORLD ! communicator for WRF-Hydro - moved to MODULE_CPL_LAND
@@ -898,6 +899,38 @@ MODULE MODULE_MPP_LAND
       return
   end subroutine write_IO_RT_int
 
+  subroutine write_IO_RT_int8(in_buff,out_buff)
+      ! the IO node will receive the data from the rest process.
+      integer(kind=int64),intent(in),dimension(:,:) :: in_buff
+      integer(kind=int64),intent(out),dimension(:,:) ::  out_buff
+      integer tag, i, status, ierr,size
+      integer ibegin,iend,jbegin,jend
+      if(my_id .ne. IO_id) then
+          size = local_rt_nx*local_rt_ny
+          tag = 2
+          call mpi_send(in_buff,size,MPI_INTEGER, IO_id,     &
+                  tag,HYDRO_COMM_WORLD,ierr)
+      else
+          do i = 0, numprocs - 1
+              ibegin = startx(i+1)*rt_AGGFACTRT - (rt_AGGFACTRT-1)
+              if(ibegin.gt.1) ibegin=ibegin - 1
+              iend   = ibegin + local_rt_nx_size(i+1) -1
+              jbegin = starty(i+1)*rt_AGGFACTRT - (rt_AGGFACTRT-1)
+              if(jbegin.gt.1) jbegin=jbegin - 1
+              jend   = jbegin + local_rt_ny_size(i+1) -1
+              if(i .eq. IO_id) then
+                  out_buff(ibegin:iend,jbegin:jend) = in_buff
+              else
+                  size = local_rt_nx_size(i+1)*local_rt_ny_size(i+1)
+                  tag = 2
+                  call mpi_recv(out_buff(ibegin:iend,jbegin:jend),size,&
+                          MPI_INTEGER,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+              end if
+          end do
+      end if
+      return
+  end subroutine write_IO_RT_int8
+
   subroutine mpp_land_bcast_log1(inout)
       logical inout
       integer ierr
@@ -917,6 +950,27 @@ MODULE MODULE_MPP_LAND
       call mpp_land_sync()
     return
   end subroutine mpp_land_bcast_int
+
+  subroutine mpp_land_bcast_int8(size,inout)
+      integer size
+      integer(kind=int64) inout(size)
+      integer ierr
+      call mpi_bcast(inout,size,MPI_INTEGER8,   &
+              IO_id,HYDRO_COMM_WORLD,ierr)
+      call mpp_land_sync()
+      return
+  end subroutine mpp_land_bcast_int8
+
+  subroutine mpp_land_bcast_int8_1d(inout)
+      integer len
+      integer(kind=int64) inout(:)
+      integer ierr
+      len = size(inout,1)
+      call mpi_bcast(inout,len,MPI_INTEGER8,   &
+              IO_id,HYDRO_COMM_WORLD,ierr)
+      call mpp_land_sync()
+      return
+  end subroutine mpp_land_bcast_int8_1d
 
   subroutine mpp_land_bcast_int1d(inout)
       integer len
@@ -1194,6 +1248,23 @@ MODULE MODULE_MPP_LAND
     return
   end subroutine MPP_LAND_COM_INTEGER
 
+
+      subroutine MPP_LAND_COM_INTEGER8(data,NX,NY,flag)
+          !   ### Communicate message on left right and up bottom directions.
+          integer NX,NY
+          integer flag != 99  test only for land model. (replace the boundary).
+          != 1   get the sum of the boundary value.
+          integer(kind=int64) data(nx,ny)
+          real in_out_data(nx,ny)
+
+          in_out_data = data + 0.0
+          call MPP_LAND_LR_COM(in_out_data,NX,NY,flag)
+          call MPP_LAND_UB_COM(in_out_data,NX,NY,flag)
+          data = in_out_data + 0
+
+          return
+      end subroutine MPP_LAND_COM_INTEGER8
+
      subroutine read_restart_3(unit,nz,out)
         integer unit,nz,i
         real buf3(global_nx,global_ny,nz),&
@@ -1361,6 +1432,43 @@ MODULE MODULE_MPP_LAND
       return
   end subroutine decompose_RT_int
 
+  subroutine decompose_RT_int8 (in_buff,out_buff,g_nx,g_ny,nx,ny)
+      ! usage: all of the cpu call this subroutine.
+      ! the IO node will distribute the data to rest of the node.
+      integer g_nx,g_ny,nx,ny
+      integer(kind=int64),intent(in),dimension(:,:) ::  in_buff
+      integer(kind=int64),intent(out),dimension(:,:) :: out_buff
+      integer tag, i, status, ierr,size
+      integer ibegin,iend,jbegin,jend
+
+      tag = 2
+      call mpp_land_sync()
+      if(my_id == IO_id) then
+          do i = 0, numprocs - 1
+              ibegin = startx(i+1)*rt_AGGFACTRT - (rt_AGGFACTRT-1)
+              if(ibegin > 1) ibegin=ibegin - 1
+              iend   = ibegin + local_rt_nx_size(i+1) -1
+              jbegin = starty(i+1)*rt_AGGFACTRT - (rt_AGGFACTRT-1)
+              if(jbegin > 1) jbegin=jbegin - 1
+              jend   = jbegin + local_rt_ny_size(i+1) -1
+
+              if(my_id == i) then
+                  out_buff=in_buff(ibegin:iend,jbegin:jend)
+              else
+                  ! send data to the rest process.
+                  size = (iend-ibegin+1)*(jend-jbegin+1)
+                  call mpi_send(in_buff(ibegin:iend,jbegin:jend),size,&
+                          MPI_INTEGER, i,tag,HYDRO_COMM_WORLD,ierr)
+              end if
+          end do
+      else
+          size = nx*ny
+          call mpi_recv(out_buff,size,MPI_INTEGER,IO_id, &
+                  tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+      end if
+      return
+  end subroutine decompose_RT_int8
+
   subroutine getNX_NY(nprocs,nx,ny)
   ! calculate the nx and ny based on the total nprocs.
     integer nprocs, nx, ny, n
@@ -1479,7 +1587,7 @@ MODULE MODULE_MPP_LAND
   ! communicate the data for channel routine.
       implicit none
       integer ix,jy,size
-      integer Link_location(ix,jy)
+      integer(kind=int64) Link_location(ix,jy)
       integer i,j, flag
       real Link_V(size), tmp_inout(ix,jy)
 
@@ -1544,7 +1652,7 @@ MODULE MODULE_MPP_LAND
   ! communicate the data for channel routine.
       implicit none
       integer ix,jy,size
-      integer Link_location(ix,jy)
+      integer(kind=int64) Link_location(ix,jy)
       integer i,j, flag
       real*8 ::  Link_V(size), tmp_inout(ix,jy)
 
@@ -1608,9 +1716,9 @@ MODULE MODULE_MPP_LAND
   ! communicate the data for channel routine.
       implicit none
       integer ix,jy,size
-      integer Link_location(ix,jy)
+      integer(kind=int64) Link_location(ix,jy)
       integer i,j, flag
-      integer Link_V(size), tmp_inout(ix,jy)
+      integer(kind=int64) Link_V(size), tmp_inout(ix,jy)
 
       if(size .eq. 0) then
            tmp_inout = -999
@@ -1639,8 +1747,10 @@ MODULE MODULE_MPP_LAND
          enddo
     endif
 
+
+
 !   commu nicate tmp_inout
-    call MPP_LAND_COM_INTEGER(tmp_inout, ix,jy,flag)
+    call MPP_LAND_COM_INTEGER8(tmp_inout, ix,jy,flag)
 
 !map the data back to Link_V
     if(size .eq. 0) return
@@ -1665,6 +1775,8 @@ MODULE MODULE_MPP_LAND
                Link_V(Link_location(i,jy)) = tmp_inout(i,jy)
       enddo
   end subroutine MPP_CHANNEL_COM_INT
+
+
      subroutine print_2(unit,in,fm)
         integer unit
         character(len=*) fm
@@ -1906,8 +2018,81 @@ MODULE MODULE_MPP_LAND
            if(allocated(tmp_v)) deallocate(tmp_v)
      end subroutine write_chanel_int
 
+     subroutine write_chanel_int8(v,map_l2g,gnlinks,nlinks,g_v)
+          implicit none
+          integer gnlinks,nlinks, map_l2g(nlinks)
+          integer(kind=int64) ::  recv(nlinks), v(nlinks)
+          integer(kind=int64), allocatable, dimension(:) :: tmp_map , tmp_v
+          integer(kind=int64), dimension(:) :: g_v
+          integer i, ierr, tag, k
+          integer length, node, message_len
 
-     subroutine write_lake_real(v,nodelist_in,nlakes)
+          if(my_id .eq. io_id) then
+              allocate(tmp_map(gnlinks))
+              allocate(tmp_v(gnlinks))
+              if(nlinks .le. 0) then
+                  tmp_map = -999
+              else
+                  tmp_map(1:nlinks) = map_l2g(1:nlinks)
+              endif
+          else
+              allocate(tmp_map(1))
+              allocate(tmp_v(1))
+          endif
+
+
+          if(my_id .eq. IO_id) then
+              do i = 0, numprocs - 1
+                  message_len = mpp_nlinks(i+1)
+                  if(i .ne. my_id) then
+                      !block receive  from other node.
+
+                      tag = 109
+                      call mpi_recv(tmp_map(1:message_len),message_len,MPI_INTEGER8,i, &
+                              tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+                      tag = 119
+
+                      call mpi_recv(tmp_v(1:message_len),message_len,MPI_INTEGER8,i,  &
+                              tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+
+                      do k = 1,message_len
+                          if(tmp_map(k) .gt. 0) then
+                              node = tmp_map(k)
+                              g_v(node) = tmp_v(k)
+                          else
+#ifdef HYDRO_D
+                      write(6,*) "Maping infor k=",k," node=",tmp_v(k)
+#endif
+                          endif
+                      enddo
+                  else
+                      do k = 1,nlinks
+                          if(map_l2g(k) .gt. 0) then
+                              node = map_l2g(k)
+                              g_v(node) = v(k)
+                          else
+#ifdef HYDRO_D
+                      write(6,*) "Maping infor k=",k," node=",map_l2g(k)
+#endif
+                          endif
+                      enddo
+                  end if
+
+              end do
+          else
+              tag =  109
+              call mpi_send(map_l2g,nlinks,MPI_INTEGER8, IO_id,     &
+                      tag,HYDRO_COMM_WORLD,ierr)
+              tag = 119
+              call mpi_send(v,nlinks,MPI_INTEGER8,IO_id,   &
+                      tag,HYDRO_COMM_WORLD,ierr)
+          end if
+          if(allocated(tmp_map)) deallocate(tmp_map)
+          if(allocated(tmp_v)) deallocate(tmp_v)
+      end subroutine write_chanel_int8
+
+
+      subroutine write_lake_real(v,nodelist_in,nlakes)
         implicit none
         real recv(nlakes), v(nlakes)
         integer nodelist(nlakes), nlakes, nodelist_in(nlakes)
@@ -2058,6 +2243,31 @@ MODULE MODULE_MPP_LAND
        return
     end subroutine combine_int1d
 
+  subroutine combine_int8_1d(vin,nsize, flag)
+      implicit none
+      integer nsize,i,j,tag,ierr, flag, k
+      integer(kind=int64), dimension(nsize):: vin,recv
+      tag = 319
+      if(nsize .le. 0) return
+      if(my_id .eq. IO_id) then
+          do i = 0, numprocs - 1
+              if(i .ne. my_id) then
+                  call mpi_recv(recv,nsize,MPI_INTEGER8,i,  &
+                          tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+                  do k = 1, nsize
+                      if(recv(k) .ne. flag) then
+                          vin(k) = recv(k)
+                      endif
+                  enddo
+              endif
+          end do
+      else
+          call mpi_send(vin,nsize,MPI_INTEGER8,IO_id,   &
+                  tag,HYDRO_COMM_WORLD,ierr)
+      endif
+      call mpp_land_bcast_int8_1d(vin)
+      return
+  end subroutine combine_int8_1d
 
     subroutine sum_real1d(vin,nsize)
        implicit none
@@ -2362,7 +2572,36 @@ MODULE MODULE_MPP_LAND
 
      end subroutine updateLake_seqInt
 
-     subroutine updateLake_seq(in,nsize,in0)
+      subroutine updateLake_seqInt8(in,nsize,in0)
+          implicit none
+          integer :: nsize
+          integer(kind=int64), dimension(nsize) :: in
+          integer(kind=int64), dimension(nsize) :: tmp
+          integer(kind=int64), dimension(:) :: in0
+          integer tag, i, status, ierr, k
+          if(nsize .le. 0) return
+
+          tag = 29
+          if(my_id .ne. IO_id) then
+              call mpi_send(in,nsize,MPI_INTEGER8, IO_id,     &
+                      tag,HYDRO_COMM_WORLD,ierr)
+          else
+              do i = 0, numprocs - 1
+                  if(i .ne. IO_id) then
+                      call mpi_recv(tmp,nsize,&
+                              MPI_INTEGER8,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+                      do k = 1, nsize
+                          if(in0(k) .ne. tmp(k)) in(k) = tmp(k)
+                      end do
+                  end if
+              end do
+          end if
+          call mpp_land_bcast_int8_1d(in)
+
+      end subroutine updateLake_seqInt8
+
+
+      subroutine updateLake_seq(in,nsize,in0)
        implicit none
        integer :: nsize
        real, dimension(nsize) :: in

--- a/trunk/NDHMS/MPP/mpp_land.F
+++ b/trunk/NDHMS/MPP/mpp_land.F
@@ -142,7 +142,7 @@ MODULE MODULE_MPP_LAND
 
   !old subroutine MPP_LAND_INIT(flag, ew_numprocs, sn_numprocs)
   subroutine MPP_LAND_INIT(in_global_nx,in_global_ny)
-!    ### initialize the land model logically based on the two D method. 
+!    ### initialize the land model logically based on the two D method.
 !    ### Call this function directly if it is nested with WRF.
     implicit none
     integer, optional :: in_global_nx, in_global_ny
@@ -151,7 +151,7 @@ MODULE MODULE_MPP_LAND
     logical mpi_inited
 
     global_nx = in_global_nx
-    global_ny = in_global_ny 
+    global_ny = in_global_ny
 
     ! left_right_np = ew_numprocs
     ! up_down_np  = sn_numprocs
@@ -908,7 +908,7 @@ MODULE MODULE_MPP_LAND
       if(my_id .ne. IO_id) then
           size = local_rt_nx*local_rt_ny
           tag = 2
-          call mpi_send(in_buff,size,MPI_INTEGER, IO_id,     &
+          call mpi_send(in_buff,size,MPI_INTEGER8, IO_id,     &
                   tag,HYDRO_COMM_WORLD,ierr)
       else
           do i = 0, numprocs - 1
@@ -924,7 +924,7 @@ MODULE MODULE_MPP_LAND
                   size = local_rt_nx_size(i+1)*local_rt_ny_size(i+1)
                   tag = 2
                   call mpi_recv(out_buff(ibegin:iend,jbegin:jend),size,&
-                          MPI_INTEGER,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+                          MPI_INTEGER8,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
               end if
           end do
       end if
@@ -1458,12 +1458,12 @@ MODULE MODULE_MPP_LAND
                   ! send data to the rest process.
                   size = (iend-ibegin+1)*(jend-jbegin+1)
                   call mpi_send(in_buff(ibegin:iend,jbegin:jend),size,&
-                          MPI_INTEGER, i,tag,HYDRO_COMM_WORLD,ierr)
+                          MPI_INTEGER8, i,tag,HYDRO_COMM_WORLD,ierr)
               end if
           end do
       else
           size = nx*ny
-          call mpi_recv(out_buff,size,MPI_INTEGER,IO_id, &
+          call mpi_recv(out_buff,size,MPI_INTEGER8,IO_id, &
                   tag,HYDRO_COMM_WORLD,mpp_status,ierr)
       end if
       return
@@ -2818,6 +2818,3 @@ MODULE MODULE_MPP_LAND
 
 
 END MODULE MODULE_MPP_LAND
-
-
-

--- a/trunk/NDHMS/Routing/Noah_distr_routing_overland.F
+++ b/trunk/NDHMS/Routing/Noah_distr_routing_overland.F
@@ -30,7 +30,7 @@ subroutine OverlandRouting( &
     REAL, INTENT(IN) :: DT, DTRT_TER
     integer, INTENT(IN) :: ixrt, jxrt, rt_option
     !REAL, INTENT(out), DIMENSION(IXRT,JXRT)   :: SFCHEADSUBRT  ! moved into overland_data%control
-    real, intent(inout) :: q_sfcflx_x,q_sfcflx_y
+    real, dimension(IXRT,JXRT), intent(inout) :: q_sfcflx_x,q_sfcflx_y
 
     ! REMOVED VARIABLES
     !INTEGER, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: LAKE_MSKRT
@@ -876,4 +876,3 @@ SUBROUTINE ROUTE_OVERLAND2 (dt,                               &
 
     !DJG ----------------------------------------------------------------------
 end subroutine ROUTE_OVERLAND2
-

--- a/trunk/NDHMS/Routing/Reservoirs/Level_Pool/module_levelpool.F
+++ b/trunk/NDHMS/Routing/Reservoirs/Level_Pool/module_levelpool.F
@@ -22,6 +22,7 @@ module module_levelpool
     use module_reservoir, only: reservoir, reservoir_input, &
                                      reservoir_output
     use module_hydro_stop, only: HYDRO_stop
+    use iso_fortran_env, only: int64
 
 #ifdef RESERVOIR_D
     use module_reservoir_utilities, only: create_levelpool_diagnostic_log_file, &
@@ -68,7 +69,7 @@ contains
         real, intent(in)    :: orifice_coefficient       ! orifice coefficient
         real, intent(in)    :: orifice_area              ! orifice area (meters^2)
         real, intent(in)    :: max_depth                 ! max depth of reservoir before overtop (meters)
-        integer, intent(in) :: lake_number               ! lake number
+        integer(kind=int64), intent(in) :: lake_number               ! lake number
         character(len=15)   :: lake_number_string
 
 #ifdef RESERVOIR_D
@@ -236,7 +237,7 @@ contains
         real, intent(IN)    :: oc      ! orifice coeff.
         real, intent(IN)    :: oa      ! orifice area (m^2)
         real, intent(IN)    :: maxh    ! max depth of reservoir before overtop (m)
-        integer, intent(IN) :: ln      ! lake number
+        integer(kind=int64), intent(IN) :: ln      ! lake number
 
         !!DJG Add lake option switch here...move up to namelist in future versions...
         integer :: LAKE_OPT            ! Lake model option (move to namelist later)

--- a/trunk/NDHMS/Routing/Reservoirs/Level_Pool/module_levelpool_properties.F
+++ b/trunk/NDHMS/Routing/Reservoirs/Level_Pool/module_levelpool_properties.F
@@ -7,6 +7,7 @@
 module module_levelpool_properties
 
     use module_reservoir, only: reservoir_properties
+    use iso_fortran_env, only: int64
     implicit none
 
     ! Extend/derive level pool properties from the abstract base
@@ -21,7 +22,7 @@ module module_levelpool_properties
         real :: orifice_coefficient      ! orifice coefficient
         real :: orifice_area             ! orifice area (meters^2)
         real :: max_depth                ! max depth of reservoir before overtop (meters)
-        integer :: lake_number           ! lake number
+        integer(kind=int64) :: lake_number           ! lake number
 
     contains
 
@@ -47,7 +48,7 @@ contains
         real, intent(in)    :: orifice_coefficient      ! orifice coefficient
         real, intent(in)    :: orifice_area             ! orifice area (meters^2)
         real, intent(in)    :: max_depth                ! max depth of reservoir before overtop (meters)
-        integer, intent(in) :: lake_number              ! lake number
+        integer(kind=int64), intent(in) :: lake_number              ! lake number
 
         ! Assign the values passed in to a particular level pool reservoir
         ! properties object's variables.

--- a/trunk/NDHMS/Routing/Reservoirs/Persistence_Level_Pool_Hybrid/module_persistence_levelpool_hybrid.F
+++ b/trunk/NDHMS/Routing/Reservoirs/Persistence_Level_Pool_Hybrid/module_persistence_levelpool_hybrid.F
@@ -25,6 +25,7 @@ module module_persistence_levelpool_hybrid
     use module_reservoir, only: reservoir, reservoir_input, reservoir_output
     use module_reservoir_read_timeslice_data, only: usgs_timeslice_data, usace_timeslice_data, timeslice_data_type
     use module_hydro_stop, only: HYDRO_stop
+    use iso_fortran_env, only: int64
     implicit none
 
     ! Extend/derive hybrid type from the abstract base
@@ -76,7 +77,7 @@ contains
         real,    intent(in)    :: orifice_area              ! orifice area (meters^2)
         real,    intent(in)    :: lake_max_water_elevation  ! max water elevation (meters)
         real,    intent(in)    :: initial_fractional_depth  ! initial fraction water depth
-        integer, intent(in)    :: lake_number               ! lake number
+        integer(kind=int64), intent(in)    :: lake_number               ! lake number
         integer, intent(in)    :: reservoir_type            ! reservoir type
         character(len=*),   intent(in) :: reservoir_parameter_file
         character(len=19),  intent(in) :: start_date

--- a/trunk/NDHMS/Routing/Reservoirs/Persistence_Level_Pool_Hybrid/module_persistence_levelpool_hybrid_properties.F
+++ b/trunk/NDHMS/Routing/Reservoirs/Persistence_Level_Pool_Hybrid/module_persistence_levelpool_hybrid_properties.F
@@ -12,6 +12,7 @@ module module_persistence_levelpool_hybrid_properties
                                           handle_err
     use module_reservoir, only: reservoir_properties
     use netcdf
+    use iso_fortran_env, only: int64
     implicit none
 
     ! Extend/derive hybrid properties from the abstract base
@@ -48,7 +49,7 @@ contains
         real,    intent(in)          :: lake_area                    ! area of lake (km^2)
         real,    intent(in)          :: lake_max_water_elevation     ! max water elevation (meters)
         real,    intent(in)          :: orifice_elevation            ! orifice elevation (meters AMSL)
-        integer, intent(in)          :: lake_number                  ! lake number
+        integer(kind=int64), intent(in)  :: lake_number                  ! lake number
         integer, intent(in)          :: reservoir_type               ! reservoir type
         integer, intent(in)          :: observation_lookback_hours
         integer, intent(in)          :: observation_update_time_interval_seconds

--- a/trunk/NDHMS/Routing/Reservoirs/RFC_Forecasts/module_rfc_forecasts.F
+++ b/trunk/NDHMS/Routing/Reservoirs/RFC_Forecasts/module_rfc_forecasts.F
@@ -21,6 +21,7 @@ module module_rfc_forecasts
     use module_reservoir, only: reservoir, reservoir_input, reservoir_output
     use module_reservoir_read_rfc_time_series_data, only: time_series_data
     use module_hydro_stop, only: HYDRO_stop
+    use iso_fortran_env, only: int64
     implicit none
 
     ! Extend/derive rfc forecasts type from the abstract base
@@ -71,7 +72,7 @@ contains
         real,    intent(in)    :: orifice_area              ! orifice area (meters^2)
         real,    intent(in)    :: lake_max_water_elevation  ! max water elevation (meters)
         real,    intent(in)    :: initial_fractional_depth  ! initial fraction water depth
-        integer, intent(in)    :: lake_number               ! lake number
+        integer(kind=int64), intent(in)    :: lake_number               ! lake number
         integer, intent(in)    :: reservoir_type            ! reservoir type
         character(len=*),   intent(in) :: reservoir_parameter_file
         character(len=19),  intent(in) :: start_date

--- a/trunk/NDHMS/Routing/Reservoirs/RFC_Forecasts/module_rfc_forecasts_properties.F
+++ b/trunk/NDHMS/Routing/Reservoirs/RFC_Forecasts/module_rfc_forecasts_properties.F
@@ -12,6 +12,7 @@ module module_rfc_forecasts_properties
                                           handle_err
     use module_reservoir, only: reservoir_properties
     use netcdf
+    use iso_fortran_env, only: int64
 
     implicit none
 
@@ -47,7 +48,7 @@ contains
     subroutine rfc_forecasts_properties_init(this, lake_number, reservoir_parameter_file)
         implicit none
         class(rfc_forecasts_properties_interface), intent(inout) :: this ! the type object being initialized
-        integer, intent(in)          :: lake_number                   ! lake number
+        integer(kind=int64), intent(in)  :: lake_number                   ! lake number
         character(len=*), intent(in) :: reservoir_parameter_file
         integer                      :: ncid, var_id, lake_id_index
         integer                      :: status                        ! status of reading NetCDF

--- a/trunk/NDHMS/Routing/Reservoirs/module_reservoir_utilities.F
+++ b/trunk/NDHMS/Routing/Reservoirs/module_reservoir_utilities.F
@@ -4,6 +4,7 @@
 module module_reservoir_utilities
     use netcdf
     use module_hydro_stop, only: HYDRO_stop
+    use iso_fortran_env, only: int64
     implicit none
 
 #ifndef NCEP_WCOSS
@@ -168,10 +169,10 @@ contains
     subroutine read_reservoir_type(reservoir_parameter_file, lake_parameter_lake_ids, number_of_lake_parameter_lakes, &
         reservoir_types)
         character(len=*), intent(in) :: reservoir_parameter_file
-        integer, dimension(:), intent(in) :: lake_parameter_lake_ids
+        integer(kind=int64), dimension(:), intent(in) :: lake_parameter_lake_ids
         integer, intent(in) :: number_of_lake_parameter_lakes
         integer, dimension(:), intent(inout) :: reservoir_types
-        integer, allocatable, dimension(:) :: reservoir_parameter_lake_ids
+        integer(kind=int64), allocatable, dimension(:) :: reservoir_parameter_lake_ids
 
         integer, dimension(nf90_max_var_dims) :: dim_ids
         integer :: ncid, var_id, lake_index, number_of_reservoirs, number_of_reservoir_types
@@ -358,7 +359,8 @@ contains
     ! Read lake id from reservoir parameter file and determine the lake_id_index, which
     ! is the index of the particular reservoir's values in all of the parameter arrays.
     subroutine read_netcdf_lake_id(ncid, lake_number, netcdf_array_name, reservoir_parameter_file, lake_id_index)
-        integer, intent(in) :: ncid, lake_number
+        integer, intent(in)          :: ncid
+        integer(kind=int64), intent(in)  :: lake_number
         character(len=*), intent(in) :: netcdf_array_name
         character(len=*), intent(in) :: reservoir_parameter_file
         integer, intent(out) :: lake_id_index

--- a/trunk/NDHMS/Routing/module_GW_baseflow.F
+++ b/trunk/NDHMS/Routing/module_GW_baseflow.F
@@ -26,6 +26,7 @@ module module_GW_baseflow
    use MODULE_mpp_GWBUCKET, only: gw_sum_real, gw_write_io_real
    use MODULE_mpp_ReachLS, only : updatelinkv
 #endif
+   use iso_fortran_env, only: int64
    implicit none
 
 !#include "rt_include.inc"
@@ -293,7 +294,7 @@ contains
    real, intent(in), dimension(ix,jx)                :: runoff1x_in
    real, dimension(ix,jx)                            :: runoff1x
    real, intent(in)                                  :: basns_area(numbasns),dist(ixrt,jxrt,9),DT
-   integer, intent(in)                                  :: basnsInd(numbasns)
+   integer(kind=int64), intent(in)                       :: basnsInd(numbasns)
    real, intent(in),dimension(numbasns)              :: C,ex,z_mx
    real, intent(out),dimension(numbasns)             :: qout_gwsubbas
    real, intent(out),dimension(numbasns)             :: qin_gwsubbas
@@ -525,7 +526,7 @@ contains
       integer,dimension(global_rt_nx,global_rt_ny) :: gw_strm_msk
       real,dimension(numbasns) :: gwbas_pix_ct 
       real,dimension(gnumbasns) :: tmp_gwbas_pix_ct 
-      integer, intent(in), dimension(:) :: basnsInd
+      integer(kind=int64), intent(in), dimension(:) :: basnsInd
 
       gw_strm_msk = 0
 

--- a/trunk/NDHMS/Routing/module_HYDRO_io.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_io.F
@@ -23,7 +23,7 @@ module module_HYDRO_io
 #ifdef MPP_LAND
      use module_mpp_land
      use module_mpp_reachls,  only: ReachLS_decomp, reachls_wreal, ReachLS_write_io, &
-                                    ReachLS_wInt, reachls_wreal2, TONODE2RSL, gbcastvalue
+                                    ReachLS_wInt, reachls_wreal2, TONODE2RSL, TONODE2RSL8, gbcastvalue
      use MODULE_mpp_GWBUCKET, only: gw_write_io_real, gw_write_io_int
 #endif
    use Module_Date_utilities_rt, only: geth_newdate
@@ -35,6 +35,7 @@ module module_HYDRO_io
    use netcdf
    use module_hydro_stop, only:HYDRO_stop
    use hashtable
+   use iso_fortran_env, only: int64
 
    implicit none
 
@@ -725,7 +726,7 @@ end subroutine get_albedo12m_netcdf
         INTEGER, DIMENSION(IXRT,JXRT)                :: DIRECTION  !- flow direction
         INTEGER, DIMENSION(IXRT,JXRT)                :: LAKE_MSKRT
         REAL, DIMENSION(IXRT,JXRT)                   :: LAT, LON
-        INTEGER, DIMENSION(IXRT,JXRT)                :: CH_LNKRT   !- link routing ID
+        INTEGER(kind=int64), DIMENSION(IXRT,JXRT)                :: CH_LNKRT   !- link routing ID
         integer, INTENT(IN)                          :: UDMP_OPT
         integer                                      :: NLAKES
 
@@ -775,7 +776,7 @@ end subroutine get_albedo12m_netcdf
 #endif
 !!!! LINKID is used for reach based method.  ?
      IF(channel_option.ne.3 .and. UDMP_OPT.ne.1) then  !get maxnodes and links from grid
-         call readRT2d_int(var_name,CH_LNKRT,ixrt,jxrt,&
+         call readRT2d_int8(var_name,CH_LNKRT,ixrt,jxrt,&
                    trim(geo_finegrid_flnm), fatalErr=.TRUE.)
      endif
 
@@ -1187,7 +1188,57 @@ end subroutine get_albedo12m_netcdf
         end do
 #endif
      end SUBROUTINE nreadRT2d_int
-!---------------------------------------------------------
+
+
+     subroutine nreadRT2d_int8(var_name, inv, ixrt, jxrt, fileName, fatalErr)
+         implicit none
+         INTEGER, INTENT(IN) :: ixrt,jxrt
+         INTEGER :: i, j, ii,jj, iret
+         CHARACTER(len=*):: var_name,fileName
+         integer(kind=int64), INTENT(OUT), dimension(ixrt,jxrt) :: inv
+         integer(kind=int64), dimension(ixrt,jxrt) :: inv_tmp
+         logical, optional, intent(in) :: fatalErr
+         logical :: fatalErr_local
+#ifdef MPP_LAND
+     integer(kind=int64), allocatable,dimension(:,:) :: g_inv_tmp, g_inv
+#endif
+         fatalErr_local = .FALSE.
+         if(present(fatalErr)) fatalErr_local=fatalErr
+
+#ifdef MPP_LAND
+     if(my_id .eq. io_id) then
+          allocate(g_inv_tmp(global_rt_nx,global_rt_ny))
+          allocate(g_inv(global_rt_nx,global_rt_ny))
+          g_inv_tmp = -9999.9
+          call  get2d_int8(var_name,g_inv_tmp,global_rt_nx,global_rt_ny,&
+                 trim(fileName), fatalErr=fatalErr_local)
+
+          jj = global_rt_ny
+          do j = 1, global_rt_ny
+             g_inv(:,j) = g_inv_tmp(:,jj)
+             jj = global_rt_ny - j
+          end do
+     else
+          allocate(g_inv_tmp(1,1))
+          allocate(g_inv(1,1))
+     endif
+     call decompose_RT_int8(g_inv,inv,global_rt_nx,global_rt_ny,IXRT,JXRT)
+     if(allocated(g_inv_tmp)) deallocate(g_inv_tmp)
+     if(allocated(g_inv)) deallocate(g_inv)
+#else
+         call  get2d_int(var_name,inv_tmp,ixrt,jxrt,&
+                 trim(fileName), fatalErr=fatalErr_local)
+         do i=1,ixrt
+             jj=jxrt
+             do j=1,jxrt
+                 inv(i,j)=inv_tmp(i,jj)
+                 jj=jxrt-j
+             end do
+         end do
+#endif
+     end SUBROUTINE nreadRT2d_int8
+
+         !---------------------------------------------------------
 !DJG -----------------------------------------------------
 
      subroutine readRT2d_real(var_name, inv, ixrt, jxrt, fileName, fatalErr)
@@ -1235,6 +1286,28 @@ end subroutine get_albedo12m_netcdf
          end do
 
      end SUBROUTINE readRT2d_int
+
+     subroutine readRT2d_int8(var_name, inv, ixrt, jxrt, fileName, fatalErr)
+         implicit none
+         INTEGER, INTENT(IN) :: ixrt,jxrt
+         INTEGER :: i, j, ii,jj
+         CHARACTER(len=*):: var_name,fileName
+         integer(kind=int64), INTENT(OUT), dimension(ixrt,jxrt) :: inv
+         integer(kind=int64), dimension(ixrt,jxrt) :: inv_tmp
+         logical, optional, intent(in) :: fatalErr
+         logical :: fatalErr_local
+         fatalErr_local = .FALSE.
+         if(present(fatalErr)) fatalErr_local=fatalErr
+         call  get2d_int8(var_name,inv_tmp,ixrt,jxrt,&
+                 trim(fileName), fatalErr=fatalErr_local)
+
+         jj = jxrt
+         do j = 1, jxrt
+             inv(:,j) = inv_tmp(:,jj)
+             jj = jxrt - j
+         end do
+
+     end SUBROUTINE readRT2d_int8
 
 !---------------------------------------------------------
 !DJG -----------------------------------------------------
@@ -1375,7 +1448,7 @@ end subroutine get_albedo12m_netcdf
       implicit none
       integer, intent(in) :: ixrt,jxrt, numbasns
       integer, dimension(:,:) :: gw_strm_msk, gw_strm_msk_lind
-      integer, dimension(:) :: basnsInd
+      integer(kind=int64), dimension(:) :: basnsInd
       integer:: i,j,k,bas
       gw_strm_msk_lind = -999
       do j = 1, jxrt
@@ -1399,7 +1472,7 @@ end subroutine get_albedo12m_netcdf
      integer, intent(in),dimension(ix,jx) ::  GWSUBBASMSK
      integer, intent(out):: gnumbasns
      integer, intent(inout):: numbasns
-     integer, intent(inout),allocatable,dimension(:):: basnsInd
+     integer(kind=int64), intent(inout),allocatable,dimension(:):: basnsInd
 
      integer,dimension(numbasns):: tmpbuf
 
@@ -1444,7 +1517,7 @@ end subroutine get_albedo12m_netcdf
 
    implicit none
    integer, intent(in) :: gnumbasns, numbasns
-   integer, intent(in),  dimension(numbasns) :: basnsInd
+   integer(kind=int64), intent(in),  dimension(numbasns) :: basnsInd
    real,    intent(out), dimension(numbasns) :: gw_buck_coeff, gw_buck_exp, gw_buck_loss
    real,    intent(out), dimension(numbasns) :: z_max, z_gwsubbas, basns_area
    integer, intent(out), dimension(numbasns) :: bas_id
@@ -4715,7 +4788,7 @@ end subroutine mpp_output_chrt
      real, dimension(NLAKES),                  intent(inout) :: latlake,lonlake,elevlake,resht
      real, dimension(NLAKES),                  intent(inout) :: qlakei,qlakeo  !-- inflow and outflow of lake
      real,                                     intent(in) :: dtrt_ch
-     integer, dimension(NLAKES),               intent(in) :: LAKEIDM     ! lake id
+     integer(kind=int64), dimension(NLAKES),       intent(in) :: LAKEIDM     ! lake id
 
      character(len=*),                         intent(in) :: startdate
      character(len=*),                         intent(in) :: date
@@ -5008,7 +5081,7 @@ end subroutine mpp_output_chrt
      integer,                                  intent(in) :: NLAKES
      real, dimension(NLAKES),                  intent(in) :: latlake,lonlake,elevlake,resht
      real, dimension(NLAKES),                  intent(in) :: qlakei,qlakeo  !-- inflow and outflow of lake
-     integer, dimension(NLAKES),               intent(in) :: LAKEIDM        !-- LAKE ID
+     integer(kind=int64), dimension(NLAKES),       intent(in) :: LAKEIDM        !-- LAKE ID
      real,                                     intent(in) :: dtrt_ch
 
      character(len=*),                         intent(in) :: startdate
@@ -5170,14 +5243,14 @@ end subroutine mpp_output_chrt
      integer,                                  intent(in) :: NLINKS,ixrt,jxrt
      real,                                     intent(in) :: dt
      real, dimension(:,:),                intent(in) :: qlink
-     integer, dimension(IXRT,JXRT),            intent(in) :: CH_NETLNK_in
+     integer(kind=int64), dimension(IXRT,JXRT),            intent(in) :: CH_NETLNK_in
      character(len=*),          intent(in)     :: geo_finegrid_flnm
      character(len=*),                         intent(in) :: startdate
      character(len=*),                         intent(in) :: date
 
      integer::  gnlinks , map_l2g(nlinks)
 
-     integer, allocatable,dimension(:,:)         :: CH_NETLNK
+     integer(kind=int64), allocatable,dimension(:,:)         :: CH_NETLNK
      real, allocatable,dimension(:,:)                :: g_qlink
 
      if(my_id .eq. io_id) then
@@ -5191,7 +5264,7 @@ end subroutine mpp_output_chrt
      call write_chanel_real(qlink(:,1),map_l2g,gnlinks,nlinks,g_qlink(:,1))
      call write_chanel_real(qlink(:,2),map_l2g,gnlinks,nlinks,g_qlink(:,2))
 
-     call write_IO_rt_int(CH_NETLNK_in, CH_NETLNK)
+     call write_IO_rt_int8(CH_NETLNK_in, CH_NETLNK)
 
     if(my_id.eq.IO_id) then
         call  output_chrtgrd(igrid, split_output_count, g_ixrt,g_jxrt, &
@@ -5215,7 +5288,7 @@ end subroutine mpp_output_chrt
      integer,                                  intent(in) :: NLINKS,ixrt,jxrt
      real,                                     intent(in) :: dt
      real, dimension(:,:),                intent(in) :: qlink
-     integer, dimension(IXRT,JXRT),            intent(in) :: CH_NETLNK
+     integer(kind=int64), dimension(IXRT,JXRT), intent(in) :: CH_NETLNK
      character(len=*),          intent(in)     :: geo_finegrid_flnm
      character(len=*),                         intent(in) :: startdate
      character(len=*),                         intent(in) :: date
@@ -5430,6 +5503,52 @@ end subroutine mpp_output_chrt
     return
   end subroutine get2d_int
 
+    subroutine get2d_int8(var_name,out_buff,ix,jx,fileName, fatalErr)
+        implicit none
+        integer :: iret,varid,ncid,ix,jx
+        integer(kind=int64) out_buff(ix,jx)
+        character(len=*), intent(in) :: var_name
+        character(len=*), intent(in) :: fileName
+        logical, optional, intent(in) :: fatalErr
+        logical :: fatalErr_local
+        character(len=256) :: errMsg
+
+        fatalErr_local = .false.
+        if(present(fatalErr)) fatalErr_local=fatalErr
+
+        iret = nf90_open(trim(fileName), NF90_NOWRITE, ncid)
+        if (iret .ne. 0) then
+            errMsg = "get2d_int: failed to open the netcdf file: " // trim(fileName)
+            print*, trim(errMsg)
+            if(fatalErr_local) call hydro_stop(trim(errMsg))
+        endif
+
+        iret = nf90_inq_varid(ncid,trim(var_name),  varid)
+        if(iret .ne. 0) then
+            errMsg = "get2d_int: failed to find the variable: " // &
+                    trim(var_name) // ' in ' // trim(fileName)
+            print*, trim(errMsg)
+            if(fatalErr_local) call hydro_stop(errMsg)
+        endif
+
+        iret = nf90_get_var(ncid, varid, out_buff)
+        if(iret .ne. 0) then
+            errMsg = "get2d_int: failed to read the variable: " // &
+                    trim(var_name) // " in " //trim(fileName)
+            print*,trim(errMsg)
+            if(fatalErr_local) call hydro_stop(trim(errMsg))
+        endif
+
+        iret = nf90_close(ncid)
+        if(iret .ne. 0) then
+            errMsg = "get2d_int: failed to close the file: " // &
+                    trim(fileName)
+            print*,trim(errMsg)
+            if(fatalErr_local) call hydro_stop(trim(errMsg))
+        endif
+
+        return
+    end subroutine get2d_int8
 
 #ifdef MPP_LAND
       SUBROUTINE MPP_READ_ROUTEDIM(did,g_IXRT,g_JXRT, GCH_NETLNK,GNLINKS,IXRT,JXRT, &
@@ -5527,7 +5646,8 @@ end subroutine mpp_output_chrt
 
         INTEGER, INTENT(IN) :: IXRT,JXRT
         REAL, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: ELRT,LKSATFAC
-        INTEGER, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: CH_NETRT,CH_LNKRT
+        INTEGER, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: CH_NETRT
+        INTEGER(kind=int64), INTENT(INOUT), DIMENSION(IXRT,JXRT) :: CH_LNKRT
 !Dummy inverted grids
         REAL, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: OVROUGHRTFAC
         REAL, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: RETDEPRTFAC
@@ -5545,7 +5665,7 @@ end subroutine mpp_output_chrt
 
      IF(channel_option .ne. 3 .and. UDMP_OPT .ne. 1) then  !get maxnodes and links from grid
         var_name = "LINKID"
-        call nreadRT2d_int(var_name,CH_LNKRT,ixrt,jxrt,&
+        call nreadRT2d_int8(var_name,CH_LNKRT,ixrt,jxrt,&
                trim(geo_finegrid_flnm), fatalErr=.true.)
      endif
 
@@ -6528,7 +6648,7 @@ end if  ! end if(nlst_rt(did)%SUBRTSWCRT  .eq. 1 .or. &
                        basnsInd, inV,vName )
       implicit none
       integer :: ncid,numbasns,gnumbasns
-      integer, dimension(:) :: basnsInd
+      integer(kind=int64), dimension(:) :: basnsInd
       real, dimension(:) :: inV
       character(len=*) :: vName
       integer i, j, k
@@ -6554,7 +6674,7 @@ end if  ! end if(nlst_rt(did)%SUBRTSWCRT  .eq. 1 .or. &
                        gnumbasns,basnsInd, vName)
       implicit none
       integer :: ncid,numbasns,gnumbasns
-      integer, dimension(:) :: basnsInd
+      integer(kind=int64), dimension(:) :: basnsInd
       real, dimension(:) :: outV
       character(len=*) :: vName
       integer i, j,k
@@ -7311,11 +7431,12 @@ integer                                      :: CHANRTSWCRT, NLINKS, NLAKES
 real, intent(IN), dimension(IXRT,JXRT)       :: fgDEM
 integer, dimension(IXRT,JXRT)                :: DIRECTION
 integer, dimension(IXRT,JXRT)                :: GSTRMFRXSTPTS
-integer, intent(IN), dimension(IXRT,JXRT)    :: CH_NETRT, CH_LNKRT
+integer, intent(IN), dimension(IXRT,JXRT)    :: CH_NETRT
+integer(kind=int64), intent(IN), dimension(IXRT,JXRT)    :: CH_LNKRT
 integer, intent(INOUT), dimension(IXRT,JXRT) :: LAKE_MSKRT
 integer,                dimension(IXRT,JXRT) :: GORDER  !-- gridded stream orderk
 #ifdef MPP_LAND
-integer,                dimension(IXRT,JXRT) :: Link_Location !-- gridded stream orderk
+integer(kind=int64),    dimension(IXRT,JXRT) :: Link_Location !-- gridded stream orderk
 integer :: LNLINKSL
 #endif
 integer                                      :: I,J,K,channel_option
@@ -7325,21 +7446,22 @@ character(len=28)                            :: dir
 
 !----DJG,DNY New variables for channel and lake routing
 character(len=155)	 :: header
-integer, intent(INOUT),  dimension(NLINKS)   :: FROM_NODE
+integer(kind=int64), intent(INOUT),  dimension(NLINKS)   :: FROM_NODE
 real, intent(INOUT),  dimension(NLINKS)      :: ZELEV
 real, intent(INOUT),  dimension(NLINKS)      :: CHLAT,CHLON
 
+integer(kind=int64), intent(INOUT),  dimension(NLINKS)   :: TO_NODE
 integer, intent(INOUT),  dimension(NLINKS)   :: TYPEL
-integer, intent(INOUT),  dimension(NLINKS)   :: TO_NODE,ORDER
+integer, intent(INOUT),  dimension(NLINKS)   :: ORDER
 integer, intent(INOUT),  dimension(NLINKS)   :: STRMFRXSTPTS
 
 integer, intent(INOUT)                       :: MAXORDER
 real, intent(INOUT),  dimension(NLINKS)      :: CHANLEN   !channel length
 real, intent(INOUT),  dimension(NLINKS)      :: MannN, So !mannings N
-integer, intent(INOUT),  dimension(NLINKS)   :: LAKENODE !,LINKID   ! identifies which nodes pour into which lakes
+integer(kind=int64), intent(INOUT),  dimension(NLINKS)   :: LAKENODE !,LINKID   ! identifies which nodes pour into which lakes
 real, intent(IN)                             :: dist(ixrt,jxrt,9)
 
-integer, intent(IN), dimension(IXRT,JXRT)    :: CH_NETLNK
+integer(kind=int64), intent(IN), dimension(IXRT,JXRT)    :: CH_NETLNK
 real,  dimension(IXRT,JXRT)                  :: ChSSlpG,BwG,TwG,MannNG  !channel properties
 real,  dimension(IXRT,JXRT)                  :: Tw_CCG,n_CCG            !channel properties of compound
 real,  dimension(IXRT,JXRT)                  :: ChannKG                 !Channel Infiltration
@@ -7348,7 +7470,7 @@ real,  dimension(IXRT,JXRT)                  :: chanDepth, elrt
 
 !-- store the location x,y location of the channel element
 integer, intent(INOUT), dimension(NLINKS)   :: CHANXI, CHANYJ
-integer , dimension(:) ::  LAKEIDM
+integer(kind=int64), dimension(:) ::  LAKEIDM
 
 !--reservoir/lake attributes
 logical, intent(IN)			            :: reservoir_type_specified
@@ -7372,7 +7494,8 @@ character(len=*  )                           :: geo_finegrid_flnm, route_lake_f
 character(len=256)                           :: var_name
 
 integer                                      :: tmp, cnt, ncid, iret, jj,ct
-integer 			             :: IOstatus, OUTLAKEID
+integer 			             :: IOstatus
+integer(kind=int64)              :: OUTLAKEID
 
 real                                         :: gc,n
 integer :: did
@@ -7548,7 +7671,7 @@ do j = 1,JXRT  !rows
                MannN(cnt) = MannNG(i,j)
                ChSSlp(cnt) = ChSSlpG(i,j)
                Bw(cnt) = BwG(i,j)
-               ChannK(cnt) = ChannKG(i,j) 
+               ChannK(cnt) = ChannKG(i,j)
                Tw(cnt) = TwG(i,j)
                Tw_CC(cnt) = Tw_CCG(i,j)
                n_CC(cnt) = n_CCG(i,j)
@@ -7821,7 +7944,7 @@ do j = 1,JXRT
             MannN(cnt) = MannNG(i,j)
             ChSSlp(cnt) = ChSSlpG(i,j)
             Bw(cnt) = BwG(i,j)
-            ChannK(cnt) = ChannKG(i,j) 
+            ChannK(cnt) = ChannKG(i,j)
             Tw(cnt) = TwG(i,j)
             Tw_CC(cnt) = Tw_CCG(i,j)
             n_CC(cnt) = n_CCG(i,j)
@@ -8187,7 +8310,7 @@ print*, "my_id=",my_id, "cnt = ", cnt
 
 #ifdef MPP_LAND
 Link_location = CH_NETLNK
-call MPP_CHANNEL_COM_INT(Link_location,ixrt,jxrt,TYPEL,NLINKS,99)
+call MPP_CHANNEL_COM_INT(Link_location,ixrt,jxrt,int(TYPEL, int64),NLINKS,99)
 call MPP_CHANNEL_COM_INT(Link_location,ixrt,jxrt,LAKENODE,NLINKS,99)
 #endif
 
@@ -8211,7 +8334,7 @@ subroutine read_routelink(&
      CHLON,        NLINKSL,      LINKID,   GNLINKSL,   &
      NLINKS,       gages,        gageMiss               )
 
-integer, intent(INOUT),  dimension(NLINKS) :: TO_NODE, TYPEL, ORDER
+integer, intent(INOUT),  dimension(NLINKS) :: TYPEL, ORDER
 integer, intent(INOUT)                     :: MAXORDER
 integer                                    :: NLAKES
 real,    intent(INOUT),  dimension(NLINKS) :: MUSK, MUSX
@@ -8220,7 +8343,6 @@ real,    intent(INOUT),  dimension(NLINKS) :: CHANLEN, MannN, So
 real,    intent(INOUT),  dimension(:)      :: ChSSlp, Bw, Tw !added Top Width LKR/DY
 real,    intent(INOUT),  dimension(:)      :: Tw_CC, n_CC !compound chnannel params
 real,    intent(INOUT),  dimension(:)      :: ChannK !added ChanLoss
-integer, intent(INOUT),  dimension(:)      :: LAKEIDA !lake COMid 4all link on full nlinks database
 real,    intent(INOUT),  dimension(:)      :: HRZAREA
 real,    intent(INOUT),  dimension(:)      :: LAKEMAXH, WEIRH, WEIRC, WEIRL, DAML
 real,    intent(INOUT),  dimension(:)      :: ORIFICEC, ORIFICEA, ORIFICEE
@@ -8228,19 +8350,20 @@ logical, intent(IN)                        :: reservoir_type_specified
 integer, intent(INOUT),  dimension(:)      :: reservoir_type
 character(len=*), intent(in)               :: reservoir_parameter_file
 real,    intent(INOUT),  dimension(:)      :: LATLAKE, LONLAKE, ELEVLAKE
-integer, intent(INOUT), dimension(:)       :: LAKEIDM !lake id in LAKEPARM table (.nc or .tbl)
+integer(kind=int64), intent(INOUT), dimension(:)  :: LAKEIDM !lake id in LAKEPARM table (.nc or .tbl)
+integer(kind=int64), intent(INOUT), dimension(:)  :: LAKEIDA !lake COMid 4all link on full nlinks database
 integer, intent(INOUT),  dimension(:)      :: LAKEIDX !seq index of lakes(1:Nlakes) mapped to COMID
 character(len=256)                         :: route_link_f, route_lake_f
 real,    intent(INOUT),  dimension(NLINKS) :: ZELEV, CHLAT, CHLON
 integer                                    :: NLINKS, NLINKSL
-integer, intent(INOUT),  dimension(NLINKS) :: LINKID   !  which nodes pour into which lakes
+integer(kind=int64), intent(INOUT),  dimension(NLINKS) :: TO_NODE, LINKID   !  which nodes pour into which lakes
 integer                                    :: GNLINKSL
 character(len=15), intent(inout), dimension(nlinks) :: gages  !! need to respect the default values
-character(len=15), intent(in)                :: gageMiss
+character(len=15), intent(in)              :: gageMiss
 integer :: did
 
 !! local variables
-integer, dimension(NLAKES)                   :: LAKELINKID !temporarily store the outlet index for each modeled lake
+integer(kind=int64), dimension(NLAKES)         :: LAKELINKID !temporarily store the outlet index for each modeled lake
 
 did = 1
 LAKELINKID = 0
@@ -8267,7 +8390,7 @@ if (NLAKES > 0) then
    !         call mpp_land_bcast_int(NLINKSL,LAKEIDA)
    !         call mpp_land_bcast_int(NLINKSL,LAKEIDX)
    call mpp_land_bcast_real(NLAKES,HRZAREA)
-   call mpp_land_bcast_int(NLAKES,LAKEIDM)
+   call mpp_land_bcast_int8(NLAKES,LAKEIDM)
    call mpp_land_bcast_real(NLAKES,LAKEMAXH)
    call mpp_land_bcast_real(NLAKES,WEIRH  )
    call mpp_land_bcast_real(NLAKES,WEIRC  )
@@ -8299,8 +8422,9 @@ end subroutine read_routelink
         character(len=*) :: route_link_f,route_lake_f
         integer  :: GNLINKSL, NLINKSL, tmp_from_node,NLAKES
 
-        INTEGER, INTENT(INOUT)                   :: MAXORDER
-        INTEGER, intent(out), dimension(:) :: LAKEIDA, LINKID, TO_NODE, TYPEL, ORDER
+        INTEGER, INTENT(INOUT)                     :: MAXORDER
+        integer(kind=int64), intent(out), dimension(:) :: LAKEIDA, LINKID, TO_NODE
+        INTEGER, intent(out), dimension(:)         :: TYPEL, ORDER
 
         real,dimension(:,:)  :: QLINK
         real, intent(out), dimension(:) ::  CHLON, CHLAT, ZELEV, MUSK, MUSX, CHANLEN
@@ -8311,14 +8435,16 @@ end subroutine read_routelink
         character(len=15), intent(in) :: gageMiss
 
 !NLAKES
-        INTEGER, intent(out), dimension(:)  ::  LAKEIDM, reservoir_type
+        integer(kind=int64), intent(out), dimension(:)  ::  LAKEIDM
+        integer, intent(out), dimension(:)  ::  reservoir_type
         logical, intent(in)		            ::  reservoir_type_specified
         character(len=*), intent(in)        ::  reservoir_parameter_file
         REAL, intent(out), dimension(:) :: HRZAREA,LAKEMAXH, WEIRC, WEIRL, DAML, ORIFICEC, WEIRH, &
                    ORIFICEA, ORIFICEE, ELEVLAKE
 !end NLAKES
 
-        INTEGER, dimension(GNLINKSL) ::  tmpLAKEIDA, tmpLINKID,  tmpTO_NODE, tmpTYPEL, tmpORDER
+        INTEGER(kind=int64), dimension(GNLINKSL) ::  tmpLAKEIDA, tmpLINKID,  tmpTO_NODE
+        INTEGER, dimension(GNLINKSL) ::  tmpTYPEL, tmpORDER
         character(len=15), dimension(gnlinksl) :: tmpGages
         CHARACTER(len=155)	 :: header
         integer :: i
@@ -8332,7 +8458,7 @@ end subroutine read_routelink
         real, allocatable, dimension(:) ::  tmpCHLON, tmpCHLAT, tmpZELEV, tmpMUSK, tmpMUSX, tmpCHANLEN
         real, allocatable, dimension(:) ::  tmpMannN, tmpSo, tmpChSSlp, tmpBw, tmpTw, tmpTw_CC, tmpn_CC
         real, allocatable, dimension(:) ::  tmpChannK
-#endif 
+#endif
 
         !! is RouteLink file netcdf (*.nc) or csv (*.csv)
         route_link_f_r = adjustr(route_link_f)
@@ -8459,7 +8585,7 @@ end subroutine read_routelink
            call mpp_land_bcast_real(NLAKES, ORIFICEC)
            call mpp_land_bcast_real(NLAKES, ORIFICEA)
            call mpp_land_bcast_real(NLAKES, ORIFICEE)
-           call mpp_land_bcast_int(NLAKES, LAKEIDM)
+           call mpp_land_bcast_int8(NLAKES, LAKEIDM)
            call mpp_land_bcast_real(NLAKES, ELEVLAKE)
            call mpp_land_bcast_int(NLAKES, reservoir_type)
         endif
@@ -8495,7 +8621,7 @@ end subroutine read_routelink
                  CHLAT,      ZELEV,     TYPEL,    ORDER,    &
                  QLINK(:,1), MUSK,      MUSX,     CHANLEN,  &
                  MannN,      So,        ChSSlp,   Bw,       &
-                 Tw,         Tw_CC,     n_CC,     ChannK, gages,    & 
+                 Tw,         Tw_CC,     n_CC,     ChannK, gages,    &
                  LAKEIDA                                     )
 
         else
@@ -8577,18 +8703,19 @@ integer                                      :: I,J,channel_option
 character(len=28)                            :: dir
 
 character(len=155)	 :: header
-integer, intent(INOUT),  dimension(NLINKS)   :: FROM_NODE
+integer(kind=int64), intent(INOUT),  dimension(NLINKS)   :: FROM_NODE
 real, intent(INOUT),  dimension(NLINKS)      :: ZELEV
 real, intent(INOUT),  dimension(NLINKS)      :: CHLAT,CHLON
 
+integer(kind=int64), intent(INOUT),  dimension(NLINKS)   :: TO_NODE
 integer, intent(INOUT),  dimension(NLINKS)   :: TYPEL
-integer, intent(INOUT),  dimension(NLINKS)   :: TO_NODE,ORDER
+integer, intent(INOUT),  dimension(NLINKS)   :: ORDER
 integer, intent(INOUT),  dimension(NLINKS)   :: STRMFRXSTPTS
 
 integer, intent(INOUT)                       :: MAXORDER
 real, intent(INOUT),  dimension(NLINKS)      :: CHANLEN   !channel length
 real, intent(INOUT),  dimension(NLINKS)      :: MannN, So !mannings N
-integer, intent(INOUT),  dimension(NLINKS)   :: LAKENODE  ! identifies which nodes pour into which lakes
+integer(kind=int64), intent(INOUT),  dimension(NLINKS)   :: LAKENODE  ! identifies which nodes pour into which lakes
 real, intent(IN)                             :: dist(ixrt,jxrt,9)
 integer, intent(INOUT),  dimension(NLINKS)   :: map_l2g
 
@@ -8607,7 +8734,7 @@ real, intent(INOUT),  dimension(NLAKES)      :: ORIFICEE
 integer, intent(INOUT), dimension(NLAKES)    :: reservoir_type
 character(len=*), intent(in)                 :: reservoir_parameter_file
 real, intent(INOUT),  dimension(NLAKES)      :: LATLAKE,LONLAKE,ELEVLAKE
-real, intent(INOUT), dimension(NLINKS)       :: ChSSlp, Bw, Tw 
+real, intent(INOUT), dimension(NLINKS)       :: ChSSlp, Bw, Tw
 real, intent(INOUT), dimension(NLINKS)       :: Tw_CC, n_CC, ChannK
 
 character(len=*  )                           :: geo_finegrid_flnm, route_lake_f
@@ -8616,14 +8743,17 @@ character(len=256)                           :: var_name
 integer                                      :: tmp, cnt, ncid
 real                                         :: gc,n
 
-integer, intent(IN), dimension(IXRT,JXRT)    :: CH_NETLNK,GCH_NETLNK
+integer(kind=int64), intent(IN), dimension(IXRT,JXRT)    :: CH_NETLNK,GCH_NETLNK
 real, intent(IN), dimension(IXRT,JXRT)       :: ELRT
-integer, intent(IN), dimension(IXRT,JXRT) :: CH_NETRT, CH_LNKRT
-integer, intent(OUT), dimension(IXRT,JXRT) :: LAKE_MSKRT, link_location
+integer, intent(IN), dimension(IXRT,JXRT)    :: CH_NETRT
+integer(kind=int64), intent(IN), dimension(IXRT,JXRT) :: CH_LNKRT
+integer, intent(OUT), dimension(IXRT,JXRT) :: LAKE_MSKRT
+integer(kind=int64), intent(OUT), dimension(IXRT,JXRT) :: link_location
 real, intent(OUT), dimension(IXRT,JXRT)    :: latval,lonval
 integer :: k
 integer, dimension(nlinks)            :: node_table, nlinks_index
-integer, dimension(nlakes)            :: lake_index, LAKEIDM
+integer, dimension(nlakes)            :: lake_index
+integer(kind=int64), dimension(nlakes)    :: LAKEIDM
 integer :: yw_mpp_nlinks , l, mpp_nlinks
 
 
@@ -8838,12 +8968,12 @@ subroutine read_route_link_netcdf( route_link_file,                         &
 
 implicit none
 character(len=*),        intent(in)  :: route_link_file
-integer, dimension(:),   intent(out) :: LAKEIDA, LINKID, TO_NODE
+integer(kind=int64), dimension(:),   intent(out) :: LAKEIDA, LINKID, TO_NODE
 real,    dimension(:),   intent(out) :: CHLON, CHLAT, ZELEV
 integer, dimension(:),   intent(out) :: TYPEL, ORDER
 real,    dimension(:),   intent(out) :: QLINK
 real,    dimension(:),   intent(out) :: MUSK, MUSX, CHANLEN
-real,    dimension(:),   intent(out) :: MannN, So, ChSSlp, Bw, Tw 
+real,    dimension(:),   intent(out) :: MannN, So, ChSSlp, Bw, Tw
 real,    dimension(:),   intent(out) :: Tw_CC, n_CC, ChannK
 
 character(len=15), dimension(:), intent(inout) :: gages
@@ -8863,9 +8993,9 @@ if (iRet /= nf90_noErr) then
 endif
 
 
-call get_1d_netcdf_int(ncid,  'link',     LINKID,    'read_route_link_netcdf', .TRUE.)
-call get_1d_netcdf_int(ncid,  'NHDWaterbodyComID',  LAKEIDA, 'read_route_link_netcdf', .FALSE.)
-call get_1d_netcdf_int(ncid,  'to',       TO_NODE,   'read_route_link_netcdf', .TRUE.)
+call get_1d_netcdf_int64(ncid,  'link',     LINKID,    'read_route_link_netcdf', .TRUE.)
+call get_1d_netcdf_int64(ncid,  'NHDWaterbodyComID',  LAKEIDA, 'read_route_link_netcdf', .FALSE.)
+call get_1d_netcdf_int64(ncid,  'to',       TO_NODE,   'read_route_link_netcdf', .TRUE.)
 call get_1d_netcdf_real(ncid, 'lon',      CHLON,     'read_route_link_netcdf', .TRUE.)
 call get_1d_netcdf_real(ncid, 'lat',      CHLAT,     'read_route_link_netcdf', .TRUE.)
 call get_1d_netcdf_real(ncid, 'alt',      ZELEV,     'read_route_link_netcdf', .TRUE.)
@@ -8944,15 +9074,15 @@ subroutine read_route_lake_netcdf(route_lake_file,                         &
                                    LAKEIDM, lakelat, lakelon, ELEVLAKE, NLAKES)
 
     implicit none
-    character(len=*),        intent(in)  :: route_lake_file
-    integer,                 intent(in)  :: NLAKES
-    logical,                 intent(in)  :: reservoir_type_specified
-    character(len=*),        intent(in)  :: reservoir_parameter_file
-    integer, dimension(:),   intent(out) :: LAKEIDM
-    real,    dimension(:),   intent(out) :: HRZAREA,  LAKEMAXH, WEIRC,    WEIRL, WEIRH, DAML
-    real,    dimension(:),   intent(out) :: ORIFICEC, ORIFICEA, ORIFICEE, lakelat, lakelon
-    real,    dimension(:),   intent(out) :: ELEVLAKE
-    integer, dimension(:),   intent(out) :: reservoir_type
+    character(len=*),              intent(in)  :: route_lake_file
+    integer,                       intent(in)  :: NLAKES
+    logical,                       intent(in)  :: reservoir_type_specified
+    character(len=*),              intent(in)  :: reservoir_parameter_file
+    integer(kind=int64), dimension(:), intent(out) :: LAKEIDM
+    real,    dimension(:),         intent(out) :: HRZAREA,  LAKEMAXH, WEIRC,    WEIRL, WEIRH, DAML
+    real,    dimension(:),         intent(out) :: ORIFICEC, ORIFICEA, ORIFICEE, lakelat, lakelon
+    real,    dimension(:),         intent(out) :: ELEVLAKE
+    integer, dimension(:),         intent(out) :: reservoir_type
 
     integer :: iRet, ncid, ii, varid
     logical :: fatal_if_error
@@ -8968,7 +9098,7 @@ subroutine read_route_lake_netcdf(route_lake_file,                         &
        if (fatal_IF_ERROR) call hydro_stop("read_route_lake_netcdf: Problem opening file.")
     endif
 
-    call get_1d_netcdf_int(ncid,  'lake_id',     LAKEIDM,'read_route_lake_netcdf', .TRUE.)
+    call get_1d_netcdf_int64(ncid,  'lake_id',   LAKEIDM,'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'LkArea',   HRZAREA,   'read_route_lake_netcdf', .TRUE.)
     !rename the LAKEPARM input vars for Elev instead of Ht, 08/23/17 LKR/DY
     call get_1d_netcdf_real(ncid, 'LkMxE',    LAKEMAXH,  'read_route_lake_netcdf', .TRUE.)
@@ -8976,14 +9106,14 @@ subroutine read_route_lake_netcdf(route_lake_file,                         &
     call get_1d_netcdf_real(ncid, 'WeirE',    WEIRH,     'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'WeirC',    WEIRC,     'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'WeirL',    WEIRL,     'read_route_lake_netcdf', .TRUE.)
-    call get_1d_netcdf_real(ncid, 'Dam_Length', DAML,      'read_route_lake_netcdf', .TRUE.)
+    call get_1d_netcdf_real(ncid, 'Dam_Length', DAML,    'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'OrificeC', ORIFICEC,  'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'OrificeA', ORIFICEA,  'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'OrificeE', ORIFICEE,  'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'lat', lakelat,        'read_route_lake_netcdf', .TRUE.)
     call get_1d_netcdf_real(ncid, 'lon', lakelon,        'read_route_lake_netcdf', .TRUE.)
     !remove the alt var. and add initial fractional depth var. LKR/DY
-    call get_1d_netcdf_real(ncid, 'ifd', ELEVLAKE,         'read_route_lake_netcdf', .FALSE.)
+    call get_1d_netcdf_real(ncid, 'ifd', ELEVLAKE,       'read_route_lake_netcdf', .FALSE.)
 
     iRet = nf90_close(ncId)
     if (iRet /= nf90_noErr) then
@@ -9049,6 +9179,26 @@ if (iRet /= nf90_NoErr) then
 end if
 end subroutine get_1d_netcdf_int
 
+    subroutine get_1d_netcdf_int64(ncid, varName, var, callingRoutine, fatal_if_error)
+        integer,                       intent(in)  :: ncid !! the file identifier
+        character(len=*),              intent(in)  :: varName
+        integer(kind=int64), dimension(:), intent(out) :: var
+        character(len=*),              intent(in)  :: callingRoutine
+        logical,                       intent(in)  :: fatal_if_error
+        integer :: varid, iret
+        iRet = nf90_inq_varid(ncid, varName, varid)
+        if (iret /= nf90_noErr) then
+            if (fatal_IF_ERROR) then
+                print*, trim(callingRoutine) // ": get_1d_netcdf_real: variable: " // trim(varName)
+                call hydro_stop("get_1d_netcdf")
+            end if
+        end if
+        iRet = nf90_get_var(ncid, varid, var)
+        if (iRet /= nf90_NoErr) then
+            print*, trim(callingRoutine) // ": get_1d_netcdf_int: values: " // trim(varName)
+            if (fatal_IF_ERROR) call hydro_stop("get_1d_netcdf_int")
+        end if
+    end subroutine get_1d_netcdf_int64
 
 subroutine get_1d_netcdf_real(ncid, varName, var, callingRoutine, fatal_if_error)
 integer,            intent(in)  :: ncid !! the file identifier
@@ -9168,14 +9318,14 @@ subroutine readBucket_nhd(infile, numbasns, gw_buck_coeff, gw_buck_exp, &
                 gw_buck_loss, z_max, z_init, LINKID, nhdBuckMask)
     implicit none
     integer :: numbasns
-    integer, dimension(numbasns) :: LINKID
+    integer(kind=int64), dimension(numbasns) :: LINKID
     real, dimension(numbasns) :: gw_buck_coeff, gw_buck_exp, gw_buck_loss
     real, dimension(numbasns) :: z_max, z_init
     integer, dimension(numbasns) :: nhdBuckMask
     character(len=*) :: infile
 !   define temp array
     integer :: i,j,k, gnid, ncid, varid, ierr, dimid, iret
-    integer, allocatable, dimension(:) :: tmpLinkid
+    integer(kind=int64), allocatable, dimension(:) :: tmpLinkid
     real, allocatable, dimension(:) :: tmpCoeff, tmpExp, tmpLoss
     real, allocatable, dimension(:) :: tmpz_max, tmpz_init
 
@@ -9249,7 +9399,7 @@ subroutine readBucket_nhd(infile, numbasns, gw_buck_coeff, gw_buck_exp, &
                print * , "could not find ComID from ", infile
                call hydro_stop("Failed to read BUCKETPARM")
           endif
-          iret = nf90_get_var(ncid, varid, tmpLinkid)
+          iret = nf90_get_var(ncid, varid, tmpLinkID)
 #ifdef MPP_LAND
     endif
        if(gnid .gt. 0) then
@@ -9260,7 +9410,7 @@ subroutine readBucket_nhd(infile, numbasns, gw_buck_coeff, gw_buck_exp, &
           endif
           call mpp_land_bcast_real_1d(tmpz_max)
           call mpp_land_bcast_real_1d(tmpz_init)
-          call mpp_land_bcast_int(gnid ,tmpLinkid)
+          call mpp_land_bcast_int8(gnid ,tmpLinkid)
        endif
 #endif
 
@@ -9275,7 +9425,7 @@ subroutine readBucket_nhd(infile, numbasns, gw_buck_coeff, gw_buck_exp, &
        !                z_max(k) = tmpz_max(i)
        !                z_init(k) = tmpz_init(i)
        !                nhdBuckMask(k) = 1
-       !                goto 301 
+       !                goto 301
        !             endif
        !         end do
        ! 301     continue
@@ -9283,9 +9433,9 @@ subroutine readBucket_nhd(infile, numbasns, gw_buck_coeff, gw_buck_exp, &
 
        block
          type(hash_t) :: hash_table
-         integer :: val,it
+         integer(kind=int64) :: val,it
          logical :: found
-         
+
          call hash_table%set_all_idx(LINKID,numbasns)
          do it=1, gnid
             call hash_table%get(tmpLinkid(it), val, found)
@@ -9353,7 +9503,8 @@ end subroutine readBucket_nhd
      real, dimension(:),               intent(in) :: chlon,chlat
      real, dimension(:),                  intent(in) :: hlink,zelev
 
-     integer, dimension(:),               intent(in) :: ORDER, linkid
+     integer, dimension(:),               intent(in) :: ORDER
+     integer(kind=int64), dimension(:),       intent(in) :: linkid
 
      real,                                     intent(in) :: dtrt_ch
      real, dimension(:,:),                intent(in) :: qlink
@@ -9376,7 +9527,8 @@ end subroutine readBucket_nhd
 #ifdef WRF_HYDRO_NUDGING
       real, allocatable,dimension(:) :: g_nudge
 #endif
-      integer, allocatable,dimension(:) :: g_order, g_linkid
+      integer, allocatable,dimension(:) :: g_order
+      integer(kind=int64), allocatable, dimension(:) :: g_linkid
       real,allocatable,dimension(:,:) :: g_qlink
       integer  :: gsize
       real*8, allocatable, dimension(:) :: g_accSfcLatRunoff, g_accBucket
@@ -9486,7 +9638,7 @@ end subroutine readBucket_nhd
         call write_chanel_real(qlink(:,1),map_l2g,gnlinks,nlinks,g_qlink(:,1))
         call write_chanel_real(qlink(:,2),map_l2g,gnlinks,nlinks,g_qlink(:,2))
         call write_chanel_int(order,map_l2g,gnlinks,nlinks,g_order)
-        call write_chanel_int(linkid,map_l2g,gnlinks,nlinks,g_linkid)
+        call write_chanel_int8(linkid,map_l2g,gnlinks,nlinks,g_linkid)
         call write_chanel_real(chlon,map_l2g,gnlinks,nlinks,g_chlon)
         call write_chanel_real(chlat,map_l2g,gnlinks,nlinks,g_chlat)
         call write_chanel_real(zelev,map_l2g,gnlinks,nlinks,g_zelev)
@@ -9579,7 +9731,7 @@ end subroutine mpp_output_chrt2
 
 
 
-     integer, allocatable, DIMENSION(:)         :: linkid
+     integer(kind=int64), allocatable, dimension(:) :: linkid
 
      integer, allocatable, DIMENSION(:)         :: rec_num_of_station
      integer, allocatable, DIMENSION(:)         :: rec_num_of_stationO
@@ -9937,7 +10089,7 @@ end subroutine output_chrt2
 
 #ifdef MPP_LAND
        real, allocatable, dimension(:) :: g_qin_gwsubbas, g_qout_gwsubbas, g_z_gwsubbas
-       integer, allocatable, dimension(:) :: g_basnsInd
+       integer(kind=int64), allocatable, dimension(:) :: g_basnsInd
        if(my_id .eq. io_id) then
           if(nlst(did)%GWBASESWCRT.EQ.1 .OR. nlst(did)%GWBASESWCRT.GE.4) then
                allocate(g_qin_gwsubbas(rt_domain(did)%gnumbasns))
@@ -10037,7 +10189,7 @@ end subroutine output_chrt2
      integer,                                  intent(in) :: split_output_count
      integer,                                  intent(in) :: nbasns
      real, dimension(:),                  intent(in) :: gw_in_var, gw_out_var, gw_z_var
-     integer, dimension(:),               intent(in) :: gw_id_var
+     integer(kind=int64), dimension(:),               intent(in) :: gw_id_var
 
      character(len=*),                         intent(in) :: startdate
      character(len=*),                         intent(in) :: date
@@ -10206,9 +10358,8 @@ end subroutine output_chrt2
     subroutine nhdLakeMap(NLAKES, NLINKSL, TYPEL, LAKELINKID, LAKEIDX, gTO_NODE,LINKID, LAKEIDM, LAKEIDA)
         !--- get the lake configuration here.
         implicit none
-        integer, dimension(:),   intent(inout) :: TYPEL, LAKELINKID, LAKEIDX
-        integer, dimension(:),   intent(inout) :: gTO_NODE
-        integer, dimension(:),   intent(inout) :: LINKID, LAKEIDM, LAKEIDA
+        integer, dimension(:),         intent(inout) :: TYPEL, LAKEIDX
+        integer(kind=int64), dimension(:), intent(inout) :: LINKID, LAKEIDA, LAKELINKID, LAKEIDM, gTO_NODE
         integer, intent(in) :: NLAKES, NLINKSL
         integer, dimension(NLINKSL) :: OUTLAKEID
         integer :: i,j,k, kk
@@ -10295,21 +10446,24 @@ end subroutine output_chrt2
     subroutine nhdLakeMap_mpp(NLAKES, NLINKSL, TYPEL, LAKELINKID, LAKEIDX, TO_NODE,LINKID, LAKEIDM, LAKEIDA,GNLINKSL)
         !--- get the lake configuration here.
         implicit none
-        integer, dimension(:),   intent(out) :: TYPEL, LAKELINKID, LAKEIDX
-        integer, dimension(:),   intent(inout) :: TO_NODE
-        integer, dimension(:),   intent(in) :: LINKID, LAKEIDA
-        integer, dimension(:),   intent(inout) :: LAKEIDM
+        integer, dimension(:),           intent(out)   :: TYPEL
+        integer, dimension(:),   intent(out)   :: LAKEIDX
+        integer(kind=int64), dimension(:),   intent(inout) :: TO_NODE
+        integer(kind=int64), dimension(:),   intent(out)   :: LAKELINKID
+        integer(kind=int64), dimension(:),   intent(in)    :: LINKID, LAKEIDA
+        integer(kind=int64), dimension(:),   intent(inout) :: LAKEIDM
         integer, intent(in) :: NLAKES, NLINKSL ,GNLINKSL
 !yw        integer, dimension(NLINKSL) :: OUTLAKEID
-        integer, allocatable, dimension(:) :: OUTLAKEID
+        integer(kind=int64), allocatable, dimension(:) :: OUTLAKEID
         integer :: i,size2 ,j,k, kk, num, maxNum, m, mm, tmpSize
-        integer, allocatable, dimension(:) :: gLINKID, tmpTYPEL, tmpLINKID, ind,  &
-                    tmplakeida, tmpoutlakeid, tmpTO_NODE, gLAKEIDA, gLAKEIDX
-        integer, allocatable, dimension(:,:) :: gtonodeout
+        integer, allocatable, dimension(:) :: tmpTYPEL, ind, gLAKEIDX
+        integer(kind=int64), allocatable, dimension(:) :: gLINKID, tmpLINKID, tmplakeida, tmpoutlakeid, gLAKEIDA
+        integer(kind=int64), allocatable, dimension(:,:) :: gtonodeout
 
-        integer,allocatable, dimension(:) ::  gto, tmpLAKELINKID, gTYPEL, gOUTLAKEID
+        integer, allocatable, dimension(:) ::  gTYPEL
+        integer(kind=int64), allocatable, dimension(:) ::  tmpLAKELINKID, gOUTLAKEID, tmpTO_NODE, gto
 
-      integer tmpBuf(GNLINKSL)
+      integer(kind=int64) tmpBuf(GNLINKSL)
 
       tmpSize = size(TO_NODE,1)
       allocate(OUTLAKEID(tmpSize))
@@ -10349,14 +10503,14 @@ end subroutine output_chrt2
 
       block
         type(hash_t) :: hash_table
-        integer :: val,it
-        integer, allocatable :: num_a(:)
+        integer(kind=int64) :: val,it
+        integer(kind=int64), allocatable :: num_a(:)
         logical :: found
-        
+
         allocate(num_a(NLINKSL))
         num_a = 0
         kk = 0
-        
+
         call hash_table%set_all_idx(linkid, NLINKSL)
         do it=1, gnlinksl
            call hash_table%get(gto(it), val, found)
@@ -10367,7 +10521,7 @@ end subroutine output_chrt2
         end do
         maxNum = maxval(num_a)
         num_a = 1
-      
+
         allocate(ind(kk))
         allocate(gToNodeOut(NLINKSL,maxNum+1))
         gToNodeOut = -99
@@ -10376,7 +10530,7 @@ end subroutine output_chrt2
         allocate(tmpLAKEIDA(kk))
         allocate(tmpOUTLAKEID(kk))
         allocate(tmpTO_NODE(kk))
-        
+
         if(kk .gt. 0) then
            tmpOUTLAKEID = -999
            tmpTYPEL = -999
@@ -10386,9 +10540,9 @@ end subroutine output_chrt2
            OUTLAKEID = -999
            TYPEL = -999
         endif
-        
+
         kk = 0
-        
+
         ! The following loops are replaced by a hashtable-based algorithm
         ! do m = 1, NLINKSL
         !          num = 1
@@ -10403,7 +10557,7 @@ end subroutine output_chrt2
         !              endif
         !           end do
         ! enddo
-        
+
         do it=1, gnlinksl
            call hash_table%get(gto(it), val, found)
            if(found .eqv. .true.) then
@@ -10415,12 +10569,12 @@ end subroutine output_chrt2
               num_a(val) = num_a(val) + 1
            end if
         end do
-        
+
         deallocate(num_a)
         call hash_table%clear()
-        
+
       end block
-      
+
       size2 = kk
       deallocate (gto)
 
@@ -10473,7 +10627,7 @@ end subroutine output_chrt2
        END DO
 
 !yw       call sum_int1d(LAKELINKID, NLAKES)
-       call updateLake_seqInt(LAKELINKID,nlakes,tmpLAKELINKID)
+       call updateLake_seqInt8(LAKELINKID,nlakes,tmpLAKELINKID)
 
        if(allocated(tmplakelinkid))  deallocate(tmpLAKELINKID)
 
@@ -10499,7 +10653,7 @@ end subroutine output_chrt2
 !     end do
 
        call TONODE2RSL(ind,tmpTYPEL,size2,gNLINKSL,NLINKSL,TYPEL(1:NLINKSL), -999 )
-       call TONODE2RSL(ind,tmpOUTLAKEID,size2,gNLINKSL,NLINKSL,OUTLAKEID(1:NLINKSL), -999 )
+       call TONODE2RSL8(ind,tmpOUTLAKEID,size2,gNLINKSL,NLINKSL,OUTLAKEID(1:NLINKSL), -999 )
 
 
  ! assign the the inflow nodes to the lank with a new TO_NODE id, which is the outflow link
@@ -10595,17 +10749,16 @@ end subroutine output_chrt2
     subroutine nhdLakeMap_scan(NLAKES, NLINKSL, LAKELINKID, TO_NODE,LINKID, LAKEIDM, LAKEIDA,GNLINKSL)
         !--- get the lake configuration here.
         implicit none
-        integer, dimension(NLAKES) :: LAKELINKID
-        integer, dimension(:),   intent(in) :: TO_NODE
-        integer, dimension(:),   intent(in) :: LINKID, LAKEIDA
-        integer, dimension(:),   intent(inout) :: LAKEIDM
+        integer(kind=int64), dimension(:), intent(in) :: TO_NODE
+        integer(kind=int64), dimension(NLAKES) :: LAKELINKID
+        integer(kind=int64), dimension(:),   intent(in) :: LINKID, LAKEIDA
+        integer(kind=int64), dimension(:),   intent(inout) :: LAKEIDM
         integer, intent(in) :: NLAKES, NLINKSL ,GNLINKSL
         integer :: i,size ,j,k, kk, num, maxNum, m, mm
-        integer, allocatable, dimension(:) :: ind,  &
-                    tmplakeida, tmpoutlakeid, tmpTO_NODE, gLAKEIDA
-        integer, allocatable, dimension(:,:) :: gtonodeout
-
-        integer,allocatable, dimension(:) ::  gto , tmpLAKELINKID, gtoLakeId_g, gtoLakeId
+        integer(kind=int64), allocatable, dimension(:) :: tmplakeida, tmpoutlakeid, gLAKEIDA, tmpTO_NODE, gto
+        integer(kind=int64), allocatable, dimension(:) :: ind
+        integer(kind=int64), allocatable, dimension(:,:) :: gtonodeout
+        integer(kind=int64), allocatable, dimension(:) ::  tmpLAKELINKID, gtoLakeId_g, gtoLakeId
 
 !       integer tmpBuf(GNLINKSL)
         integer, dimension(nlakes) :: lakemask
@@ -10642,14 +10795,14 @@ end subroutine output_chrt2
 
       block
         type(hash_t) :: hash_table
-        integer :: val,it
-        integer, allocatable :: num_a(:)
+        integer(kind=int64) :: val,it
+        integer(kind=int64), allocatable :: num_a(:)
         logical :: found
-        
+
         allocate(num_a(NLINKSL))
         num_a = 0
         kk = 0
-         
+
         call hash_table%set_all_idx(linkid, NLINKSL)
         do it=1, gnlinksl
            call hash_table%get(gto(it), val, found)
@@ -10661,15 +10814,15 @@ end subroutine output_chrt2
         end do
         maxNum = maxval(num_a)
         num_a = 1
-        
+
         allocate(ind(kk))
         allocate(gToNodeOut(NLINKSL,maxNum+1))
         gToNodeOut = -99
         allocate(tmpLAKEIDA(kk))
         allocate(tmpTO_NODE(kk))
-        
-        kk = 0 
-        
+
+        kk = 0
+
         ! The following loops are replaced by a hashtable-based algorithm
         ! do m = 1, NLINKSL
         !    num = 1
@@ -10684,7 +10837,7 @@ end subroutine output_chrt2
         !       endif
         !    end do
         ! end do
-        
+
         do it=1, gnlinksl
            call hash_table%get(gto(it), val, found)
            if(found .eqv. .true.) then
@@ -10696,12 +10849,12 @@ end subroutine output_chrt2
               num_a(val) = num_a(val) + 1
            end if
         end do
-        
+
         deallocate(num_a)
         call hash_table%clear()
-        
+
       end block
-         
+
       size = kk
       if(allocated(gto)) deallocate (gto)
 
@@ -10737,7 +10890,7 @@ end subroutine output_chrt2
 !yw        call match1dLake(LAKELINKID, NLAKES, -999)
 
 !yw double check
-      call combine_int1d(gtoLakeId_g,gnlinksl, -999)
+      call combine_int8_1d(gtoLakeId_g,gnlinksl, -999)
       call ReachLS_decomp(gtoLakeId_g,gtoLakeId)
 
        lakemask = 0
@@ -10778,7 +10931,7 @@ end subroutine output_chrt2
 !end double check
 
 
-       call updateLake_seqInt(LAKELINKID,nlakes,tmpLAKELINKID)
+       call updateLake_seqInt8(LAKELINKID,nlakes,tmpLAKELINKID)
 
 !      if(my_id .eq. 0) then
 !          write(65,*) "check LAKEIDM   *****,"
@@ -10813,7 +10966,8 @@ end subroutine output_chrt2
 
     implicit none
 
-    integer, dimension(:),  intent(in) :: inLINKID, inTYPEL
+    integer, dimension(:),  intent(in) :: inTYPEL
+    integer(kind=int64), dimension(:), intent(in) :: inLINKID
     integer, intent(in) :: inNLINKS
 
     integer            :: iret
@@ -10821,7 +10975,8 @@ end subroutine output_chrt2
     integer            :: linkdim
     character(len=256), parameter :: output_flnm = "LAKE_TYPES.nc"
 
-    integer, allocatable, dimension(:) :: linkId, typeL
+    integer, allocatable, dimension(:) :: typeL
+    integer(kind=int64), allocatable, dimension(:) :: linkId
 
 #ifdef MPP_LAND
 
@@ -10866,7 +11021,7 @@ end subroutine output_chrt2
        iret = nf90_def_dim(ncid, "link", inNLINKS, linkdim)
 
        !-- link  id
-       iret = nf90_def_var(ncid, "LINKID", NF90_INT, (/linkdim/), varid)
+       iret = nf90_def_var(ncid, "LINKID", NF90_INT64, (/linkdim/), varid)
        iret = nf90_put_att(ncid, varid, 'long_name', 'Link ID')
 
        !- lake reach type, var

--- a/trunk/NDHMS/Routing/module_HYDRO_utils.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_utils.F
@@ -21,6 +21,7 @@
 module module_HYDRO_utils
   use module_RT_data, only: rt_domain
   use config_base, only: nlst
+  use iso_fortran_env, only: int64
 #ifdef MPP_LAND
   use module_mpp_land, only: global_nx, global_ny, my_id, IO_id, &
        decompose_data_real, write_io_real, MPP_LAND_COM_REAL, &
@@ -406,11 +407,33 @@ contains
       end do
    end subroutine get_area_g
 
+    subroutine get_area_g8(basns_area,GWSUBBASMSK, numbasns,ix,jx,dist)
+        integer :: i,j, n, ix,jx, numbasns
+        integer :: count(numbasns)
+        real :: basns_area(numbasns) , dist(ix,jx,9)
+        integer(kind=int64) :: GWSUBBASMSK(ix,jx)
+        basns_area = 0
+        count = 0
+        do  j = 1, jx
+            do  i = 1, ix
+                n = GWSUBBASMSK(i,j)
+                if(n .gt. 0) then
+                    basns_area(n) = basns_area(n)+dist(i,j,9)
+                    count(n) = count(n) + 1
+                endif
+            end do
+        end do
+        do i = 1, numbasns
+            if(count(i) .gt. 0) then
+                basns_area(i) = basns_area(i) / count(i)
+            end if
+        end do
+    end subroutine get_area_g8
 
    subroutine get_node_area(did)
        integer :: did
-       call get_area_g(rt_domain(did)%node_area,rt_domain(did)%CH_NETLNK, &
-         rt_domain(did)%NLINKS,rt_domain(did)%ixrt,rt_domain(did)%jxrt,rt_domain(did)%overland%properties%distance_to_neighbor)
+       call get_area_g8(rt_domain(did)%node_area, rt_domain(did)%CH_NETLNK, &
+         rt_domain(did)%NLINKS,rt_domain(did)%ixrt, rt_domain(did)%jxrt, rt_domain(did)%overland%properties%distance_to_neighbor)
    end subroutine get_node_area
     
 

--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -9,6 +9,8 @@ use module_version, only: get_code_version, get_nwm_version
 use orchestrator_base
 use module_hydro_stop, only: HYDRO_stop
 
+use iso_fortran_env, only: int64
+
 implicit none
 
 ! Module-wide variables
@@ -110,14 +112,16 @@ subroutine output_chrt_NWM(domainId)
    ! sorting has taken place by ascending feature_id value.
    real, allocatable, dimension(:) :: strFlowLocal,velocityLocal,qlossLocal
    real, allocatable, dimension(:,:) :: g_qlink
-   integer, allocatable, dimension(:) :: g_linkid,g_order
+   integer, allocatable, dimension(:) :: g_order
+   integer(kind=int64), allocatable, dimension(:) :: g_linkid
    real, allocatable, dimension(:) :: g_chlat,g_chlon,g_hlink,g_zelev
    real, allocatable, dimension(:) :: g_QLateral,g_velocity,g_qloss
    real, allocatable, dimension(:) :: g_nudge,g_qSfcLatRunoff
    real, allocatable, dimension(:) :: g_qBucket,g_qBtmVertRunoff,g_accBucket
    real*8, allocatable, dimension(:) :: g_accSfcLatRunoff
    real, allocatable, dimension(:,:) :: g_qlinkOut
-   integer, allocatable, dimension(:) :: g_orderOut,g_linkidOut
+   integer, allocatable, dimension(:) :: g_orderOut
+   integer(kind=int64), allocatable, dimension(:) :: g_linkidOut
    real, allocatable, dimension(:) :: g_chlatOut,g_chlonOut,g_hlinkOut,g_zelevOut
    real, allocatable, dimension(:) :: g_QLateralOut,g_velocityOut,g_qlossOut
    real, allocatable, dimension(:) :: g_nudgeOut,g_qSfcLatRunoffOut
@@ -134,6 +138,7 @@ subroutine output_chrt_NWM(domainId)
    integer :: numPtsOut
    real, allocatable, dimension(:,:) :: varMetaReal
    integer, allocatable, dimension(:,:) :: varMetaInt
+   integer(kind=int64), allocatable, dimension(:,:) :: varMetaInt8
 
    character (len=64) :: modelConfigType ! This is character verion (long name) for the io_config_outputs
 
@@ -407,7 +412,7 @@ subroutine output_chrt_NWM(domainId)
          call write_chanel_real(RT_DOMAIN(domainId)%CHLON,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_chlon)
          call write_chanel_real(RT_DOMAIN(domainId)%HLINK,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_hlink)
          call write_chanel_int(RT_DOMAIN(domainId)%ORDER,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_order)
-         call write_chanel_int(RT_DOMAIN(domainId)%linkid,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_linkid)
+         call write_chanel_int8(RT_DOMAIN(domainId)%linkid,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_linkid)
          call write_chanel_real(RT_DOMAIN(domainId)%ZELEV,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_zelev)
          call write_chanel_real(RT_DOMAIN(domainId)%QLateral,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_QLateral)
          call write_chanel_real(velocityLocal,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_velocity)
@@ -654,7 +659,8 @@ subroutine output_chrt_NWM(domainId)
       allocate(varOutReal(fileMeta%numVars,numPtsOut))
       allocate(varOutInt(numPtsOut))
       allocate(varMetaReal(3,numPtsOut))
-      allocate(varMetaInt(2,numPtsOut))
+      allocate(varMetaInt(1,numPtsOut))
+      allocate(varMetaInt8(1,numPtsOut))
 
       varOutReal(1,:) = PACK(g_qlinkOut(:,1),g_outInd == 1)
       varOutReal(2,:) = PACK(g_nudgeOut,g_outInd == 1)
@@ -674,7 +680,7 @@ subroutine output_chrt_NWM(domainId)
       varMetaReal(2,:) = PACK(g_chlonOut,g_outInd == 1)
       varMetaReal(3,:) = PACK(g_zelevOut,g_outInd == 1)
       varMetaInt(1,:) = PACK(g_orderOut,g_outInd == 1)
-      varMetaInt(2,:) = PACK(g_linkidOut,g_outInd == 1)
+      varMetaInt8(1,:) = PACK(g_linkidOut,g_outInd == 1)
 
       ! Mask out missing values
       where ( varOutReal == fileMeta%modelNdv ) varOutReal = -9999.0
@@ -794,7 +800,7 @@ subroutine output_chrt_NWM(domainId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place inverse_flattening into crs variable.')
 
       ! Create feature_id variable
-      iret = nf90_def_var(ftn,"feature_id",nf90_int,dimId(1),featureVarId)
+      iret = nf90_def_var(ftn,"feature_id",nf90_int64,dimId(1),featureVarId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create feature_id variable.')
       iret = nf90_put_att(ftn,featureVarId,'long_name',trim(fileMeta%featureIdLName))
       call nwmCheck(diagFlag,iret,'ERROR: Uanble to place long_name attribute into feature_id variable')
@@ -960,7 +966,7 @@ subroutine output_chrt_NWM(domainId)
       ! Place link ID values into the NetCDF file
       iret = nf90_inq_varid(ftn,'feature_id',varId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to locate feature_id in NetCDF file.')
-      iret = nf90_put_var(ftn,varId,varMetaInt(2,:))
+      iret = nf90_put_var(ftn,varId,varMetaInt8(1,:))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place data into feature_id output variable.')
 
 #ifndef NWM_META
@@ -1014,6 +1020,7 @@ subroutine output_chrt_NWM(domainId)
       deallocate(varOutInt)
       deallocate(varMetaReal)
       deallocate(varMetaInt)
+      deallocate(varMetaInt8)
    endif
    deallocate(g_chlonOut)
    deallocate(g_chlatOut)
@@ -2394,10 +2401,10 @@ subroutine output_lakes_NWM(domainId,iGrid)
    real, allocatable, dimension(:) :: g_lakeType
    real, allocatable, dimension(:) :: g_lake_assimilated_value
    character(len=256), allocatable, dimension(:) :: g_lake_assimilated_source_file
-   integer, allocatable, dimension(:) :: g_lakeid
+   integer(kind=int64), allocatable, dimension(:) :: g_lakeid
    real, allocatable, dimension(:) :: g_lakeLatOut,g_lakeLonOut,g_lakeElevOut
    real, allocatable, dimension(:) :: g_lakeInflowOut,g_lakeOutflowOut
-   integer, allocatable, dimension(:) :: g_lakeTypeOut, g_lakeidOut
+   integer(kind=int64), allocatable, dimension(:) :: g_lakeTypeOut, g_lakeidOut
    real, allocatable, dimension(:) :: g_lake_assimilated_valueOut
    character(len=256), allocatable, dimension(:) :: g_lake_assimilated_source_fileOut
    real, allocatable, dimension(:,:) :: varOutReal   ! Array holding output variables in real format
@@ -2779,7 +2786,7 @@ subroutine output_lakes_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place inverse_flattening into crs variable.')
 
       ! Create feature_id variable
-      iret = nf90_def_var(ftn,"feature_id",nf90_int,dimId(1),featureVarId)
+      iret = nf90_def_var(ftn,"feature_id",nf90_int64,dimId(1),featureVarId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create feature_id variable.')
       iret = nf90_put_att(ftn,featureVarId,'long_name',trim(fileMeta%featureIdLName))
       call nwmCheck(diagFlag,iret,'ERROR: Uanble to place long_name attribute into feature_id variable')
@@ -3113,7 +3120,7 @@ subroutine output_chrtout_grd_NWM(domainId,iGrid)
    ! Allocatable array to hold global qlink values
    real, allocatable, dimension(:,:) :: g_qlink
    ! Allocatable array to hold streamflow index values
-   integer, allocatable, dimension(:,:) :: CH_NETLNK
+   integer(kind=int64), allocatable, dimension(:,:) :: CH_NETLNK
    ! allocatable global array to hold grid of output streamflow values
    integer, allocatable, dimension(:,:) :: tmpFlow
    real, allocatable, dimension(:,:) :: tmpFlowReal
@@ -3199,7 +3206,7 @@ subroutine output_chrtout_grd_NWM(domainId,iGrid)
       call write_chanel_real(strFlowLocal,RT_DOMAIN(domainId)%map_l2g,gNumLnks,lNumLnks,g_qlink(:,1))
       call write_chanel_real(RT_DOMAIN(domainId)%qlink(:,2),RT_DOMAIN(domainId)%map_l2g,gNumLnks,lNumLnks,g_qlink(:,2))
    endif
-   call write_IO_rt_int(RT_DOMAIN(domainId)%GCH_NETLNK, CH_NETLNK)
+   call write_IO_rt_int8(RT_DOMAIN(domainId)%GCH_NETLNK, CH_NETLNK)
 
    ! Initialize NWM dictionary derived type containing all the necessary metadat
    ! for the output file.
@@ -4112,7 +4119,7 @@ implicit none
    real, allocatable, dimension(:) :: g_chlat, g_chlon, g_hlink, strFlowLocal
    integer, allocatable, dimension(:) :: frxstPtsLocal, g_STRMFRXSTPTSOut
    real, allocatable, dimension(:) :: g_chlatOut, g_chlonOut, g_hlinkOut
-   integer, allocatable, dimension(:) :: g_linkid, g_linkidOut
+   integer(kind=int64), allocatable, dimension(:) :: g_linkid, g_linkidOut
 
 #ifdef MPP_LAND
    mppFlag = 1
@@ -4414,10 +4421,12 @@ subroutine output_chanObs_NWM(domainId)
    ! sorting has taken place by ascending feature_id value.
    real, allocatable, dimension(:) :: strFlowLocal,velocityLocal
    real, allocatable, dimension(:,:) :: g_qlink
-   integer, allocatable, dimension(:) :: g_linkid,g_order
+   integer, allocatable, dimension(:) :: g_order
+   integer(kind=int64), allocatable, dimension(:) :: g_linkid
    real, allocatable, dimension(:) :: g_chlat,g_chlon,g_hlink,g_zelev
    real, allocatable, dimension(:,:) :: g_qlinkOut
-   integer, allocatable, dimension(:) :: g_orderOut,g_linkidOut
+   integer, allocatable, dimension(:) :: g_orderOut
+   integer(kind=int64), allocatable, dimension(:) :: g_linkidOut
    real, allocatable, dimension(:) :: g_chlatOut,g_chlonOut,g_hlinkOut,g_zelevOut
    real, allocatable, dimension(:,:) :: varOutReal   ! Array holding output variables in real format
    integer, allocatable, dimension(:) :: varOutInt ! Array holding output variables after
@@ -4602,7 +4611,7 @@ subroutine output_chanObs_NWM(domainId)
          call write_chanel_real(RT_DOMAIN(domainId)%CHLAT,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_chlat)
          call write_chanel_real(RT_DOMAIN(domainId)%CHLON,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_chlon)
          call write_chanel_real(RT_DOMAIN(domainId)%HLINK,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_hlink)
-         call write_chanel_int(RT_DOMAIN(domainId)%linkid,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_linkid)
+         call write_chanel_int8(RT_DOMAIN(domainId)%linkid,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_linkid)
          call write_chanel_int(RT_DOMAIN(domainId)%ORDER,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_order)
          call write_chanel_real(RT_DOMAIN(domainId)%ZELEV,rt_domain(domainId)%map_l2g,gSize,rt_domain(domainId)%nlinks,g_zelev)
       else
@@ -4824,7 +4833,7 @@ subroutine output_chanObs_NWM(domainId)
          call nwmCheck(diagFlag,iret,'ERROR: Unable to place inverse_flattening into crs variable.')
 
          ! Create feature_id variable
-         iret = nf90_def_var(ftn,"feature_id",nf90_int,dimId(1),featureVarId)
+         iret = nf90_def_var(ftn,"feature_id",nf90_int64,dimId(1),featureVarId)
          call nwmCheck(diagFlag,iret,'ERROR: Unable to create feature_id variable.')
          ! Specify these attributes based on channel routing methods specified by
          ! user.
@@ -5159,7 +5168,7 @@ subroutine output_gw_NWM(domainId,iGrid)
    integer :: gnbasns
    ! Allocatable arrays to hold output variables.
    real, allocatable, dimension(:) :: g_qin_gwsubbas,g_qout_gwsubbas,g_qloss_gwsubbas,g_z_gwsubbas
-   integer, allocatable, dimension(:) :: g_basnsInd
+   integer(kind=int64), allocatable, dimension(:) :: g_basnsInd
    real, allocatable, dimension(:,:) :: varOutReal   ! Array holding output variables in real format
    integer, allocatable, dimension(:) :: varOutInt ! Array holding output variables after
                                                      ! scale_factor/add_offset
@@ -5438,7 +5447,7 @@ subroutine output_gw_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place units attribute into reference_time variable')
 
       ! Create feature_id variable
-      iret = nf90_def_var(ftn,"feature_id",nf90_int,dimId(1),featureVarId)
+      iret = nf90_def_var(ftn,"feature_id",nf90_int64,dimId(1),featureVarId)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create feature_id variable.')
       iret = nf90_put_att(ftn,featureVarId,'long_name',trim(fileMeta%featureIdLName))
       call nwmCheck(diagFlag,iret,'ERROR: Uanble to place long_name attribute into feature_id variable')

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -41,6 +41,7 @@ MODULE module_Routing
    use module_rfc_forecasts, only: rfc_forecasts
    use module_hydro_stop, only: HYDRO_stop
    use hashtable
+   use iso_fortran_env, only: int64
 
    IMPLICIT NONE
 
@@ -997,7 +998,7 @@ subroutine LandRT_ini(did)
 
         endif  ! end if block for UDMP_OPT
 
-        new_start_i = 0; new_start_j = 1
+        new_start_i = 1; new_start_j = 1
         new_end_i = rt_domain(did)%ixrt; new_end_j = rt_domain(did)%jxrt
 
         if(left_id .ge. 0) new_start_i = 1
@@ -1018,7 +1019,7 @@ subroutine LandRT_ini(did)
 
         block
           type(hash_t) :: hash_table
-          integer :: val,ii,jj
+          integer(kind=int64) :: val,ii,jj
           logical :: found
           
           call hash_table%set_all_idx(rt_domain(did)%LLINKID, rt_domain(did)%LNLINKSL)

--- a/trunk/NDHMS/Routing/module_UDMAP.F
+++ b/trunk/NDHMS/Routing/module_UDMAP.F
@@ -26,14 +26,17 @@ module module_UDMAP
   use module_mpp_land, only: my_id, local_startx_rt, local_starty_rt,  &
        local_endx_rt,local_endy_rt, left_id, right_id, down_id, up_id, mpp_collect_1d_int_mem, &
        IO_id , numprocs
-  use module_mpp_land, only: mpp_land_bcast_int, mpp_land_bcast_real8_1d, mpp_land_bcast_int1
+  use module_mpp_land, only: mpp_land_bcast_int, mpp_land_bcast_real8_1d, mpp_land_bcast_int1, mpp_land_bcast_int8
   
   use module_mpp_land, only: sum_int1d, global_rt_nx, global_rt_ny, write_IO_rt_int, MPP_LAND_COM_INTEGER
   
   use MODULE_mpp_ReachLS, only : updatelinkv, ReachLS_write_io, com_write1dInt, &
-       com_decomp1dInt, pack_decomp_int, pack_decomp_real8
+       com_decomp1dInt, pack_decomp_int, pack_decomp_real8, &
+       com_decomp1dint8, pack_decomp_int8, com_write1dInt8
   use module_hydro_stop, only:HYDRO_stop
   use hashtable
+
+  use iso_fortran_env, only: int64
 #endif
 
   implicit none
@@ -48,7 +51,7 @@ type userDefineMapping
     integer, allocatable, dimension(:) :: grid_i, grid_j
     real, allocatable, dimension(:) :: weight, nodeArea, cellArea
     integer :: ngrids
-    integer :: myid
+    integer(kind=int64) :: myid
 !   for bucket model definition
     real, allocatable, dimension(:) :: cellWeight
     integer, allocatable, dimension(:) :: cell_i, cell_j
@@ -57,7 +60,7 @@ end type userDefineMapping
 
 TYPE ( userDefineMapping ), allocatable, DIMENSION (:) :: LUDRSL
 
-integer, allocatable, dimension(:) :: bufid
+integer(kind=int64), allocatable, dimension(:) :: bufid
 real*8 , allocatable, dimension(:) :: bufw
 integer :: LNUMRSL  ! number of local links
 integer :: ter_rt_flag
@@ -84,8 +87,8 @@ contains
     subroutine readUDMP(ixrt,jxrt,npid, nlinksl)
         implicit none
         integer :: i,j,Ndata, did, Npid, nlinksl, k, m, kk
-        integer,allocatable,dimension(:) :: g1bufid, gbufid, linkid ,bufidflag, &
-               bufid_tmp, nprocs_map, lnsizes, istart
+        integer,allocatable,dimension(:) ::  nprocs_map, lnsizes, istart
+        integer(kind=int64), allocatable, dimension(:) :: g1bufid, gbufid, linkid, bufid_tmp, bufidflag
         integer :: ix_bufid, ii, ixrt,jxrt
         integer, allocatable, dimension(:) :: gbufi,gbufj,bufsize
         real*8 , allocatable, dimension(:) :: gbufw
@@ -153,15 +156,15 @@ contains
 !      check  polyid and linkid
         allocate(linkid(nlinksl))
         if(my_id .eq. io_id) then
-            call get1d_int(trim(nlst(did)%route_link_f),"link",linkid)
+            call get1d_int64(trim(nlst(did)%route_link_f),"link",linkid)
             allocate(gbufid(npid))
-            call get1d_int(trim(nlst(did)%UDMAP_FILE),"polyid",gbufid)
+            call get1d_int64(trim(nlst(did)%UDMAP_FILE),"polyid",gbufid)
         endif
 #ifdef MPP_LAND
        if(nlinksl .gt. 0) then
-          call mpp_land_bcast_int(nlinksl,linkid)
+          call mpp_land_bcast_int8(nlinksl,linkid)
        endif
-       call com_decomp1dInt(gbufid,npid,bufid_tmp,ix_bufid)
+       call com_decomp1dInt8(gbufid,npid,bufid_tmp,ix_bufid)
 #endif
        if(ix_bufid .gt. 0) then
           allocate(bufidflag(ix_bufid))
@@ -181,7 +184,7 @@ contains
 
        block
          type(hash_t) :: hash_table
-         integer :: val,it
+         integer(kind=int64) :: val,it
          logical :: found
          
          call hash_table%set_all_idx(bufid_tmp, ix_bufid)
@@ -195,7 +198,7 @@ contains
        end block
 
 #ifdef MPP_LAND
-      call com_write1dInt(bufidflag,ix_bufid,gbufid,npid)
+      call com_write1dInt8(bufidflag,ix_bufid,gbufid,npid)
 #endif
       if(ix_bufid .gt. 0) then
           if(allocated(bufidflag)) deallocate(bufidflag)
@@ -224,7 +227,7 @@ contains
 
 
       if(lnsizes(my_id+1) .gt. 0) allocate(bufid(lnsizes(my_id+1) ))
-      call pack_decomp_int(g1bufid, ndata, nprocs_map, lnsizes, istart,bufid)
+      call pack_decomp_int8(g1bufid, ndata, nprocs_map, lnsizes, istart,bufid)
       if(my_id .eq. io_id) then 
             if(allocated(g1bufid)) deallocate(g1bufid)
       endif
@@ -510,6 +513,29 @@ contains
           iret = nf_get_var_int(ncid, varid, out_buff)
           iret = nf_close(ncid)
       end subroutine get1d_int
+
+    subroutine get1d_int64(fileName,var_name,out_buff)
+        implicit none
+        integer :: ivar, iret,varid,ncid
+        integer(kind=int64) out_buff(:)
+        character(len=*), intent(in) :: var_name
+        character(len=*), intent(in) :: fileName
+
+        iret = nf_open(trim(fileName), NF_NOWRITE, ncid)
+        if (iret .ne. 0) then
+            print*,"FATAL ERROR: Failed to open the netcdf file: ",trim(fileName)
+            call hydro_stop("In get1d_int() -  Failed to open the netcdf file")
+            return
+        endif
+        ivar = nf_inq_varid(ncid,trim(var_name),  varid)
+        if(ivar .ne. 0) then
+            write(6,*) "Read Variable Error file: ",trim(fileName)
+            write(6,*) "Read Error: could not find ",trim(var_name)
+            call hydro_stop("In get1d_int() - failed to read netcdf variable name.")
+        end if
+        iret = nf_get_var_int64(ncid, varid, out_buff)
+        iret = nf_close(ncid)
+    end subroutine get1d_int64
 
       subroutine getUDMP_area(cell_area)
          implicit none

--- a/trunk/NDHMS/Routing/module_channel_routing.F
+++ b/trunk/NDHMS/Routing/module_channel_routing.F
@@ -30,6 +30,8 @@ use module_reservoir, only: reservoir
 use module_RT_data, only: rt_domain
 use module_hydro_stop, only: HYDRO_stop
 
+use iso_fortran_env, only: int64
+
 #endif
 implicit none
 
@@ -174,7 +176,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
         REAL, intent(IN)       :: n          ! mannings coefficient
         REAL, intent(INOUT)    :: vel        ! velocity (m/s)
         REAL, intent(INOUT)    :: qloss      ! channel infiltration (m^3/sec)
-        INTEGER, intent(IN)    :: idx        ! channel id
+        integer(kind=int64), intent(IN)    :: idx        ! channel id
         REAL, intent(INOUT)    :: depth      ! depth of flow in channel
 
 !--local variables
@@ -318,8 +320,8 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
             if(D .eq. 0.0) then
               print *, "FATAL ERROR: D is 0 in MUSKINGCUNGE", Km, X, dt,D
               call hydro_stop("In MUSKINGCUNGE() - D is 0.")
-           endif 
- 
+           endif
+
 
            C1 =  (Km*X + dt/2.000000)/D
            C2 =  (dt/2.0000 - Km*X)/D
@@ -523,7 +525,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
 
       qloss = (ChannK * dx * WPk) ! TML -- Compute qloss to pass
 
-      !TML:Added print statement to test qlos function; 
+      !TML:Added print statement to test qlos function;
       !comment out to prevent excessive file sizes when running model
       !print*, "qloss,dx,WP,WPk,depth,ChannK,qdc,ql,dt,D", qloss,dx,WP,WPk,depth,ChannK,qdc,ql,dt,D
       if((qloss*dt)/D > ((ql*dt)/D - C4)) then
@@ -589,17 +591,17 @@ END SUBROUTINE SUBMUSKINGCUNGE
         REAL, INTENT(IN), DIMENSION(IXRT,JXRT)    :: LAKEINFLORT
         REAL, INTENT(IN), DIMENSION(IXRT,JXRT)    :: ELRT
         REAL, INTENT(IN), DIMENSION(IXRT,JXRT)    :: QINFLOWBASE
-        INTEGER, INTENT(IN), DIMENSION(IXRT,JXRT) :: CH_NETLNK
+        INTEGER(kind=int64), INTENT(IN), DIMENSION(IXRT,JXRT) :: CH_NETLNK
 
         INTEGER, INTENT(IN), DIMENSION(IXRT,JXRT) :: CH_NETRT
-        INTEGER, INTENT(IN), DIMENSION(IXRT,JXRT) :: CH_LNKRT
-        INTEGER, INTENT(IN), DIMENSION(IXRT,JXRT) :: CH_LNKRT_SL
+        INTEGER(kind=int64), INTENT(IN), DIMENSION(IXRT,JXRT) :: CH_LNKRT
+        INTEGER(kind=int64), INTENT(IN), DIMENSION(IXRT,JXRT) :: CH_LNKRT_SL
 
        real , dimension(ixrt,jxrt):: latval,lonval
 
         INTEGER, INTENT(IN), DIMENSION(IXRT,JXRT) :: LAKE_MSKRT
         INTEGER, INTENT(IN), DIMENSION(NLINKS)    :: ORDER, TYPEL !--link
-        INTEGER, INTENT(IN), DIMENSION(NLINKS)    :: TO_NODE, FROM_NODE
+        INTEGER(kind=int64), INTENT(IN), DIMENSION(NLINKS)    :: TO_NODE, FROM_NODE
         INTEGER, INTENT(IN), DIMENSION(NLINKS)    :: CHANXI, CHANYJ
         REAL,    INTENT(IN), DIMENSION(NLINKS)    :: ZELEV  !--elevation of nodes
         REAL, INTENT(INOUT), DIMENSION(NLINKS)    :: CVOL
@@ -642,8 +644,8 @@ END SUBROUTINE SUBMUSKINGCUNGE
         REAL, INTENT(INOUT), DIMENSION(NLAKES)    :: QLAKEI   !-- lake inflow (cms)
         REAL,                DIMENSION(NLAKES)    :: QLAKEIP  !-- lake inflow previous timestep (cms)
         REAL, INTENT(INOUT), DIMENSION(NLAKES)    :: QLAKEO   !-- outflow from lake used in diffusion scheme
-        INTEGER, INTENT(IN), DIMENSION(NLINKS)    :: LAKENODE !-- outflow from lake used in diffusion scheme
-        INTEGER, INTENT(IN), DIMENSION(NLINKS)    :: LINKID   !--  id of channel elements for linked scheme
+        INTEGER(kind=int64), INTENT(IN), DIMENSION(NLINKS)    :: LAKENODE !-- outflow from lake used in diffusion scheme
+        INTEGER(kind=int64), INTENT(IN), DIMENSION(NLINKS)    :: LINKID   !--  id of channel elements for linked scheme
         !REAL, DIMENSION(NLINKS)                   :: QLateral !--lateral flow
         REAL, DIMENSION(NLINKS)                   :: QSUM     !--mass bal of node
         REAL*8, DIMENSION(NLINKS)                   :: QSUM8     !--mass bal of node
@@ -666,14 +668,14 @@ END SUBROUTINE SUBMUSKINGCUNGE
         integer lake_index(nlakes)
         integer nlinks_index(nlinks)
         integer mpp_nlinks, iyw, yw_mpp_nlinks
-        integer link_location(ixrt,jxrt)
+        integer(kind=int64) link_location(ixrt,jxrt)
         real     ywtmp(ixrt,jxrt)
         integer LNLINKSL
-        integer, dimension(LNLINKSL) :: LLINKID
+        integer(kind=int64), dimension(LNLINKSL) :: LLINKID
         real*8,  dimension(LNLINKSL) :: LQLateral
 !        real*4,  dimension(LNLINKSL) :: LQLateral
         integer, dimension(:) ::  toNodeInd
-        integer, dimension(:,:) ::  gtoNode
+        integer(kind=int64), dimension(:,:) ::  gtoNode
         integer  :: nToNodeInd
         real, dimension(nToNodeInd,2) :: gQLINK
 #else
@@ -1633,12 +1635,12 @@ end subroutine drive_CHANNEL
        real, intent(IN), dimension(IXRT,JXRT)    :: QINFLOWBASE
        real, dimension(ixrt,jxrt) :: landRunOff
 
-       integer, intent(IN), dimension(IXRT,JXRT) :: CH_LNKRT
-       integer, intent(IN), dimension(IXRT,JXRT) :: CH_LNKRT_SL
+       integer(kind=int64), intent(IN), dimension(IXRT,JXRT) :: CH_LNKRT
+       integer(kind=int64), intent(IN), dimension(IXRT,JXRT) :: CH_LNKRT_SL
 
        integer, intent(IN), dimension(IXRT,JXRT) :: LAKE_MSKRT
        integer, intent(IN), dimension(:)         :: ORDER, TYPEL !--link
-       integer, intent(IN), dimension(:)     :: TO_NODE, FROM_NODE
+       integer(kind=int64), intent(in), dimension(:)     :: TO_NODE, FROM_NODE
        integer, intent(IN), dimension(:)     :: CHANXI, CHANYJ
        real, intent(IN), dimension(:)        :: MUSK, MUSX
        real, intent(IN), dimension(:)        :: CHANLEN
@@ -1674,16 +1676,16 @@ end subroutine drive_CHANNEL
        real, dimension(IXRT,JXRT)                :: ZWATTBLRT          !DJG !!! Match with subsfce/gw routing & Change 'INTENT' to 'INOUT' when ready to update groundwater state...
 
        !-- lake params
-       integer, intent(IN), dimension(:)    :: LAKEIDM  !-- NHDPLUS lakeid for lakes to be modeled
+       integer(kind=int64), intent(IN), dimension(:)    :: LAKEIDM  !-- NHDPLUS lakeid for lakes to be modeled
 
        real, intent(INOUT), dimension(:)    :: RESHT    !-- reservoir height (m)
        real, intent(INOUT), dimension(:)    :: QLAKEI   !-- lake inflow (cms)
        real,                dimension(NLAKES)    :: QLAKEIP  !-- lake inflow previous timestep (cms)
        real, intent(INOUT), dimension(NLAKES)    :: QLAKEO   !-- outflow from lake used in diffusion scheme
 
-       integer, intent(IN), dimension(:)    :: LAKENODE !-- outflow from lake used in diffusion scheme
-       integer, intent(IN), dimension(:)   :: LINKID   !--  id of channel elements for linked scheme
-       integer, intent(IN), dimension(:)   :: LAKEIDA  !--  (don't need) NHDPLUS lakeid for all lakes in domain
+       integer(kind=int64), intent(IN), dimension(:)    :: LAKENODE !-- outflow from lake used in diffusion scheme
+       integer(kind=int64), intent(IN), dimension(:)   :: LINKID   !--  id of channel elements for linked scheme
+       integer(kind=int64), intent(IN), dimension(:)   :: LAKEIDA  !--  (don't need) NHDPLUS lakeid for all lakes in domain
        integer, intent(IN), dimension(:)   :: LAKEIDX  !--  the sequential index of the lakes id by com id
 
        real, dimension(NLINKS)                   :: QSUM     !--mass bal of node
@@ -1711,7 +1713,7 @@ end subroutine drive_CHANNEL
        real     ywtmp(ixrt,jxrt)
        integer LNLINKSL
        integer, dimension(:)         ::  toNodeInd
-       integer, dimension(:,:)       ::  gtoNode
+       integer(kind=int64), dimension(:,:)       ::  gtoNode
        integer  :: nToNodeInd
        real, dimension(nToNodeInd,2) :: gQLINK
 #else


### PR DESCRIPTION
TYPE: enchantment

KEYWORDS: nhd,reach,hydrofabric

SOURCE: Ryan@NCAR

DESCRIPTION OF CHANGES: In order to support the new NHDPlus High Resolution dataset that uses large-integer IDs, the routing and lake code required updates to use 64-bit integers internally.

TESTS CONDUCTED: Extensive testing with Alaska NWM domain

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [X] Backwards compatible
 - [-] Requires new files? _Supports new 64-bit RouteLink, but does not require it_
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
