### PR TITLE
Channel NaN fixes for Muskingum-Cunge

### DIFF
--- a/trunk/NDHMS/Routing/module_channel_routing.F
+++ b/trunk/NDHMS/Routing/module_channel_routing.F
@@ -266,7 +266,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
 
            Twl = Bw + 2.0*z*h_0      !--top surface water width of the channel inflow
 
-            if( (h_0 .gt. bfd) .and. (TwCC .gt.0.0) .and. (nCC .gt.0) ) then !water outside of defined channel
+            if ( (h_0 .gt. bfd) .and. (TwCC .gt. 0.0) .and. (nCC .gt. 0.0) ) then !water outside of defined channel
              AREA =  (Bw + bfd * z) * bfd
              AREAC = (TwCC * (h_0 -bfd)) !assume compound component is rect. chan, that's 3 times the Tw
              WP = (Bw + 2.0 * bfd * sqrt(1.0 + z*z))
@@ -285,10 +285,9 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
 
             endif
 
-          if( (h_0 .gt. bfd) .and. (TwCC .gt.0.0) .and. (nCC .gt.0) ) then !water outside of defined channel
+          if ( (h_0 .gt. bfd) .and. (TwCC .gt. 0.0) .and. (nCC .gt. 0.0) ) then !water outside of defined channel
             !weight the celerity by the contributing area, and assume that the mannings
             !of the spills is 2x the manning of the channel
-            if (nCC <= 0.0) print *, "ADCHECK_CC1: nCC TwCC h_0 bfd", nCC, TwCC, h_0, bfd
                 Ck = max(0.0,((sqrt(So)/n)*((5./3.)*R**(2./3.) - &
                 ((2./3.)*R**(5./3.)*(2.0*sqrt(1.0 + z*z)/(Bw+2.0*bfd*z))))*AREA &
                 + ((sqrt(So)/(nCC))*(5./3.)*(h_0-bfd)**(2./3.))*AREAC)/(AREA+AREAC))
@@ -307,8 +306,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
             Km = dt
           endif
 
-          if( (h_0 .gt. bfd)  .and. (TwCC .gt.0.0) .and. (nCC .gt.0) ) then !water outside of defined channel
-             if (nCC <= 0.0) print *, "ADCHECK_CC2: nCC TwCC h_0 bfd", nCC, TwCC, h_0, bfd
+          if ( (h_0 .gt. bfd) .and. (TwCC .gt. 0.0) .and. (nCC .gt. 0.0) ) then !water outside of defined channel
              X = min(0.5,max(0.0,0.5*(1-(Qj_0/(2.0*TwCC*So*Ck*dx)))))
           else
             if(Ck .gt. 0.0) then
@@ -353,8 +351,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
 
            Twl = Bw + 2.0*z*h                    !--top width of the channel inflow
 
-           if( (h .gt. bfd) .and. (TwCC .gt.0.0) .and. (nCC .gt.0) ) then !water outside of defined channel
-             if (nCC <= 0.0) print *, "ADCHECK_CC3: nCC TwCC h bfd", nCC, TwCC, h, bfd
+           if ( (h .gt. bfd) .and. (TwCC .gt. 0.0) .and. (nCC .gt. 0.0) ) then !water outside of defined channel
              AREA =  (Bw + bfd * z) * bfd
              AREAC = (TwCC * (h-bfd)) !assume compound component is rect. chan, that's 3 times the Tw
              WP = (Bw + 2.0 * bfd * sqrt(1.0 + z*z))
@@ -373,8 +370,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
               endif
            endif
 
-          if( (h .gt. bfd) .and. (TwCC .gt.0.0) .and. (nCC .gt.0) ) then !water outside of defined channel, assumed rectangular, 3x TW and n = 3x
-                if (nCC <= 0.0) print *, "ADCHECK_CC4: nCC TwCC h bfd", nCC, TwCC, h, bfd
+          if ( (h .gt. bfd) .and. (TwCC .gt. 0.0) .and. (nCC .gt. 0.0) ) then !water outside of defined channel, assumed rectangular, 3x TW and n = 3x
                 Ck = max(0.0,((sqrt(So)/n)*((5./3.)*R**(2./3.) - &
                 ((2./3.)*R**(5./3.)*(2.0*sqrt(1.0 + z*z)/(Bw + 2.0*bfd*z))))*AREA &
                 + ((sqrt(So)/(nCC))*(5./3.)*(h-bfd)**(2./3.))*AREAC)/(AREA+AREAC))
