### PR TITLE
Expose NEXP parameter

### DIFF
--- a/trunk/NDHMS/Data_Rec/rt_include.inc
+++ b/trunk/NDHMS/Data_Rec/rt_include.inc
@@ -243,6 +243,7 @@
       INTEGER, allocatable, DIMENSION(:,:)   :: VEGTYP
       REAL, allocatable, DIMENSION(:,:)      :: OV_ROUGH2d
       !REAL,    allocatable, DIMENSION(:)   :: SLDPTH
+      REAL,    allocatable, DIMENSION(:,:)   :: NEXP
 
 !!! define constant/parameter
     real ::   ov_rough(50)!, ZSOIL(100) ! ZSOIL moved to subsurface properties module

--- a/trunk/NDHMS/Routing/Noah_distr_routing.F
+++ b/trunk/NDHMS/Routing/Noah_distr_routing.F
@@ -887,6 +887,7 @@ subroutine disaggregateDomain_drv(did)
                             RT_DOMAIN(did)%INFXSRT, rt_domain(did)%dist_lsm(:,:,9), &
                             RT_DOMAIN(did)%SMCMAX1, RT_DOMAIN(did)%SMCREF1, &
                             RT_DOMAIN(did)%SMCWLT1, RT_DOMAIN(did)%VEGTYP, RT_DOMAIN(did)%LKSAT, &
+                            RT_DOMAIN(did)%NEXP, &
                             rt_domain(did)%overland%properties%distance_to_neighbor, &
                             RT_DOMAIN(did)%INFXSWGT, &
                             RT_DOMAIN(did)%OVROUGHRTFAC,RT_DOMAIN(did)%LKSATFAC, &
@@ -900,6 +901,7 @@ subroutine disaggregateDomain_drv(did)
                             rt_domain(did)%overland%properties%roughness, &
                             rt_domain(did)%overland%streams_and_lakes%lake_mask, &
                             rt_domain(did)%subsurface%properties%lksatrt, &
+                            rt_domain(did)%subsurface%properties%nexprt, &
                             RT_DOMAIN(did)%OV_ROUGH2d, &
                             RT_DOMAIN(did)%subsurface%properties%sldpth, &
                             RT_DOMAIN(did)%soiltypRT, RT_DOMAIN(did)%soiltyp, &
@@ -924,9 +926,9 @@ end subroutine disaggregateDomain_drv
 !===================================================================================================
 subroutine disaggregateDomain(IX, JX, NSOIL, IXRT, JXRT, AGGFACTRT, &
                               SICE, SMC, SH2OX, INFXSRT, area_lsm, SMCMAX1, SMCREF1, &
-                              SMCWLT1, VEGTYP, LKSAT, dist,INFXSWGT,OVROUGHRTFAC, &
+                              SMCWLT1, VEGTYP, LKSAT, NEXP, dist,INFXSWGT,OVROUGHRTFAC, &
                               LKSATFAC, CH_NETRT,SH2OWGT,SMCREFRT, INFXSUBRT,SMCMAXRT, &
-                              SMCWLTRT,SMCRT, OVROUGHRT, LAKE_MSKRT, LKSATRT, OV_ROUGH2d,  &
+                              SMCWLTRT,SMCRT, OVROUGHRT, LAKE_MSKRT, LKSATRT, NEXPRT, OV_ROUGH2d,  &
                               SLDPTH, soiltypRT, soiltyp, elrt, iswater)
 #ifdef MPP_LAND
    use module_mpp_land, only: left_id,down_id,right_id, &
