### PR TITLE
Revert mismatched minimum slope limit.

### DIFF
--- a/trunk/NDHMS/Routing/module_HYDRO_io.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_io.F
@@ -9007,8 +9007,8 @@ call get_1d_netcdf_real(ncid, 'MusX',     MUSX,      'read_route_link_netcdf', .
 call get_1d_netcdf_real(ncid, 'Length',   CHANLEN,   'read_route_link_netcdf', .TRUE.)
 call get_1d_netcdf_real(ncid, 'n',        MannN,     'read_route_link_netcdf', .TRUE.)
 call get_1d_netcdf_real(ncid, 'So',       So,        'read_route_link_netcdf', .TRUE.)
-!! impose a minimum as this sometimes fails in the file. LKR changed to 10^-4 on 2/2018.
-where(So .lt. 0.0001) So=0.00001
+!! impose a minimum as this sometimes fails in the file. 
+where(So .lt. 0.00001) So=0.00001
 call get_1d_netcdf_real(ncid, 'ChSlp',    ChSSlp,    'read_route_link_netcdf', .TRUE.)
 call get_1d_netcdf_real(ncid, 'BtmWdth',  Bw,        'read_route_link_netcdf', .TRUE.)
 !! Loads channel infiltration, by default is zero, my need to add namelist option in future


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: channel

SOURCE: Aubrey D, NCAR 

DESCRIPTION OF CHANGES: Reverting mismatched min slope setting back to original formulation. Answer changing if reach slopes < 1e-4 exist in domain.

ISSUE: Fixes #591 

TESTS CONDUCTED: Tested over CONUS NWM for 1 year. Results as expected - small differences in certain reaches.

### Checklist
 - [x] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [x] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