@@ -391,8 +387,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
            else
             Km = dt
            endif
-          if( (h .gt. bfd) .and. (TwCC .gt.0.0) .and. (nCC .gt.0) ) then !water outside of defined channel
-            if (nCC <= 0.0) print *, "ADCHECK_CC5: nCC TwCC h bfd", nCC, TwCC, h, bfd
+          if ( (h .gt. bfd) .and. (TwCC .gt. 0.0) .and. (nCC .gt. 0.0) ) then !water outside of defined channel
             X = min(0.5,max(0.25,0.5*(1-(((C1*qup)+(C2*quc)+(C3*qdp) + C4)/(2.0*TwCC*So*Ck*dx)))))
 
           else

--- a/trunk/NDHMS/Routing/module_channel_routing.F
+++ b/trunk/NDHMS/Routing/module_channel_routing.F
@@ -306,7 +306,8 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
             Km = dt
           endif
 
-          if ( (h_0 .gt. bfd) .and. (TwCC .gt. 0.0) .and. (nCC .gt. 0.0) ) then !water outside of defined channel
+          if ( (h_0 .gt. bfd) .and. (TwCC .gt. 0.0) .and. (nCC .gt. 0.0) .and. (Ck .gt. 0.0) ) then 
+          !water outside of defined channel
              X = min(0.5,max(0.0,0.5*(1-(Qj_0/(2.0*TwCC*So*Ck*dx)))))
           else
             if(Ck .gt. 0.0) then
@@ -321,7 +322,6 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
               print *, "FATAL ERROR: D is 0 in MUSKINGCUNGE", Km, X, dt,D
               call hydro_stop("In MUSKINGCUNGE() - D is 0.")
            endif
-
 
            C1 =  (Km*X + dt/2.000000)/D
            C2 =  (dt/2.0000 - Km*X)/D
@@ -343,7 +343,6 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
                     (AREA+AREAC) * (R**(2./3.)) * sqrt(So)) !f0(x)
            endif
 !           WPk = WP*MIN((h/(modK*SQRT(Bw))),1.0)  ! KINEROS2 Mod. This shouldn't be HERE.
-
 
            !--upper interval -----------
            WPC    = 0.0
@@ -370,7 +369,8 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
               endif
            endif
 
-          if ( (h .gt. bfd) .and. (TwCC .gt. 0.0) .and. (nCC .gt. 0.0) ) then !water outside of defined channel, assumed rectangular, 3x TW and n = 3x
+          if ( (h .gt. bfd) .and. (TwCC .gt. 0.0) .and. (nCC .gt. 0.0) ) then
+          !water outside of defined channel, assumed rectangular, 3x TW and n = 3x
                 Ck = max(0.0,((sqrt(So)/n)*((5./3.)*R**(2./3.) - &
                 ((2./3.)*R**(5./3.)*(2.0*sqrt(1.0 + z*z)/(Bw + 2.0*bfd*z))))*AREA &
                 + ((sqrt(So)/(nCC))*(5./3.)*(h-bfd)**(2./3.))*AREAC)/(AREA+AREAC))
@@ -382,22 +382,22 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
                  Ck = 0.0
                endif
           endif
+
            if(Ck .gt. 0.0) then
             Km = max(dt,dx/Ck)
            else
             Km = dt
            endif
-          if ( (h .gt. bfd) .and. (TwCC .gt. 0.0) .and. (nCC .gt. 0.0) ) then !water outside of defined channel
+
+          if ( (h .gt. bfd) .and. (TwCC .gt. 0.0) .and. (nCC .gt. 0.0) .and. (Ck .gt. 0.0) ) then
+          !water outside of defined channel
             X = min(0.5,max(0.25,0.5*(1-(((C1*qup)+(C2*quc)+(C3*qdp) + C4)/(2.0*TwCC*So*Ck*dx)))))