@@ -953,6 +955,7 @@ subroutine disaggregateDomain(IX, JX, NSOIL, IXRT, JXRT, AGGFACTRT, &
    real, intent(in),  dimension(IX,JX)           :: SMCREF1 ! coarse grid field capacity
    real, intent(in),  dimension(IX,JX)           :: SMCWLT1 ! coarse grid wilting point
    real, intent(in),  dimension(IX,JX)           :: LKSAT ! coarse grid lateral ksat (m/s)
+   real, intent(in),  dimension(IX,JX)           :: NEXP ! coarse grid n exponent
    real, intent(in), dimension(ix,jx)            :: OV_ROUGH2d ! overland roughness
    ! LSM states:
    real, intent(in),  dimension(IX,JX,NSOIL)     :: SMC ! total soil moisture (m3/m3)
@@ -981,6 +984,7 @@ subroutine disaggregateDomain(IX, JX, NSOIL, IXRT, JXRT, AGGFACTRT, &
    real, intent(out), dimension(IXRT,JXRT,NSOIL) :: SMCREFRT ! field capacity on routing grid
    real, intent(out), dimension(IXRT,JXRT,NSOIL) :: SMCWLTRT ! wilting point on routing grid
    real, intent(out), dimension(IXRT,JXRT)       :: LKSATRT ! lateral ksat on the routing grid (m/s)
+   real, intent(out), dimension(IXRT,JXRT)       :: NEXPRT ! n exponent on the routing grid
    real, intent(out), dimension(IXRT,JXRT)       :: OVROUGHRT ! overland roughness on the routing grid
    ! States:
    real, intent(out), dimension(IX,JX,NSOIL)     :: SICE ! soil ice content on coarse grid (m3/m3)
@@ -1193,6 +1197,9 @@ subroutine disaggregateDomain(IX, JX, NSOIL, IXRT, JXRT, AGGFACTRT, &
                smScaleFact = min(1., smScaleFact) !make sure scale factor doesn't go over 1
                LKSATRT(IXXRT,JYYRT) = LKSAT(I,J) * LKSATFAC(IXXRT,JYYRT) * smScaleFact
 
+               ! n exponent for subsurface routing
+               nexprt(ixxrt,jyyrt) = nexp(i,j)
+
                ! Lake mask
                !DJG set up lake mask...
                !--- modify to make lake mask large here, but not one of the routed lakes!!!
@@ -1264,6 +1271,7 @@ subroutine disaggregateDomain(IX, JX, NSOIL, IXRT, JXRT, AGGFACTRT, &
 #ifdef MPP_LAND
    call MPP_LAND_COM_REAL(INFXSUBRT,IXRT,JXRT,99)
    call MPP_LAND_COM_REAL(LKSATRT,IXRT,JXRT,99)
+   call MPP_LAND_COM_REAL(NEXPRT,IXRT,JXRT,99)
    call MPP_LAND_COM_REAL(OVROUGHRT,IXRT,JXRT,99)
    call MPP_LAND_COM_INTEGER(LAKE_MSKRT,IXRT,JXRT,99)
    do i = 1, NSOIL

--- a/trunk/NDHMS/Routing/Noah_distr_routing_subsurface.F
+++ b/trunk/NDHMS/Routing/Noah_distr_routing_subsurface.F
@@ -244,7 +244,8 @@ SUBROUTINE SUBSFC_RTNG(subrt_data, subrt_static, subrt_input, subrt_output, CWAT
     !     if(subrt_static%rt_option .eq. 1) then
     CALL ROUTE_SUBSURFACE1(subrt_data%properties%distance_to_neighbor, &
                            subrt_data%properties%zwattablrt, &
-                           subrt_data%properties%lksatrt, subrt_data%properties%soldeprt, &
+                           subrt_data%properties%lksatrt, subrt_data%properties%nexprt, &
+                           subrt_data%properties%soldeprt, &
                            subrt_static%IXRT, subrt_static%JXRT, &
                            subrt_data%properties%surface_slope, &
                            subrt_data%properties%max_surface_slope_index, &
@@ -563,7 +564,7 @@ END SUBROUTINE FINDZWAT
 !  - Adapted from Wigmosta, 1994
 !  - Returns qsub=DQSUB which in turn becomes SUBFLO in head calc.
 !===================================================================================================
-SUBROUTINE ROUTE_SUBSURFACE1(dist, z, latksat, soldep, &
+SUBROUTINE ROUTE_SUBSURFACE1(dist, z, latksat, nexp, soldep, &
                              XX, YY, SO8RT, SO8RT_D, &
                              CWATAVAIL, SUBDT, QSUBDRY, QSUBDRYT, qsub)
 #ifdef MPP_LAND
@@ -581,6 +582,7 @@ SUBROUTINE ROUTE_SUBSURFACE1(dist, z, latksat, soldep, &
    real, intent(in), dimension(XX,YY)      :: z ! depth to water table (m)
    real, intent(in), dimension(XX,YY)      :: latksat
                                               ! lateral saturated hydraulic conductivity (m/s)
+   real, intent(in), dimension(XX,YY)      :: nexp ! latksat decay coefficient
    real, intent(in), dimension(XX,YY)      :: soldep ! soil depth (m)
    real, intent(in), dimension(XX,YY,8)    :: SO8RT ! terrain slope in all directions (m/m)
    integer, intent(in), dimension(XX,YY,3) :: SO8RT_D ! steepest terrain slope cell (i, j, index)
@@ -603,7 +605,6 @@ SUBROUTINE ROUTE_SUBSURFACE1(dist, z, latksat, soldep, &
    ! Local arrays
    real*8, DIMENSION(XX,YY) :: qsub_tmp, QSUBDRY_tmp ! temp trackers for fluxes (m3/s)
    ! Local parameters
-   real, parameter :: nexp=1.0  ! local power law exponent
    real :: tmp_dist(9)
 
    ! Initialize temp variables
@@ -651,7 +652,7 @@ SUBROUTINE ROUTE_SUBSURFACE1(dist, z, latksat, soldep, &
                endif
 
                ! Do the rest if the lowest grid can be found.
-               hh = ( 1 - ( z(i,j) / soldep(i,j) ) ) ** nexp
+               hh = ( 1 - ( z(i,j) / soldep(i,j) ) ) ** nexp(i,j)
                ksat = latksat(i,j)
 
                if (hh .lt. 0.) then
@@ -662,7 +663,7 @@ SUBROUTINE ROUTE_SUBSURFACE1(dist, z, latksat, soldep, &
 
                ! Calculate flux from cell
                ! AD_NOTE: gamma and qqsub are negative when flow is out of cell
-               gamma = -1.0 * ( (dist(i,j,index) * ksat * soldep(i,j)) / nexp ) * beta
+               gamma = -1.0 * ( (dist(i,j,index) * ksat * soldep(i,j)) / nexp(i,j) ) * beta
                qqsub = gamma * hh
 
                ! AD_NOTE: Moved this water available constraint from outside qsub calc loop
@@ -686,7 +687,7 @@ SUBROUTINE ROUTE_SUBSURFACE1(dist, z, latksat, soldep, &
                      "so8RT=",so8RT(i,j,index),"latksat=",ksat, &
                      "tan(beta)=",tan(beta),i,j,z(i,j),z(IXX0,JYY0)
                   print*, "ixx0=",ixx0, "jyy0=",jyy0
-                  print*, "soldep =", soldep(i,j), "nexp=",nexp
+                  print*, "soldep =", soldep(i,j), "nexp=",nexp(i,j)
                   call hydro_stop("In ROUTE_SUBSURFACE1() - qqsub should be negative")
                endif
 

--- a/trunk/NDHMS/Routing/Subsurface/module_subsurface_properties.F
+++ b/trunk/NDHMS/Routing/Subsurface/module_subsurface_properties.F
@@ -47,6 +47,9 @@ module module_subsurface_properties
         ! centerpoint distance to each neighbor (m)
         real, pointer, dimension(:,:,:) :: distance_to_neighbor => null()
 
+        ! disaggregated lksat decay exponent
+        real, allocatable, dimension(:,:) :: nexprt
+
     contains
 
         procedure :: init => subsurface_properties_init
@@ -131,6 +134,14 @@ contains
             allocation_error = .true.
         end if
 
+        ! allocate the array only if not already allocated
+        if ( .not. allocated(this%nexprt) ) then
+            allocate( this%nexprt(ix,jx) )
+            this%nexprt = 1.0
+        else
+            allocation_error = .true.
+        end if
+
         if ( allocation_error ) &
             write(0,*) "attempt to allocate data in members of subsurface properties structure&
             &that where already allocated. The allocated members where not changed"
@@ -204,6 +215,12 @@ contains
             allocation_error = .true.
         end if
 
+        ! only deallocated if already allocated
+        if ( allocated(this%nexprt) ) then
+            deallocate( this%nexprt)
+        else
+            allocation_error = .true.
+        end if
 
         if ( allocation_error ) &
             write(0,*) "attempt to deallocate data in members of subsurface properties structure&

--- a/trunk/NDHMS/Routing/module_HYDRO_io.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_io.F
@@ -624,7 +624,7 @@ end subroutine get_albedo12m_netcdf
     character(len=*), intent(in) :: name
     integer, intent(in) :: ncid
     integer, intent(in) :: idim, jdim
-    real, dimension(idim,jdim), intent(out) :: array
+    real, dimension(idim,jdim), intent(inout) :: array
     character(len=256), intent(out) :: units
     ! fatal_IF_ERROR:  an input code value:
     !      .TRUE. if an error in reading the data should stop the program.
@@ -11164,14 +11164,21 @@ end subroutine hdtbl_out
 subroutine hdtbl_in_nc(did)
    implicit none
    integer :: did
-   call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"SMCMAX1",rt_domain(did)%SMCMAX1)
-   call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"SMCREF1",rt_domain(did)%SMCREF1)
-   call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"SMCWLT1",rt_domain(did)%SMCWLT1)
-   call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"OV_ROUGH2D",rt_domain(did)%OV_ROUGH2D)
-   call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"LKSAT",rt_domain(did)%LKSAT)
-   call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"NEXP",rt_domain(did)%NEXP)
+   integer :: ierr
+   call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"SMCMAX1",rt_domain(did)%SMCMAX1,ierr)
+   call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"SMCREF1",rt_domain(did)%SMCREF1,ierr)
+   call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"SMCWLT1",rt_domain(did)%SMCWLT1,ierr)
+   call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"OV_ROUGH2D",rt_domain(did)%OV_ROUGH2D,ierr)
+   call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"LKSAT",rt_domain(did)%LKSAT,ierr)
+   call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"NEXP",rt_domain(did)%NEXP,ierr)
+   ! Letting this variable be optional and setting to global default value if not found
+   if (ierr /= 0) then
+     write(6,*)  "WARNING (hydtbl_in_nc): NEXP not found so setting to global 1.0"
+     rt_domain(did)%NEXP = 1.0
+   endif
 end subroutine hdtbl_in_nc
