### PR TITLE
Fix bug in forcing LAI read dims. Minor updates to VEGFRA read.

### DIFF
--- a/trunk/NDHMS/Routing/module_lsm_forcing.F
+++ b/trunk/NDHMS/Routing/module_lsm_forcing.F
@@ -79,7 +79,7 @@ Contains
     call get_2d_netcdf_ruc("RAINNC", ncid, pcp,   ix, jx,tlevel, .true., ierr)
     call get_2d_netcdf_ruc("VEGFRA", ncid, fpar,  ix, jx,tlevel, .true., ierr)
     if(ierr == 0) then
-        if(maxval(fpar) .gt. 10 .and. (maxval(fpar) .lt. 10000) ) fpar = fpar/100.
+        if(maxval(fpar) .gt. 10 .and. (maxval(fpar) .lt. 10000) ) fpar = fpar*0.01
     endif
     call get_2d_netcdf_ruc("LAI", ncid, lai,  ix, jx,tlevel, .true., ierr)
 
@@ -2793,7 +2793,7 @@ end subroutine read_hydro_forcing_mpp1
     endif
     call mpp_land_bcast_int1(ierr)
     if(ierr == 0) call decompose_data_real (buf2,fpar)
-    if(my_id .eq. io_id ) call get_2d_netcdf("LAI",     ncid, buf2,   units, ix, jx, .FALSE., ierr)
+    if(my_id .eq. io_id ) call get_2d_netcdf("LAI",     ncid, buf2,   units, global_nx, global_ny, .FALSE., ierr)
     call mpp_land_bcast_int1(ierr)
     if(ierr == 0) call decompose_data_real (buf2,lai)
 
@@ -2882,8 +2882,10 @@ end subroutine read_hydro_forcing_mpp1
     call mpp_land_bcast_int1(ierr)
     if(ierr == 0) call decompose_data_real (buf2,lai)
     if(my_id .eq. io_id) then
-       call get_2d_netcdf_ruc("VEGFRA", ncid, fpar,  ix, jx,tlevel, .true., ierr)
-       if(maxval(fpar) .gt. 10 .and. (maxval(fpar) .lt. 10000) ) fpar = fpar/100.
+       call get_2d_netcdf_ruc("VEGFRA", ncid, buf2, global_nx, global_ny, tlevel, .true., ierr)
+       if(ierr == 0) then
+          if(maxval(buf2) .gt. 10 .and. maxval(buf2) .lt. 10000)  buf2 = buf2 * 1.E-2
+       endif
     endif
     call mpp_land_bcast_int1(ierr)
     if(ierr == 0) call decompose_data_real (buf2,fpar)
@@ -2907,7 +2909,7 @@ end subroutine read_hydro_forcing_mpp1
     call get_2d_netcdf_ruc("RAINNC", ncid, pcp,   ix, jx,tlevel, .true., ierr)
     call get_2d_netcdf_ruc("VEGFRA", ncid, fpar,  ix, jx,tlevel, .false., ierr)
     if(ierr == 0) then
-        if(maxval(fpar) .gt. 10 .and. (maxval(fpar) .lt. 10000) ) fpar = fpar/100.
+        if(maxval(fpar) .gt. 10 .and. (maxval(fpar) .lt. 10000) ) fpar = fpar * 0.01
     endif
     call get_2d_netcdf_ruc("LAI", ncid, lai,  ix, jx,tlevel, .false., ierr)
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: forcings, lai, vegfra

SOURCE: Aubrey D, NCAR

DESCRIPTION OF CHANGES: Read of LAI var from HRLDAS forcings was using wrong dim specs. Fixed. Also reviewed the similar VEGFRA reads and fixed a few inconsistencies, but likely never triggered in common model configs.

TESTS CONDUCTED: CONUS and small basin tests with LAI in forcing files now behave as expected. Confirmed LAI in output matches forcings. No change in standard DVEG=4 or no LAI forcing configs.

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [x] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