-
           else
-
             if(Ck .gt. 0.0) then
              X = min(0.5,max(0.25,0.5*(1-(((C1*qup)+(C2*quc)+(C3*qdp) + C4)/(2.0*Twl*So*Ck*dx)))))
             else
              X = 0.5
             endif
-
           endif
 
            D = (Km*(1 - X) + dt/2)              !--seconds

--- a/trunk/NDHMS/Routing/module_channel_routing.F
+++ b/trunk/NDHMS/Routing/module_channel_routing.F
@@ -288,6 +288,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
           if(h_0 .gt. bfd) then !water outside of defined channel
             !weight the celerity by the contributing area, and assume that the mannings
             !of the spills is 2x the manning of the channel
+            if (nCC <= 0.0) print *, "ADCHECK_CC1: nCC TwCC h_0 bfd", nCC, TwCC, h_0, bfd
                 Ck = max(0.0,((sqrt(So)/n)*((5./3.)*R**(2./3.) - &
                 ((2./3.)*R**(5./3.)*(2.0*sqrt(1.0 + z*z)/(Bw+2.0*bfd*z))))*AREA &
                 + ((sqrt(So)/(nCC))*(5./3.)*(h_0-bfd)**(2./3.))*AREAC)/(AREA+AREAC))
@@ -307,6 +308,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
           endif
 
           if(h_0 .gt. bfd) then !water outside of defined channel
+             if (nCC <= 0.0) print *, "ADCHECK_CC2: nCC TwCC h_0 bfd", nCC, TwCC, h_0, bfd
              X = min(0.5,max(0.0,0.5*(1-(Qj_0/(2.0*TwCC*So*Ck*dx)))))
           else
             if(Ck .gt. 0.0) then
@@ -352,6 +354,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
            Twl = Bw + 2.0*z*h                    !--top width of the channel inflow
 
            if(h .gt. bfd) then !water outside of defined channel
+             if (nCC <= 0.0) print *, "ADCHECK_CC3: nCC TwCC h bfd", nCC, TwCC, h, bfd
              AREA =  (Bw + bfd * z) * bfd
              AREAC = (TwCC * (h-bfd)) !assume compound component is rect. chan, that's 3 times the Tw
              WP = (Bw + 2.0 * bfd * sqrt(1.0 + z*z))
@@ -371,6 +374,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
            endif
 
           if(h .gt. bfd) then !water outside of defined channel, assumed rectangular, 3x TW and n = 3x
+                if (nCC <= 0.0) print *, "ADCHECK_CC4: nCC TwCC h bfd", nCC, TwCC, h, bfd
                 Ck = max(0.0,((sqrt(So)/n)*((5./3.)*R**(2./3.) - &
                 ((2./3.)*R**(5./3.)*(2.0*sqrt(1.0 + z*z)/(Bw + 2.0*bfd*z))))*AREA &
                 + ((sqrt(So)/(nCC))*(5./3.)*(h-bfd)**(2./3.))*AREAC)/(AREA+AREAC))
@@ -388,6 +392,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
             Km = dt
            endif
           if(h .gt. bfd) then !water outside of defined channel
+            if (nCC <= 0.0) print *, "ADCHECK_CC5: nCC TwCC h bfd", nCC, TwCC, h, bfd
             X = min(0.5,max(0.25,0.5*(1-(((C1*qup)+(C2*quc)+(C3*qdp) + C4)/(2.0*TwCC*So*Ck*dx)))))
 
           else

--- a/trunk/NDHMS/Routing/module_channel_routing.F
+++ b/trunk/NDHMS/Routing/module_channel_routing.F
@@ -266,7 +266,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
 
            Twl = Bw + 2.0*z*h_0      !--top surface water width of the channel inflow
 