-subroutine read2dlsm(did,file,varName,varOut)
+
+subroutine read2dlsm(did,file,varName,varOut,ierr)
   implicit none
   integer :: did, ncid ,ierr,iret
   character(len=*) :: file,varName

--- a/trunk/NDHMS/Routing/module_HYDRO_io.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_io.F
@@ -11157,6 +11157,7 @@ subroutine hdtbl_out(did)
       call hdtbl_out_nc(did,ncid, count,count_flag,"SMCWLT1",rt_domain(did)%SMCWLT1,"",ixd,jxd)
       call hdtbl_out_nc(did,ncid, count,count_flag,"OV_ROUGH2D",rt_domain(did)%OV_ROUGH2D,"",ixd,jxd)
       call hdtbl_out_nc(did,ncid, count,count_flag,"LKSAT",rt_domain(did)%LKSAT,"",ixd,jxd)
+      call hdtbl_out_nc(did,ncid, count,count_flag,"NEXP",rt_domain(did)%NEXP,"",ixd,jxd)
    end do
 
 end subroutine hdtbl_out
@@ -11168,6 +11169,7 @@ subroutine hdtbl_in_nc(did)
    call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"SMCWLT1",rt_domain(did)%SMCWLT1)
    call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"OV_ROUGH2D",rt_domain(did)%OV_ROUGH2D)
    call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"LKSAT",rt_domain(did)%LKSAT)
