### PR TITLE
bugfix: debugging actions workflow failure

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -19,6 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         configuration: [nwm_ana, nwm_long_range, gridded, reach]
+      # Hackfix until gdrive downloads are fixed
+      # max-parallel: 1
     runs-on: ubuntu-latest
 
     steps:
@@ -27,10 +29,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: candidate
-          
+
       - name: Checkout candidate (manual)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        env: 
+        env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: gh repo clone ${{ github.repository }} candidate && cd candidate && gh pr checkout -R ${{ github.repository }} ${{ github.event.inputs.pr }}
 
@@ -40,35 +42,34 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           path: reference
-          
+
       - name: Checkout reference (push)
         if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.before }}
           path: reference
-          
+
       - name: Checkout reference (manual)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        env: 
+        env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: gh repo clone ${{ github.repository }} reference && cd reference && git checkout origin/$(gh pr view ${{ github.event.inputs.pr }} --json baseRefName --jq '.baseRefName')
-      
+
       - name: Run testing container
         run: |
           docker run -e TRAVIS=1 -t --name test_container \
            -v $GITHUB_WORKSPACE/candidate:/home/docker/candidate \
            -v $GITHUB_WORKSPACE/reference:/home/docker/reference \
            wrfhydro/dev:modeltesting --config ${{ matrix.configuration }} --domain_tag dev
-      
+
       - name: Copy test results from container
         if: ${{ always() }}
         run: docker cp test_container:/home/docker/test_out $GITHUB_WORKSPACE/test_report
-        
+
       - name: Archive test results to GitHub
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: test-reports
           path: ${{ github.workspace }}/test_report/**.html
-        

--- a/tests/local/utils/gdrive_download.py
+++ b/tests/local/utils/gdrive_download.py
@@ -1,15 +1,21 @@
 from argparse import ArgumentParser
 
 import requests
+# import gdown
 
 
 def download_file_from_google_drive(id, destination):
     print('downloading google drive file id ' + id + ' to ' + destination)
+
+    # --- this will work once gdown is pip installed on docker
+    # gdown.download(id=id, output=destination)
+
     URL = "https://docs.google.com/uc?export=download"
 
     session = requests.Session()
 
-    response = session.get(URL, params={'id': id}, stream=True)
+    response = session.get(URL, params={'id': id, 'alt': 'media', 'confirm':'t'}
+                           , stream=True)
     token = get_confirm_token(response)
 
     if token:


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: debugging, github actions, wget, CI

SOURCE: Soren Rasmussen, NCAR 

DESCRIPTION OF CHANGES: This PR is to investigate why the actions workflow is failing, apparently randomly. Adding concurrency statement to actions workflow to try to run one test at a time. Too many concurrent wget's of google drive image may be the reason why github action tests are failing.