### PR TITLE
Update WRF coupler to recent MPP_LAND_INIT changes

### DIFF
--- a/trunk/NDHMS/CPL/WRF_cpl/module_wrf_HYDRO.F
+++ b/trunk/NDHMS/CPL/WRF_cpl/module_wrf_HYDRO.F
@@ -22,10 +22,11 @@
 module module_WRF_HYDRO
 
 #ifdef MPP_LAND
+    use mpi
     use module_mpp_land, only: global_nx, global_ny, decompose_data_real, &
                  write_io_real, my_id, mpp_land_bcast_real1, IO_id, &
                 mpp_land_bcast_real, mpp_land_bcast_int1, mpp_land_init
-    use module_CPL_LAND, only: CPL_LAND_INIT, cpl_outdate
+    use module_CPL_LAND, only: CPL_LAND_INIT, cpl_outdate, HYDRO_COMM_WORLD
     use module_hydro_stop, only: HYDRO_stop
 #endif
     use module_HYDRO_drv, only: HYDRO_ini, HYDRO_exe
@@ -77,6 +78,7 @@ CONTAINS
 
         integer :: i,j
         
+        integer :: ierr
 
 !output flux and state variable
 
@@ -98,15 +100,15 @@ CONTAINS
 
   
         if(.not. RT_DOMAIN(did)%initialized) then
-           
-           call MPP_LAND_INIT()
-
            !yw nlst_rt(did)%nsoil = config_flags%num_soil_layers
            !nlst_rt(did)%nsoil = model_config_rec%num_metgrid_soil_levels
            nlst(did)%nsoil = grid%num_soil_layers
 
          
 #ifdef MPP_LAND
+           call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
+           call MPP_LAND_INIT(grid%e_we - grid%s_we - 1, grid%e_sn - grid%s_sn - 1)
+
            call mpp_land_bcast_int1 (nlst(did)%nsoil)
 #endif
            allocate(nlst(did)%zsoil8(nlst(did)%nsoil))


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: coupled, MPP

SOURCE: Ryan @ NCAR

DESCRIPTION OF CHANGES: 

Updates `WRF_cpl/module_wrf_HYDRO.F` to use the new `MPP_LAND_INIT(global_nx, global_ny)` initializer in mpp_land.F so that coupled model can run without crashing.  Also copies the WRF-supplied MPI_COMM_WORLD to HYDRO_COMM_WORLD, since MPP assumes that MPI has already been initialized and skips this step.

TESTS CONDUCTED: 

Ran WRF-Hydro Front Range Coupled Test Case and output was reasonable (no regression test for this case)

NOTES:

The code compiled originally due to the `in_global_nx` and `in_global_ny` arguments being marked as `optional`, but then caused a crash by being assigned to module variables at runtime. If the parameters can be optional, additional code should be added to handle the not-present case.