+   call read2dlsm(did,trim(nlst(did)%hydrotbl_f),"NEXP",rt_domain(did)%NEXP)
 end subroutine hdtbl_in_nc
 subroutine read2dlsm(did,file,varName,varOut)
   implicit none

--- a/trunk/NDHMS/Routing/module_HYDRO_io.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_io.F
@@ -11179,11 +11179,13 @@ subroutine hdtbl_in_nc(did)
 end subroutine hdtbl_in_nc
 
 subroutine read2dlsm(did,file,varName,varOut,ierr)
+use module_mpp_land,only: mpp_land_bcast_int1
   implicit none
-  integer :: did, ncid ,ierr,iret
+  integer :: did, ncid , iret
   character(len=*) :: file,varName
   real,dimension(:,:) :: varOut
   character(len=256) :: units
+  integer, intent(out) :: ierr
 #ifdef MPP_LAND
   real,allocatable,dimension(:,:) :: tmpArr
   if(my_id .eq. io_id) then
@@ -11196,6 +11198,7 @@ subroutine read2dlsm(did,file,varName,varOut,ierr)
      allocate(tmpArr(1,1))
   endif
   call decompose_data_real (tmpArr,varOut)
+  call mpp_land_bcast_int1(ierr)
   deallocate(tmpArr)
 #else
      iret = nf90_open(trim(file), NF90_NOWRITE, ncid)

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -291,6 +291,9 @@ CONTAINS
   allocate( rt_domain(did)%SOLDRAIN   (IX,JX) )
             rt_domain(did)%SOLDRAIN    = 0.0
 
+  allocate( rt_domain(did)%NEXP   (IX,JX) )
+            rt_domain(did)%NEXP    = 1.0
+
   end if ! neither channel_only nor channelBucket_only
 
 


### PR DESCRIPTION
TYPE: enhancement,

KEYWORDS: subsurface routing, parameters

SOURCE: Aubrey D., NCAR 

DESCRIPTION OF CHANGES: NEXP is the exponent for the function controlling the decay of Ksat with depth, as used in the subsurface routing scheme. The exponent was hard-coded at 1.0. This update exposes NEXP in the HYDRO2DTBL.nc parameter file to ease user modification and calibration. This is an optional parameter - if missing, the code will default to NEXP=1.0. No answer changes if NEXP is not provided or if NEXP=1.0 in HYDRO2DTBL.nc.

TESTS CONDUCTED: With small test basin and NWM CONUS domains, confirmed NEXP missing, NEXP=1.0, and master give identical solutions. Confirmed parameter value changes behave as expected. Confirmed ncores and perfect restart tests pass. 

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [NA] Tests added (unit tests and/or regression/integration tests)
 - [x] Backwards compatible
 - [NA] Requires new files? If so, how to generate them.
 - [NA] Documentation included
 - [NA] Short description in the Development section of `NEWS.md`
