### PR TITLE
 bugfix: CI download crocus failure

### DIFF
--- a/tests/local/utils/gdrive_download.py
+++ b/tests/local/utils/gdrive_download.py
@@ -9,7 +9,8 @@ def download_file_from_google_drive(id, destination):
 
     session = requests.Session()
 
-    response = session.get(URL, params={'id': id}, stream=True)
+    response = session.get(URL, params={'id': id, 'alt': 'media', 'confirm':'t'}
+                           , stream=True)
     token = get_confirm_token(response)
 
     if token:


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: debugging, github actions, wget, CI

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Fixes issue where the CI tests will fail when attempting to download the Crocus tarball, returning a 'file too large to scan for viruses, download anyway?' message.

TESTS CONDUCTED: CI tests now run

NOTES: In the future it will be good to use `gdown` to download the file, but that will require `pip install gdown` updates to the docker repo.


### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