-            if(h_0 .gt. bfd) then !water outside of defined channel
+            if( (h_0 .gt. bfd) .and. (TwCC .gt.0.0) .and. (nCC .gt.0) ) then !water outside of defined channel
              AREA =  (Bw + bfd * z) * bfd
              AREAC = (TwCC * (h_0 -bfd)) !assume compound component is rect. chan, that's 3 times the Tw
              WP = (Bw + 2.0 * bfd * sqrt(1.0 + z*z))
@@ -285,7 +285,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
 
             endif
 
-          if(h_0 .gt. bfd) then !water outside of defined channel
+          if( (h_0 .gt. bfd) .and. (TwCC .gt.0.0) .and. (nCC .gt.0) ) then !water outside of defined channel
             !weight the celerity by the contributing area, and assume that the mannings
             !of the spills is 2x the manning of the channel
             if (nCC <= 0.0) print *, "ADCHECK_CC1: nCC TwCC h_0 bfd", nCC, TwCC, h_0, bfd
@@ -307,7 +307,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
             Km = dt
           endif
 
-          if(h_0 .gt. bfd) then !water outside of defined channel
+          if( (h_0 .gt. bfd)  .and. (TwCC .gt.0.0) .and. (nCC .gt.0) ) then !water outside of defined channel
              if (nCC <= 0.0) print *, "ADCHECK_CC2: nCC TwCC h_0 bfd", nCC, TwCC, h_0, bfd
              X = min(0.5,max(0.0,0.5*(1-(Qj_0/(2.0*TwCC*So*Ck*dx)))))
           else
@@ -353,7 +353,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
 
            Twl = Bw + 2.0*z*h                    !--top width of the channel inflow
 
-           if(h .gt. bfd) then !water outside of defined channel
+           if( (h .gt. bfd) .and. (TwCC .gt.0.0) .and. (nCC .gt.0) ) then !water outside of defined channel
              if (nCC <= 0.0) print *, "ADCHECK_CC3: nCC TwCC h bfd", nCC, TwCC, h, bfd
              AREA =  (Bw + bfd * z) * bfd
              AREAC = (TwCC * (h-bfd)) !assume compound component is rect. chan, that's 3 times the Tw
@@ -373,7 +373,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
               endif
            endif
 
-          if(h .gt. bfd) then !water outside of defined channel, assumed rectangular, 3x TW and n = 3x
+          if( (h .gt. bfd) .and. (TwCC .gt.0.0) .and. (nCC .gt.0) ) then !water outside of defined channel, assumed rectangular, 3x TW and n = 3x
                 if (nCC <= 0.0) print *, "ADCHECK_CC4: nCC TwCC h bfd", nCC, TwCC, h, bfd
                 Ck = max(0.0,((sqrt(So)/n)*((5./3.)*R**(2./3.) - &
                 ((2./3.)*R**(5./3.)*(2.0*sqrt(1.0 + z*z)/(Bw + 2.0*bfd*z))))*AREA &
@@ -391,7 +391,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
            else
             Km = dt
            endif
-          if(h .gt. bfd) then !water outside of defined channel
+          if( (h .gt. bfd) .and. (TwCC .gt.0.0) .and. (nCC .gt.0) ) then !water outside of defined channel
             if (nCC <= 0.0) print *, "ADCHECK_CC5: nCC TwCC h bfd", nCC, TwCC, h, bfd
             X = min(0.5,max(0.25,0.5*(1-(((C1*qup)+(C2*quc)+(C3*qdp) + C4)/(2.0*TwCC*So*Ck*dx)))))
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: channel, streamflow, muskingum-cunge

SOURCE: Aubrey D, NCAR

DESCRIPTION OF CHANGES: Add extra checks to prevent divide by 0 in Muskingum-Cunge solution. With @dnyates.

ISSUE: #598 

TESTS CONDUCTED: Tested NWM-CONUS for 2 years with v3.0 draft channel parameters, including 0 compound channel width reaches. No NaNs occurred after fixes.

NOTES: May pass regression with standard channel parameters. 


### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [x] Closes issue #598 (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [n/a] Tests added (unit tests and/or regression/integration tests)
 - [x] Backwards compatible
 - [n/a] Requires new files? If so, how to generate them.
 - [n/a] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
