### PR TITLE
New impervious runoff adjustment options

### DIFF
--- a/trunk/NDHMS/Data_Rec/module_namelist.F
+++ b/trunk/NDHMS/Data_Rec/module_namelist.F
@@ -46,7 +46,7 @@ CONTAINS
                     GWBASESWCRT,  GW_RESTART,RSTRT_SWC,TERADJ_SOLAR, &
                     sys_cpl, rst_typ, rst_bi_in, rst_bi_out, &
                     gwChanCondSw, GwPreCycles, GwSpinCycles, GwPreDiagInterval, gwsoilcpl, &
-                    UDMP_OPT, io_form_outputs, bucket_loss
+                    UDMP_OPT, io_form_outputs, bucket_loss, imperv_adj
           real:: DTRT_TER,DTRT_CH,dxrt, gwChanCondConstIn, gwChanCondConstOut, gwIhShift
           character(len=256) :: route_topo_f=""
           character(len=256) :: route_chan_f=""
@@ -138,7 +138,7 @@ CONTAINS
                     CHRTOUT_DOMAIN,CHANOBS_DOMAIN,CHRTOUT_GRID,LSMOUT_DOMAIN,&
                     RTOUT_DOMAIN, output_gw, outlake, &
                     frxst_pts_out, udmap_file, UDMP_OPT, GWBUCKPARM_file, bucket_loss, &
-                    io_config_outputs, io_form_outputs, hydrotbl_f, t0OutputFlag, output_channelBucket_influx
+                    io_config_outputs, io_form_outputs, hydrotbl_f, t0OutputFlag, output_channelBucket_influx, imperv_adj
 
 #ifdef WRF_HYDRO_NUDGING
    namelist /NUDGING_nlist/ nudgingParamFile,       netwkReExFile,          &
@@ -173,6 +173,7 @@ CONTAINS
    reservoir_rfc_forecasts = .FALSE.
    reservoir_rfc_forecasts_lookback_hours = 24
    reservoir_type_specified = .FALSE.
+   imperv_adj = 0
 
 #ifdef WRF_HYDRO_NUDGING
    ! Default values for NUDGING_nlist
@@ -359,6 +360,7 @@ CONTAINS
   call mpp_land_bcast_int1(RTOUT_DOMAIN)
   call mpp_land_bcast_int1(UDMP_OPT)
   call mpp_land_bcast_int1(reservoir_data_ingest)
+  call mpp_land_bcast_int1(imperv_adj)
 #ifdef WRF_HYDRO_NUDGING
   call mpp_land_bcast_char(256, nudgingParamFile  )
   call mpp_land_bcast_char(256, netwkReExFile     )
@@ -450,6 +452,7 @@ CONTAINS
     nlst%rst_bi_out = rst_bi_out
     nlst%order_to_write = order_to_write
     nlst%compound_channel = compound_channel
+    nlst%imperv_adj = imperv_adj
 
 ! files
     nlst%route_topo_f   =  route_topo_f
@@ -533,6 +536,7 @@ CONTAINS
     write(6,*) " nlst%gwstrmfil ",  gwstrmfil
     write(6,*) " nlst%geo_finegrid_flnm ",  geo_finegrid_flnm
     write(6,*) " nlst%reservoir_data_ingest ", reservoir_data_ingest
+    write(6,*) " nlst%imperv_adj ", imperv_adj
 #ifdef WRF_HYDRO_NUDGING
     write(6,*) " nlst%nudgingParamFile      ",  trim(nudgingParamFile)
     write(6,*) " nlst%netWkReExFile         ",  trim(netWkReExFile)
@@ -779,6 +783,9 @@ subroutine rt_nlst_check(nlst)
    if(len(trim(nlst%route_lake_f)) .ne. 0) then
       inquire(file=trim(nlst%route_lake_f),exist=fileExists)
       if (.not. fileExists) call hydro_stop('hydro.namelist ERROR: route_lake_f not found.')
+   endif
+   if( (nlst%imperv_adj .lt. 0 ) .or. (nlst%imperv_adj .gt. 1) ) then
+      call hydro_stop('hydro.namelist ERROR: Invalid imperv_adj specified')
    endif
    ! Only allow lakes to be ran with gridded routing or NWM routing
    if(len(trim(nlst%route_lake_f)) .ne. 0) then

--- a/trunk/NDHMS/Data_Rec/namelist.inc
+++ b/trunk/NDHMS/Data_Rec/namelist.inc
@@ -34,7 +34,7 @@
                   SUBRTSWCRT, OVRTSWCRT, AGGFACTRT, &
                   GWBASESWCRT, GW_RESTART,RSTRT_SWC,TERADJ_SOLAR, &
                   sys_cpl, gwChanCondSw, GwPreCycles, GwSpinCycles, GwPreDiagInterval, &
-                  gwsoilcpl, UDMP_OPT, bucket_loss
+                  gwsoilcpl, UDMP_OPT, bucket_loss, imperv_adj
           logical:: GwPreDiag, GwSpinUp
           real:: DTRT_TER,DTRT_CH, DTCT, dxrt0,  gwChanCondConstIn, gwChanCondConstOut, gwIhShift
           character(len=256) :: route_topo_f=""

--- a/trunk/NDHMS/Data_Rec/rt_include.inc
+++ b/trunk/NDHMS/Data_Rec/rt_include.inc
@@ -66,6 +66,7 @@
   REAL,    allocatable, DIMENSION(:,:)      :: INFXSRT,LKSAT,LKSATRT
   !REAL,    allocatable, DIMENSION(:,:)      :: SFCHEADSUBRT,INFXSUBRT,LKSATFAC  ! SFCHEADSUBRT, INFXSUBRT moved to overland control module
   REAL,    allocatable, DIMENSION(:,:)      :: LKSATFAC
+  REAL,    allocatable, DIMENSION(:,:)      :: IMPERVFRAC
   !REAL,    allocatable, DIMENSION(:,:)      :: SOLDEPRT ! QSUBRT, QSUBBDRYRT moved to subsurface io module, SOLDEPRT, ZWATTABLRT move to susurface properties
   REAL,    allocatable, DIMENSION(:,:)      :: SUB_RESID
   REAL,    allocatable, DIMENSION(:,:)      :: q_sfcflx_x,q_sfcflx_y

--- a/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
+++ b/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
@@ -1770,21 +1770,15 @@ end subroutine HYDRO_ini
              do i = 1, RT_DOMAIN(did)%ix
                 !yw rt_domain(did)%lksat(i,j) = xdum1(soltyp(i,j) ) * 1000.0
                 rt_domain(did)%lksat(i,j) = xdum1(soltyp(i,j) )
-                IF(rt_domain(did)%VEGTYP(i,j) == rt_domain(did)%isurban ) THEN   ! urban
-                    rt_domain(did)%SMCMAX1(i,j) = 0.45
-                    rt_domain(did)%SMCREF1(i,j) = 0.42
-                    rt_domain(did)%SMCWLT1(i,j) = 0.40
-                else
-                    rt_domain(did)%SMCMAX1(i,j) = MAXSMC(soltyp(I,J))
-                    rt_domain(did)%SMCREF1(i,j) = refsmc(soltyp(I,J))
-                    rt_domain(did)%SMCWLT1(i,j) = wltsmc(soltyp(I,J))
-                    !ADCHANGE: Add some sanity checks in case calibration knocks the order of these out of sequence.
-                    !The min diffs were pulled from the existing HYDRO.TBL defaults.
-                    !Currently water is 0, so enforcing 0 as the absolute min.
-                    rt_domain(did)%SMCMAX1(i,j) = min(rt_domain(did)%SMCMAX1(i,j), 1.0)
-                    rt_domain(did)%SMCREF1(i,j) = max(min(rt_domain(did)%SMCREF1(i,j), rt_domain(did)%SMCMAX1(i,j) - 0.01), 0.0)
-                    rt_domain(did)%SMCWLT1(i,j) = max(min(rt_domain(did)%SMCWLT1(i,j), rt_domain(did)%SMCREF1(i,j) - 0.01), 0.0)
-                ENDIF
+                rt_domain(did)%SMCMAX1(i,j) = MAXSMC(soltyp(I,J))
+                rt_domain(did)%SMCREF1(i,j) = refsmc(soltyp(I,J))
+                rt_domain(did)%SMCWLT1(i,j) = wltsmc(soltyp(I,J))
+                !ADCHANGE: Add some sanity checks in case calibration knocks the order of these out of sequence.
+                !The min diffs were pulled from the existing HYDRO.TBL defaults.
+                !Currently water is 0, so enforcing 0 as the absolute min.
+                rt_domain(did)%SMCMAX1(i,j) = min(rt_domain(did)%SMCMAX1(i,j), 1.0)
+                rt_domain(did)%SMCREF1(i,j) = max(min(rt_domain(did)%SMCREF1(i,j), rt_domain(did)%SMCMAX1(i,j) - 0.01), 0.0)
+                rt_domain(did)%SMCWLT1(i,j) = max(min(rt_domain(did)%SMCWLT1(i,j), rt_domain(did)%SMCREF1(i,j) - 0.01), 0.0)
                 IF(rt_domain(did)%VEGTYP(i,j) > 0 ) THEN   ! created 2d ov_rough
                     rt_domain(did)%OV_ROUGH2d(i,j) = RT_DOMAIN(did)%OV_ROUGH(rt_domain(did)%VEGTYP(I,J))
                 endif

--- a/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
+++ b/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
@@ -40,7 +40,7 @@ module module_HYDRO_drv
    use module_gw_gw2d_data, only: gw2d
    use module_channel_routing, only: drive_channel, drive_channel_rsl
    use orchestrator_base
-   use config_base, only: nlst
+   use config_base, only: nlst, noah_lsm
    use module_routing, only: getChanDim, landrt_ini
    use module_HYDRO_utils
    use module_lsm_forcing, only: geth_newdate
@@ -1790,12 +1790,14 @@ end subroutine HYDRO_ini
        ! input from HYDRO.TBL.nc file
        print*, "reading from hydrotbl_f(HYDRO.TBL.nc)  file ...."
        call hdtbl_in_nc(did)
-       !ADCHANGE: For consistency, mirror urban and param value checks used in table read
-       where (rt_domain(did)%VEGTYP == rt_domain(did)%isurban)
-          rt_domain(did)%SMCMAX1 = 0.45
-          rt_domain(did)%SMCREF1 = 0.42
-          rt_domain(did)%SMCWLT1 = 0.40
-       endwhere
+       if (noah_lsm%imperv_option .eq. 0) then
+         !ADCHANGE: For consistency, mirror urban and param value checks used in table read
+         where (rt_domain(did)%VEGTYP == rt_domain(did)%isurban)
+           rt_domain(did)%SMCMAX1 = 0.45
+           rt_domain(did)%SMCREF1 = 0.42
+           rt_domain(did)%SMCWLT1 = 0.40
+         endwhere
+       endif
        where (rt_domain(did)%SMCMAX1 .gt. 1.0) rt_domain(did)%SMCMAX1 = 1.0
        rt_domain(did)%SMCREF1 = max(min(rt_domain(did)%SMCREF1, rt_domain(did)%SMCMAX1 - 0.01), 0.0)
        rt_domain(did)%SMCWLT1 = max(min(rt_domain(did)%SMCWLT1, rt_domain(did)%SMCREF1 - 0.01), 0.0)

--- a/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
+++ b/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
@@ -1790,7 +1790,7 @@ end subroutine HYDRO_ini
        ! input from HYDRO.TBL.nc file
        print*, "reading from hydrotbl_f(HYDRO.TBL.nc)  file ...."
        call hdtbl_in_nc(did)
-       if (noah_lsm%imperv_option .eq. 0) then
+       if (noah_lsm%imperv_option .eq. 9) then
          !ADCHANGE: For consistency, mirror urban and param value checks used in table read
          where (rt_domain(did)%VEGTYP == rt_domain(did)%isurban)
            rt_domain(did)%SMCMAX1 = 0.45

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -160,6 +160,8 @@ module module_NoahMP_hrldas_driver
   REAL, ALLOCATABLE, DIMENSION(:,:)       ::  bxaj_2D    ! Tension water distribution shape parameter [-]
   REAL, ALLOCATABLE, DIMENSION(:,:)       ::  xxaj_2D    ! Free water distribution shape parameter [-]
   REAL, ALLOCATABLE, DIMENSION(:,:)       ::  imperv_2D  ! impervious fraction
+  REAL, ALLOCATABLE, DIMENSION(:,:)       ::  impconnA_2D ! impervious connectivity A parameter from Sutherland 2000
+  REAL, ALLOCATABLE, DIMENSION(:,:)       ::  impconnB_2D ! impervious connectivity B parameter from Sutherland 2000
 #endif
 
 ! INOUT (with generic LSM equivalent) (as defined in WRF)
@@ -749,6 +751,8 @@ module module_NoahMP_hrldas_driver
   ALLOCATE ( bxaj_2D    (XSTART:XEND,YSTART:YEND) )            ! Tension water distribution shape parameter [-]
   ALLOCATE ( xxaj_2D    (XSTART:XEND,YSTART:YEND) )            ! Free water distribution shape parameter [-]
   ALLOCATE ( imperv_2D  (XSTART:XEND,YSTART:YEND) )            ! impervious fraction
+  ALLOCATE ( impconnA_2D  (XSTART:XEND,YSTART:YEND) )          ! impervious connectivity A parameter from Sutherland 2000
+  ALLOCATE ( impconnB_2D  (XSTART:XEND,YSTART:YEND) )          ! impervious connectivity B parameter from Sutherland 2000
 #endif
 
 ! INOUT (with generic LSM equivalent) (as defined in WRF)
@@ -1095,7 +1099,7 @@ module module_NoahMP_hrldas_driver
                       NSOIL,BEXP_3D,SMCDRY_3D,SMCWLT_3D,SMCREF_3D,SMCMAX_3D,  &
 		      DKSAT_3D,DWSAT_3D,PSISAT_3D,QUARTZ_3D,REFDK_2D,REFKDT_2D,&
 		      SLOPE_2D,CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,RSURFEXP_2D, &
-                      IMPERV_2D)
+                      IMPERV_2D,IMPCONNA_2D,IMPCONNB_2D)
 
     if (noah_lsm%runoff_option == 7) then
         CALL READ_XAJ_RUNOFF(noah_lsm%SPATIAL_FILENAME,XSTART, XEND, YSTART, YEND, &
@@ -1673,7 +1677,7 @@ end subroutine land_driver_ini
 		 REFDK_2D,REFKDT_2D,SLOPE_2D,                                 &
 		 CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,RSURFEXP_2D,        &
                  AXAJ_2D,BXAJ_2D,XXAJ_2D,                                     &
-                 IMPERV_2D,                                                   &
+                 IMPERV_2D,IMPCONNA_2D,IMPCONNB_2D,                           &
 #endif
 #ifdef WRF_HYDRO
                  sfcheadrt,INFXSRT,soldrain,                          &    !O

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -118,6 +118,8 @@ module module_NoahMP_hrldas_driver
   INTEGER                                 ::  IOPT_SOIL ! soil configuration option
   INTEGER                                 ::  IOPT_PEDO ! soil pedotransfer function option
   INTEGER                                 ::  IOPT_CROP ! crop model option (0->none; 1->Liu et al.)
+  INTEGER                                 ::  IOPT_IMPERV !imperviousness infiltration adjustment (0->none; 1->total; 
+                                                                                        !2->Alley&Veenhuis; 3->Sutherland)
   REAL,    ALLOCATABLE, DIMENSION(:,:,:)  ::  T_PHY     ! 3D atmospheric temperature valid at mid-levels [K]
   REAL,    ALLOCATABLE, DIMENSION(:,:,:)  ::  QV_CURR   ! 3D water vapor mixing ratio [kg/kg_dry]
   REAL,    ALLOCATABLE, DIMENSION(:,:,:)  ::  U_PHY     ! 3D U wind component [m/s]
@@ -446,6 +448,7 @@ module module_NoahMP_hrldas_driver
   IOPT_SOIL = noah_lsm%soil_data_option
   IOPT_PEDO = noah_lsm%pedotransfer_option
   IOPT_CROP = noah_lsm%crop_option
+  IOPT_IMPERV = noah_lsm%imperv_option
 
   khour = noah_lsm%khour
 
@@ -1648,7 +1651,8 @@ end subroutine land_driver_ini
 		  XLAND,     XICE,     XICE_THRESHOLD,                        &
                   IDVEG, IOPT_CRS, IOPT_BTR, IOPT_RUN,  IOPT_SFC,   IOPT_FRZ, &
 	       IOPT_INF, IOPT_RAD, IOPT_ALB, IOPT_SNF, IOPT_TBOT,   IOPT_STC, &
-	       IOPT_GLA, IOPT_RSF,IOPT_SOIL,IOPT_PEDO, IOPT_CROP,    IZ0TLND, &
+	       IOPT_GLA, IOPT_RSF,IOPT_SOIL,IOPT_PEDO, IOPT_CROP,             &
+               IOPT_IMPERV, IZ0TLND,                                          &
 		  T_PHY,  QV_CURR,    U_PHY,    V_PHY,    SWDOWN,        GLW, &
 		    P8W,   RAINBL,       SR,                                  &
 		    TSK,      HFX,      QFX,       LH,    GRDFLX,     SMSTAV, &

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -159,6 +159,7 @@ module module_NoahMP_hrldas_driver
   REAL, ALLOCATABLE, DIMENSION(:,:)       ::  axaj_2D    ! Tension water distribution inflection parameter [-]
   REAL, ALLOCATABLE, DIMENSION(:,:)       ::  bxaj_2D    ! Tension water distribution shape parameter [-]
   REAL, ALLOCATABLE, DIMENSION(:,:)       ::  xxaj_2D    ! Free water distribution shape parameter [-]
+  REAL, ALLOCATABLE, DIMENSION(:,:)       ::  imperv_2D  ! impervious fraction
 #endif
 
 ! INOUT (with generic LSM equivalent) (as defined in WRF)
@@ -747,6 +748,7 @@ module module_NoahMP_hrldas_driver
   ALLOCATE ( axaj_2D    (XSTART:XEND,YSTART:YEND) )            ! Tension water distribution inflection parameter [-]
   ALLOCATE ( bxaj_2D    (XSTART:XEND,YSTART:YEND) )            ! Tension water distribution shape parameter [-]
   ALLOCATE ( xxaj_2D    (XSTART:XEND,YSTART:YEND) )            ! Free water distribution shape parameter [-]
+  ALLOCATE ( imperv_2D  (XSTART:XEND,YSTART:YEND) )            ! impervious fraction
 #endif
 
 ! INOUT (with generic LSM equivalent) (as defined in WRF)
@@ -1092,7 +1094,8 @@ module module_NoahMP_hrldas_driver
     CALL READ_3D_SOIL(noah_lsm%SPATIAL_FILENAME, XSTART, XEND, YSTART, YEND, &
                       NSOIL,BEXP_3D,SMCDRY_3D,SMCWLT_3D,SMCREF_3D,SMCMAX_3D,  &
 		      DKSAT_3D,DWSAT_3D,PSISAT_3D,QUARTZ_3D,REFDK_2D,REFKDT_2D,&
-		      SLOPE_2D,CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,RSURFEXP_2D)
+		      SLOPE_2D,CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,RSURFEXP_2D, &
+                      IMPERV_2D)
 
     if (noah_lsm%runoff_option == 7) then
         CALL READ_XAJ_RUNOFF(noah_lsm%SPATIAL_FILENAME,XSTART, XEND, YSTART, YEND, &
@@ -1670,6 +1673,7 @@ end subroutine land_driver_ini
 		 REFDK_2D,REFKDT_2D,SLOPE_2D,                                 &
 		 CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,RSURFEXP_2D,        &
                  AXAJ_2D,BXAJ_2D,XXAJ_2D,                                     &
+                 IMPERV_2D,                                                   &
 #endif
 #ifdef WRF_HYDRO
                  sfcheadrt,INFXSRT,soldrain,                          &    !O

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -119,7 +119,7 @@ module module_NoahMP_hrldas_driver
   INTEGER                                 ::  IOPT_PEDO ! soil pedotransfer function option
   INTEGER                                 ::  IOPT_CROP ! crop model option (0->none; 1->Liu et al.)
   INTEGER                                 ::  IOPT_IMPERV !imperviousness infiltration adjustment (0->none; 1->total; 
-                                                                                        !2->Alley&Veenhuis; 3->Sutherland)
+                                                                                        !2->Alley&Veenhuis)
   REAL,    ALLOCATABLE, DIMENSION(:,:,:)  ::  T_PHY     ! 3D atmospheric temperature valid at mid-levels [K]
   REAL,    ALLOCATABLE, DIMENSION(:,:,:)  ::  QV_CURR   ! 3D water vapor mixing ratio [kg/kg_dry]
   REAL,    ALLOCATABLE, DIMENSION(:,:,:)  ::  U_PHY     ! 3D U wind component [m/s]
@@ -162,8 +162,6 @@ module module_NoahMP_hrldas_driver
   REAL, ALLOCATABLE, DIMENSION(:,:)       ::  bxaj_2D    ! Tension water distribution shape parameter [-]
   REAL, ALLOCATABLE, DIMENSION(:,:)       ::  xxaj_2D    ! Free water distribution shape parameter [-]
   REAL, ALLOCATABLE, DIMENSION(:,:)       ::  imperv_2D  ! impervious fraction
-  REAL, ALLOCATABLE, DIMENSION(:,:)       ::  impconnA_2D ! impervious connectivity A parameter from Sutherland 2000
-  REAL, ALLOCATABLE, DIMENSION(:,:)       ::  impconnB_2D ! impervious connectivity B parameter from Sutherland 2000
 #endif
 
 ! INOUT (with generic LSM equivalent) (as defined in WRF)
@@ -754,8 +752,6 @@ module module_NoahMP_hrldas_driver
   ALLOCATE ( bxaj_2D    (XSTART:XEND,YSTART:YEND) )            ! Tension water distribution shape parameter [-]
   ALLOCATE ( xxaj_2D    (XSTART:XEND,YSTART:YEND) )            ! Free water distribution shape parameter [-]
   ALLOCATE ( imperv_2D  (XSTART:XEND,YSTART:YEND) )            ! impervious fraction
-  ALLOCATE ( impconnA_2D  (XSTART:XEND,YSTART:YEND) )          ! impervious connectivity A parameter from Sutherland 2000
-  ALLOCATE ( impconnB_2D  (XSTART:XEND,YSTART:YEND) )          ! impervious connectivity B parameter from Sutherland 2000
 #endif
 
 ! INOUT (with generic LSM equivalent) (as defined in WRF)
@@ -1101,13 +1097,18 @@ module module_NoahMP_hrldas_driver
     CALL READ_3D_SOIL(noah_lsm%SPATIAL_FILENAME, XSTART, XEND, YSTART, YEND, &
                       NSOIL,BEXP_3D,SMCDRY_3D,SMCWLT_3D,SMCREF_3D,SMCMAX_3D,  &
 		      DKSAT_3D,DWSAT_3D,PSISAT_3D,QUARTZ_3D,REFDK_2D,REFKDT_2D,&
-		      SLOPE_2D,CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,RSURFEXP_2D, &
-                      IMPERV_2D,IMPCONNA_2D,IMPCONNB_2D)
+		      SLOPE_2D,CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,RSURFEXP_2D)
 
     if (noah_lsm%runoff_option == 7) then
         CALL READ_XAJ_RUNOFF(noah_lsm%SPATIAL_FILENAME,XSTART, XEND, YSTART, YEND, &
                              AXAJ_2D,BXAJ_2D,XXAJ_2D)
     end if
+
+    if (noah_lsm%imperv_option > 0) then
+        CALL READ_IMPERV(noah_lsm%SPATIAL_FILENAME,XSTART, XEND, YSTART, YEND, &
+                             IMPERV_2D)
+    end if
+
 #endif
 
 !------------------------------------------------------------------------
@@ -1681,7 +1682,7 @@ end subroutine land_driver_ini
 		 REFDK_2D,REFKDT_2D,SLOPE_2D,                                 &
 		 CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,RSURFEXP_2D,        &
                  AXAJ_2D,BXAJ_2D,XXAJ_2D,                                     &
-                 IMPERV_2D,IMPCONNA_2D,IMPCONNB_2D,                           &
+                 IMPERV_2D,                                                   &
 #endif
 #ifdef WRF_HYDRO
                  sfcheadrt,INFXSRT,soldrain,                          &    !O

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -119,7 +119,7 @@ module module_NoahMP_hrldas_driver
   INTEGER                                 ::  IOPT_PEDO ! soil pedotransfer function option
   INTEGER                                 ::  IOPT_CROP ! crop model option (0->none; 1->Liu et al.)
   INTEGER                                 ::  IOPT_IMPERV !imperviousness infiltration adjustment (0->none; 1->total; 
-                                                                                        !2->Alley&Veenhuis)
+                                                                                        !2->Alley&Veenhuis; 9->old)
   REAL,    ALLOCATABLE, DIMENSION(:,:,:)  ::  T_PHY     ! 3D atmospheric temperature valid at mid-levels [K]
   REAL,    ALLOCATABLE, DIMENSION(:,:,:)  ::  QV_CURR   ! 3D water vapor mixing ratio [kg/kg_dry]
   REAL,    ALLOCATABLE, DIMENSION(:,:,:)  ::  U_PHY     ! 3D U wind component [m/s]
@@ -1104,7 +1104,7 @@ module module_NoahMP_hrldas_driver
                              AXAJ_2D,BXAJ_2D,XXAJ_2D)
     end if
 
-    if (noah_lsm%imperv_option > 0) then
+    if (noah_lsm%imperv_option > 0 .and. noah_lsm%imperv_option < 9) then
         CALL READ_IMPERV(noah_lsm%SPATIAL_FILENAME,XSTART, XEND, YSTART, YEND, &
                              IMPERV_2D)
     end if

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -837,7 +837,7 @@ contains
   subroutine read_3d_soil(spatial_filename,xstart, xend,ystart, yend,           &
                           nsoil,bexp_3d,smcdry_3d,smcwlt_3d,smcref_3d,smcmax_3d,  &
 		          dksat_3d,dwsat_3d,psisat_3d,quartz_3d,refdk_2d,refkdt_2d,slope_2d,&
-			  cwpvt_2d,vcmx25_2d,mp_2d,hvt_2d,mfsno_2d,rsurfexp_2d)
+			  cwpvt_2d,vcmx25_2d,mp_2d,hvt_2d,mfsno_2d,rsurfexp_2d,imperv_2d)
     implicit none
     character(len=*),          intent(in)  :: spatial_filename
     integer,                   intent(in)  :: xstart, xend, ystart, yend
@@ -860,6 +860,7 @@ contains
     real,    dimension(xstart:xend,ystart:yend), intent(out)       :: hvt_2d
     real,    dimension(xstart:xend,ystart:yend), intent(out)       :: mfsno_2d
     real,    dimension(xstart:xend,ystart:yend), intent(out)       :: rsurfexp_2d
+    real,    dimension(xstart:xend,ystart:yend), intent(out)       :: imperv_2d
 
     character(len=24)  :: name
     character(len=256) :: units
@@ -1089,6 +1090,16 @@ contains
 
     iret = nf90_get_var(ncid, varid, rsurfexp_2d, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
 !
+    name = "imperv"
+    iret = nf90_inq_varid(ncid,  trim(name),  varid)
+    if (iret /= 0) then
+      print*, 'ncid = ', ncid
+      write(*,*) "FATAL ERROR: In read_3d_soil():  Problem finding variable '"//trim(name)//"' in NetCDF file: " // trim(spatial_filename)
+      stop
+    endif
+
+    iret = nf90_get_var(ncid, varid, imperv_2d, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
+ 
     ! Close the NetCDF file
     ierr = nf90_close(ncid)
     if (ierr /= 0) stop "FATAL ERROR: In module_hrldas_netcdf_io.F read_3d_soil() -  NF90_CLOSE"

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -1127,16 +1127,6 @@ contains
 
     iret = nf90_get_var(ncid, varid, rsurfexp_2d, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
 !
-    name = "imperv"
-    iret = nf90_inq_varid(ncid,  trim(name),  varid)
-    if (iret /= 0) then
-      print*, 'ncid = ', ncid
-      write(*,*) "FATAL ERROR: In read_3d_soil():  Problem finding variable '"//trim(name)//"' in NetCDF file: " // trim(spatial_filename)
-      stop
-    endif
-
-    iret = nf90_get_var(ncid, varid, imperv_2d, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
-!
     ! Close the NetCDF file
     ierr = nf90_close(ncid)
     if (ierr /= 0) stop "FATAL ERROR: In module_hrldas_netcdf_io.F read_3d_soil() -  NF90_CLOSE"

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -834,11 +834,48 @@ contains
 
 !---------------------------------------------------------------------------------------------------------
 
+  subroutine read_imperv(spatial_filename, xstart, xend, ystart, yend, imperv_2d)
+
+    implicit none
+    character(len=*),          intent(in)  :: spatial_filename
+    integer,                   intent(in)  :: xstart, xend, ystart, yend
+    real,    dimension(xstart:xend,ystart:yend), intent(out) :: imperv_2d
+
+    character(len=24)  :: name
+    character(len=256) :: units
+    integer :: ierr,iret, varid
+    integer :: ncid
+    real, dimension(xstart:xend,ystart:yend) :: xdum
+!------------------------------------------------------------------------------------------------------
+
+    ierr = nf90_open(spatial_filename, NF90_NOWRITE, ncid)
+    if (ierr /= 0) then
+       write(*,'("FATAL ERROR: In read_imperv():  Problem opening soil file: ''", A, "''")') trim(spatial_filename)
+       stop
+    endif
+
+    name = "imperv"
+    iret = nf90_inq_varid(ncid,  trim(name),  varid)
+    if (iret /= 0) then
+      print*, 'ncid = ', ncid
+      write(*,*) "FATAL ERROR: In read_imperv():  Problem finding variable '"//trim(name)//"' in NetCDF file: " // trim(spatial_filename)
+      stop
+    endif
+
+    iret = nf90_get_var(ncid, varid, imperv_2d, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
+!
+    ! Close the NetCDF file
+    ierr = nf90_close(ncid)
+    if (ierr /= 0) stop "FATAL ERROR: In module_hrldas_netcdf_io.F read_imperv() -  NF90_CLOSE"
+
+  end subroutine read_imperv
+
+!---------------------------------------------------------------------------------------------------------
+
   subroutine read_3d_soil(spatial_filename,xstart, xend,ystart, yend,           &
                           nsoil,bexp_3d,smcdry_3d,smcwlt_3d,smcref_3d,smcmax_3d,  &
 		          dksat_3d,dwsat_3d,psisat_3d,quartz_3d,refdk_2d,refkdt_2d,slope_2d,&
-			  cwpvt_2d,vcmx25_2d,mp_2d,hvt_2d,mfsno_2d,rsurfexp_2d,imperv_2d,&
-                          impconnA_2d,impconnB_2d)
+			  cwpvt_2d,vcmx25_2d,mp_2d,hvt_2d,mfsno_2d,rsurfexp_2d)
     implicit none
     character(len=*),          intent(in)  :: spatial_filename
     integer,                   intent(in)  :: xstart, xend, ystart, yend
@@ -861,9 +898,6 @@ contains
     real,    dimension(xstart:xend,ystart:yend), intent(out)       :: hvt_2d
     real,    dimension(xstart:xend,ystart:yend), intent(out)       :: mfsno_2d
     real,    dimension(xstart:xend,ystart:yend), intent(out)       :: rsurfexp_2d
-    real,    dimension(xstart:xend,ystart:yend), intent(out)       :: imperv_2d
-    real,    dimension(xstart:xend,ystart:yend), intent(out)       :: impconnA_2d
-    real,    dimension(xstart:xend,ystart:yend), intent(out)       :: impconnB_2d
 
     character(len=24)  :: name
     character(len=256) :: units
@@ -1103,26 +1137,6 @@ contains
 
     iret = nf90_get_var(ncid, varid, imperv_2d, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
 !
-    name = "impconnA"
-    iret = nf90_inq_varid(ncid,  trim(name),  varid)
-    if (iret /= 0) then
-      print*, 'ncid = ', ncid
-      write(*,*) "FATAL ERROR: In read_3d_soil():  Problem finding variable '"//trim(name)//"' in NetCDF file: " // trim(spatial_filename)
-      stop
-    endif
-
-    iret = nf90_get_var(ncid, varid, impconnA_2d, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
- !
-    name = "impconnB"
-    iret = nf90_inq_varid(ncid,  trim(name),  varid)
-    if (iret /= 0) then
-      print*, 'ncid = ', ncid
-      write(*,*) "FATAL ERROR: In read_3d_soil():  Problem finding variable '"//trim(name)//"' in NetCDF file: " // trim(spatial_filename)
-      stop
-    endif
-
-    iret = nf90_get_var(ncid, varid, impconnB_2d, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
-
     ! Close the NetCDF file
     ierr = nf90_close(ncid)
     if (ierr /= 0) stop "FATAL ERROR: In module_hrldas_netcdf_io.F read_3d_soil() -  NF90_CLOSE"

--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -837,7 +837,8 @@ contains
   subroutine read_3d_soil(spatial_filename,xstart, xend,ystart, yend,           &
                           nsoil,bexp_3d,smcdry_3d,smcwlt_3d,smcref_3d,smcmax_3d,  &
 		          dksat_3d,dwsat_3d,psisat_3d,quartz_3d,refdk_2d,refkdt_2d,slope_2d,&
-			  cwpvt_2d,vcmx25_2d,mp_2d,hvt_2d,mfsno_2d,rsurfexp_2d,imperv_2d)
+			  cwpvt_2d,vcmx25_2d,mp_2d,hvt_2d,mfsno_2d,rsurfexp_2d,imperv_2d,&
+                          impconnA_2d,impconnB_2d)
     implicit none
     character(len=*),          intent(in)  :: spatial_filename
     integer,                   intent(in)  :: xstart, xend, ystart, yend
@@ -861,6 +862,8 @@ contains
     real,    dimension(xstart:xend,ystart:yend), intent(out)       :: mfsno_2d
     real,    dimension(xstart:xend,ystart:yend), intent(out)       :: rsurfexp_2d
     real,    dimension(xstart:xend,ystart:yend), intent(out)       :: imperv_2d
+    real,    dimension(xstart:xend,ystart:yend), intent(out)       :: impconnA_2d
+    real,    dimension(xstart:xend,ystart:yend), intent(out)       :: impconnB_2d
 
     character(len=24)  :: name
     character(len=256) :: units
@@ -1099,7 +1102,27 @@ contains
     endif
 
     iret = nf90_get_var(ncid, varid, imperv_2d, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
- 
+!
+    name = "impconnA"
+    iret = nf90_inq_varid(ncid,  trim(name),  varid)
+    if (iret /= 0) then
+      print*, 'ncid = ', ncid
+      write(*,*) "FATAL ERROR: In read_3d_soil():  Problem finding variable '"//trim(name)//"' in NetCDF file: " // trim(spatial_filename)
+      stop
+    endif
+
+    iret = nf90_get_var(ncid, varid, impconnA_2d, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
+ !
+    name = "impconnB"
+    iret = nf90_inq_varid(ncid,  trim(name),  varid)
+    if (iret /= 0) then
+      print*, 'ncid = ', ncid
+      write(*,*) "FATAL ERROR: In read_3d_soil():  Problem finding variable '"//trim(name)//"' in NetCDF file: " // trim(spatial_filename)
+      stop
+    endif
+
+    iret = nf90_get_var(ncid, varid, impconnB_2d, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
+
     ! Close the NetCDF file
     ierr = nf90_close(ncid)
     if (ierr /= 0) stop "FATAL ERROR: In module_hrldas_netcdf_io.F read_3d_soil() -  NF90_CLOSE"

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
@@ -35,7 +35,8 @@ CONTAINS
 		 XLAND,     XICE,XICE_THRES,                                & ! IN : Vegetation/Soil characteristics
                  IDVEG, IOPT_CRS,  IOPT_BTR, IOPT_RUN, IOPT_SFC, IOPT_FRZ,  & ! IN : User options
               IOPT_INF, IOPT_RAD,  IOPT_ALB, IOPT_SNF,IOPT_TBOT, IOPT_STC,  & ! IN : User options
-              IOPT_GLA, IOPT_RSF, IOPT_SOIL,IOPT_PEDO,IOPT_CROP,  IZ0TLND,  & ! IN : User options
+              IOPT_GLA, IOPT_RSF, IOPT_SOIL,IOPT_PEDO,IOPT_CROP,            & ! IN : User options
+              IOPT_IMPERV, IZ0TLND,                                         & ! IN : User options
                    T3D,     QV3D,     U_PHY,    V_PHY,   SWDOWN,      GLW,  & ! IN : Forcing
 		 P8W3D,PRECIP_IN,        SR,                                & ! IN : Forcing
                    TSK,      HFX,      QFX,        LH,   GRDFLX,    SMSTAV, & ! IN/OUT LSM eqv
@@ -123,6 +124,8 @@ CONTAINS
     INTEGER,                                         INTENT(IN   ) ::  IOPT_SOIL ! soil configuration option
     INTEGER,                                         INTENT(IN   ) ::  IOPT_PEDO ! soil pedotransfer function option
     INTEGER,                                         INTENT(IN   ) ::  IOPT_CROP ! crop model option (0->none; 1->Liu et al.)
+    INTEGER,                                         INTENT(IN   ) ::  IOPT_IMPERV !imperviousness infiltration adjustment (0->none; 1->total; 
+                                                                                        !2->Alley&Veenhuis; 3->Sutherland)
     INTEGER,                                         INTENT(IN   ) ::  IZ0TLND   ! option of Chen adjustment of Czil (not used)
     REAL,    DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN   ) ::  T3D       ! 3D atmospheric temperature valid at mid-levels [K]
     REAL,    DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN   ) ::  QV3D      ! 3D water vapor mixing ratio [kg/kg_dry]
@@ -484,7 +487,7 @@ CONTAINS
 
     CALL NOAHMP_OPTIONS(IDVEG  ,IOPT_CRS  ,IOPT_BTR  ,IOPT_RUN  ,IOPT_SFC  ,IOPT_FRZ , &
                      IOPT_INF  ,IOPT_RAD  ,IOPT_ALB  ,IOPT_SNF  ,IOPT_TBOT, IOPT_STC , &
-		     IOPT_RSF  ,IOPT_SOIL ,IOPT_PEDO ,IOPT_CROP )
+		     IOPT_RSF  ,IOPT_SOIL ,IOPT_PEDO ,IOPT_CROP, IOPT_IMPERV )
 
     IPRINT    =  .false.                     ! debug printout
 

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
@@ -64,6 +64,7 @@ CONTAINS
 		 REFDK_2D,REFKDT_2D,SLOPE_2D,                                 &
 		 CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,RSURFEXP_2D,        &
                  AXAJ_2D,BXAJ_2D,XXAJ_2D,                                     &
+                 IMPERV_2D,                                                   &
 #endif
 #ifdef WRF_HYDRO
                sfcheadrt,INFXSRT,soldrain,                                  &
@@ -165,6 +166,7 @@ CONTAINS
     REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  AXAJ_2D   ! Xinanjiang: Tension water distribution inflection parameter [-]
     REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  BXAJ_2D   ! Xinanjiang: Tension water distribution shape parameter [-]
     REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  XXAJ_2D   ! Xinanjiang: Free water distribution shape parameter [-]
+    REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  IMPERV_2D ! impervious fraction
 #endif
 
 ! INOUT (with generic LSM equivalent)
@@ -667,6 +669,7 @@ CONTAINS
        parameters%axaj   = AXAJ_2D(I,J)           ! Xinanjiang: Tension water distribution inflection parameter [-]
        parameters%bxaj   = BXAJ_2D(I,J)           ! Xinanjiang: Tension water distribution shape parameter [-]
        parameters%xxaj   = XXAJ_2D(I,J)           ! Xinanjiang: Free water distribution shape parameter [-]
+       parameters%imperv = IMPERV_2D(I,J)         ! impervious fraction
 #endif
        CALL TRANSFER_MP_PARAMETERS(VEGTYP,SOILTYP,SLOPETYP,SOILCOLOR,CROPTYPE,parameters)
        
@@ -1204,6 +1207,11 @@ SUBROUTINE TRANSFER_MP_PARAMETERS(VEGTYPE,SOILTYPE,SLOPETYPE,SOILCOLOR,CROPTYPE,
     parameters%AXAJ = AXAJ_TABLE(SOILTYPE)
     parameters%BXAJ = BXAJ_TABLE(SOILTYPE)
     parameters%XXAJ = XXAJ_TABLE(SOILTYPE)
+    IF (parameters%URBAN_FLAG) THEN 
+      parameters%IMPERV = IMPERV_URBAN_TABLE
+    ELSE
+      parameters%IMPERV = 0.0
+    ENDIF
 #endif
 ! ----------------------------------------------------------------------
 ! Transfer GENPARM parameters

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
@@ -1216,10 +1216,6 @@ SUBROUTINE TRANSFER_MP_PARAMETERS(VEGTYPE,SOILTYPE,SLOPETYPE,SOILCOLOR,CROPTYPE,
     parameters%KDT    = parameters%REFKDT * parameters%DKSAT(1) / parameters%REFDK
 
     IF(parameters%URBAN_FLAG)THEN  ! Hardcoding some urban parameters for soil
-       parameters%SMCMAX = 0.45 
-       parameters%SMCREF = 0.42 
-       parameters%SMCWLT = 0.40 
-       parameters%SMCDRY = 0.40 
        parameters%CSOIL  = 3.E6
     ENDIF
 

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
@@ -64,7 +64,7 @@ CONTAINS
 		 REFDK_2D,REFKDT_2D,SLOPE_2D,                                 &
 		 CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,RSURFEXP_2D,        &
                  AXAJ_2D,BXAJ_2D,XXAJ_2D,                                     &
-                 IMPERV_2D,                                                   &
+                 IMPERV_2D,IMPCONNA_2D,IMPCONNB_2D,                           &
 #endif
 #ifdef WRF_HYDRO
                sfcheadrt,INFXSRT,soldrain,                                  &
@@ -167,6 +167,8 @@ CONTAINS
     REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  BXAJ_2D   ! Xinanjiang: Tension water distribution shape parameter [-]
     REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  XXAJ_2D   ! Xinanjiang: Free water distribution shape parameter [-]
     REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  IMPERV_2D ! impervious fraction
+    REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  IMPCONNA_2D ! impervious connectivity A parameter from Sutherland 2000  
+    REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  IMPCONNB_2D ! impervious connectivity B parameter from Sutherland 2000
 #endif
 
 ! INOUT (with generic LSM equivalent)
@@ -670,6 +672,8 @@ CONTAINS
        parameters%bxaj   = BXAJ_2D(I,J)           ! Xinanjiang: Tension water distribution shape parameter [-]
        parameters%xxaj   = XXAJ_2D(I,J)           ! Xinanjiang: Free water distribution shape parameter [-]
        parameters%imperv = IMPERV_2D(I,J)         ! impervious fraction
+       parameters%impconnA = IMPCONNA_2D(I,J)     ! impervious connectivity A parameter from Sutherland 2000
+       parameters%impconnB = IMPCONNB_2D(I,J)     ! impervious connectivity B parameter from Sutherland 2000
 #endif
        CALL TRANSFER_MP_PARAMETERS(VEGTYP,SOILTYP,SLOPETYP,SOILCOLOR,CROPTYPE,parameters)
        
@@ -1209,8 +1213,12 @@ SUBROUTINE TRANSFER_MP_PARAMETERS(VEGTYPE,SOILTYPE,SLOPETYPE,SOILCOLOR,CROPTYPE,
     parameters%XXAJ = XXAJ_TABLE(SOILTYPE)
     IF (parameters%URBAN_FLAG) THEN 
       parameters%IMPERV = IMPERV_URBAN_TABLE
+      parameters%IMPCONNA = IMPCONNA_TABLE
+      parameters%IMPCONNB = IMPCONNB_TABLE
     ELSE
       parameters%IMPERV = 0.0
+      parameters%IMPCONNA = 1.0
+      parameters%IMPCONNB = 1.0
     ENDIF
 #endif
 ! ----------------------------------------------------------------------

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
@@ -125,7 +125,7 @@ CONTAINS
     INTEGER,                                         INTENT(IN   ) ::  IOPT_PEDO ! soil pedotransfer function option
     INTEGER,                                         INTENT(IN   ) ::  IOPT_CROP ! crop model option (0->none; 1->Liu et al.)
     INTEGER,                                         INTENT(IN   ) ::  IOPT_IMPERV !imperviousness infiltration adjustment (0->none; 1->total; 
-                                                                                        !2->Alley&Veenhuis; 3->Sutherland)
+                                                                                        !9->old)
     INTEGER,                                         INTENT(IN   ) ::  IZ0TLND   ! option of Chen adjustment of Czil (not used)
     REAL,    DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN   ) ::  T3D       ! 3D atmospheric temperature valid at mid-levels [K]
     REAL,    DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN   ) ::  QV3D      ! 3D water vapor mixing ratio [kg/kg_dry]
@@ -1228,7 +1228,7 @@ SUBROUTINE TRANSFER_MP_PARAMETERS(VEGTYPE,SOILTYPE,SLOPETYPE,SOILCOLOR,CROPTYPE,
     parameters%KDT    = parameters%REFKDT * parameters%DKSAT(1) / parameters%REFDK
 
     IF(parameters%URBAN_FLAG)THEN  ! Hardcoding some urban parameters for soil
-       if (iopt_imperv .eq. 0) then
+       if (iopt_imperv .eq. 9) then
          parameters%SMCMAX = 0.45 
          parameters%SMCREF = 0.42 
          parameters%SMCWLT = 0.40 

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
@@ -678,7 +678,7 @@ CONTAINS
        parameters%impconnA = IMPCONNA_2D(I,J)     ! impervious connectivity A parameter from Sutherland 2000
        parameters%impconnB = IMPCONNB_2D(I,J)     ! impervious connectivity B parameter from Sutherland 2000
 #endif
-       CALL TRANSFER_MP_PARAMETERS(VEGTYP,SOILTYP,SLOPETYP,SOILCOLOR,CROPTYPE,parameters)
+       CALL TRANSFER_MP_PARAMETERS(VEGTYP,SOILTYP,SLOPETYP,SOILCOLOR,CROPTYPE,parameters,iopt_imperv)
        
        GRAIN = 0.0                ! mass of grain [g/m2]
        GDD   = 0.0                ! growing degree days
@@ -1014,7 +1014,7 @@ CONTAINS
   END SUBROUTINE noahmplsm
 !------------------------------------------------------
 
-SUBROUTINE TRANSFER_MP_PARAMETERS(VEGTYPE,SOILTYPE,SLOPETYPE,SOILCOLOR,CROPTYPE,parameters)
+SUBROUTINE TRANSFER_MP_PARAMETERS(VEGTYPE,SOILTYPE,SLOPETYPE,SOILCOLOR,CROPTYPE,parameters,iopt_imperv)
 
   USE NOAHMP_TABLES
   USE MODULE_SF_NOAHMPLSM
@@ -1026,6 +1026,7 @@ SUBROUTINE TRANSFER_MP_PARAMETERS(VEGTYPE,SOILTYPE,SLOPETYPE,SOILCOLOR,CROPTYPE,
   INTEGER, INTENT(IN)    :: SLOPETYPE
   INTEGER, INTENT(IN)    :: SOILCOLOR
   INTEGER, INTENT(IN)    :: CROPTYPE
+  INTEGER, INTENT(IN)    :: iopt_imperv
     
   type (noahmp_parameters), intent(inout) :: parameters
     
@@ -1235,6 +1236,12 @@ SUBROUTINE TRANSFER_MP_PARAMETERS(VEGTYPE,SOILTYPE,SLOPETYPE,SOILCOLOR,CROPTYPE,
     parameters%KDT    = parameters%REFKDT * parameters%DKSAT(1) / parameters%REFDK
 
     IF(parameters%URBAN_FLAG)THEN  ! Hardcoding some urban parameters for soil
+       if (iopt_imperv .eq. 0) then
+         parameters%SMCMAX = 0.45 
+         parameters%SMCREF = 0.42 
+         parameters%SMCWLT = 0.40 
+         parameters%SMCDRY = 0.40 
+       endif
        parameters%CSOIL  = 3.E6
     ENDIF
 

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
@@ -65,7 +65,7 @@ CONTAINS
 		 REFDK_2D,REFKDT_2D,SLOPE_2D,                                 &
 		 CWPVT_2D,VCMX25_2D,MP_2D,HVT_2D,MFSNO_2D,RSURFEXP_2D,        &
                  AXAJ_2D,BXAJ_2D,XXAJ_2D,                                     &
-                 IMPERV_2D,IMPCONNA_2D,IMPCONNB_2D,                           &
+                 IMPERV_2D,                                                   &
 #endif
 #ifdef WRF_HYDRO
                sfcheadrt,INFXSRT,soldrain,                                  &
@@ -170,8 +170,6 @@ CONTAINS
     REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  BXAJ_2D   ! Xinanjiang: Tension water distribution shape parameter [-]
     REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  XXAJ_2D   ! Xinanjiang: Free water distribution shape parameter [-]
     REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  IMPERV_2D ! impervious fraction
-    REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  IMPCONNA_2D ! impervious connectivity A parameter from Sutherland 2000  
-    REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(IN)          ::  IMPCONNB_2D ! impervious connectivity B parameter from Sutherland 2000
 #endif
 
 ! INOUT (with generic LSM equivalent)
@@ -675,8 +673,6 @@ CONTAINS
        parameters%bxaj   = BXAJ_2D(I,J)           ! Xinanjiang: Tension water distribution shape parameter [-]
        parameters%xxaj   = XXAJ_2D(I,J)           ! Xinanjiang: Free water distribution shape parameter [-]
        parameters%imperv = IMPERV_2D(I,J)         ! impervious fraction
-       parameters%impconnA = IMPCONNA_2D(I,J)     ! impervious connectivity A parameter from Sutherland 2000
-       parameters%impconnB = IMPCONNB_2D(I,J)     ! impervious connectivity B parameter from Sutherland 2000
 #endif
        CALL TRANSFER_MP_PARAMETERS(VEGTYP,SOILTYP,SLOPETYP,SOILCOLOR,CROPTYPE,parameters,iopt_imperv)
        
@@ -1217,12 +1213,8 @@ SUBROUTINE TRANSFER_MP_PARAMETERS(VEGTYPE,SOILTYPE,SLOPETYPE,SOILCOLOR,CROPTYPE,
     parameters%XXAJ = XXAJ_TABLE(SOILTYPE)
     IF (parameters%URBAN_FLAG) THEN 
       parameters%IMPERV = IMPERV_URBAN_TABLE
-      parameters%IMPCONNA = IMPCONNA_TABLE
-      parameters%IMPCONNB = IMPCONNB_TABLE
     ELSE
       parameters%IMPERV = 0.0
-      parameters%IMPCONNA = 1.0
-      parameters%IMPCONNB = 1.0
     ENDIF
 #endif
 ! ----------------------------------------------------------------------

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -7201,6 +7201,7 @@ ENDIF   ! CROPTYPE == 0
   REAL                     :: INFMAX
   REAL, DIMENSION(1:NSOIL) :: DMAX
   INTEGER, PARAMETER       :: CVFRZ = 3
+  REAL                     :: imperv_eff   !effective imperviousness
 ! --------------------------------------------------------------------------------
 
     IF (QINSUR >  0.0) THEN
@@ -7249,13 +7250,15 @@ ENDIF   ! CROPTYPE == 0
        INFMAX = INFMAX * FCR
 
 ! imperviousness adjustment
-       RUNSRF = QINSUR * parameters%imperv
+       ! Effective imperviousness from Alley & Veenhuis
+       imperv_eff = 0.0015 * ( (100. * parameters%imperv)**1.41 )
+       RUNSRF = QINSUR * imperv_eff
 
        CALL WDFCND2 (parameters,WDF,WCND,SH2O(1),SICEMAX,1)
        INFMAX = MAX (INFMAX,WCND)
        INFMAX = MIN (INFMAX,PX)
 
-       RUNSRF = RUNSRF + MAX(0., (QINSUR * (1. - parameters%imperv)) - INFMAX)
+       RUNSRF = RUNSRF + MAX(0., (QINSUR * (1. - imperv_eff)) - INFMAX)
        PDDUM = QINSUR - RUNSRF
 
     END IF

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -304,6 +304,8 @@ MODULE MODULE_SF_NOAHMPLSM
      REAL :: RSURF_SNOW   !surface resistance for snow(s/m)
      REAL :: RSURF_EXP    !exponent in the shape parameter for soil resistance option 1
      REAL :: IMPERV       !impervious fraction
+     REAL :: IMPCONNA     !impervious connectivity A parameter from Sutherland 2000
+     REAL :: IMPCONNB     !impervious connectivity B parameter from Sutherland 2000
 
 !------------------------------------------------------------------------------------------!
 ! From the crop section of MPTABLE.TBL
@@ -7250,8 +7252,8 @@ ENDIF   ! CROPTYPE == 0
        INFMAX = INFMAX * FCR
 
 ! imperviousness adjustment
-       ! Effective imperviousness from Alley & Veenhuis
-       imperv_eff = 0.0015 * ( (100. * parameters%imperv)**1.41 )
+       ! Effective imperviousness from Sutherland 2000
+       imperv_eff = parameters%impconnA * ( (100. * parameters%imperv)**parameters%impconnB ) / 100.
        RUNSRF = QINSUR * imperv_eff
 
        CALL WDFCND2 (parameters,WDF,WCND,SH2O(1),SICEMAX,1)
@@ -9266,6 +9268,8 @@ MODULE NOAHMP_TABLES
     REAL :: RSURF_SNOW_TABLE    !surface resistance for snow(s/m)
     REAL :: RSURF_EXP_TABLE    !exponent in the shape parameter for soil resistance option 1
     REAL :: IMPERV_URBAN_TABLE  !imperviousness fraction
+    REAL :: IMPCONNA_TABLE      !impervious connectivity A parameter from Sutherland 2000
+    REAL :: IMPCONNB_TABLE      !impervious connectivity B parameter from Sutherland 2000
 
 ! MPTABLE.TBL crop parameters
 
@@ -9771,12 +9775,12 @@ CONTAINS
     REAL :: CO2,O2,TIMEAN,FSATMX,Z0SNO,SSI,SNOW_RET_FAC, &
             SWEMX,TAU0,GRAIN_GROWTH,EXTRA_GROWTH,DIRT_SOOT,&
 	    BATS_COSZ,BATS_VIS_NEW,BATS_NIR_NEW,BATS_VIS_AGE,BATS_NIR_AGE,BATS_VIS_DIR,BATS_NIR_DIR,&
-	    RSURF_SNOW,RSURF_EXP,IMPERV_URBAN
+	    RSURF_SNOW,RSURF_EXP,IMPERV_URBAN,IMPCONNA,IMPCONNB
 
     NAMELIST / noahmp_global_parameters / CO2,O2,TIMEAN,FSATMX,Z0SNO,SSI,SNOW_RET_FAC, &
             SWEMX,TAU0,GRAIN_GROWTH,EXTRA_GROWTH,DIRT_SOOT,&
 	    BATS_COSZ,BATS_VIS_NEW,BATS_NIR_NEW,BATS_VIS_AGE,BATS_NIR_AGE,BATS_VIS_DIR,BATS_NIR_DIR,&
-	    RSURF_SNOW,RSURF_EXP,IMPERV_URBAN
+	    RSURF_SNOW,RSURF_EXP,IMPERV_URBAN,IMPCONNA,IMPCONNB
 
 
     ! Initialize our variables to bad values, so that if the namelist read fails, we come to a screeching halt as soon as we try to use anything.
@@ -9802,6 +9806,8 @@ BATS_NIR_DIR_TABLE   = -1.E36
 RSURF_SNOW_TABLE     = -1.E36
  RSURF_EXP_TABLE     = -1.E36
 IMPERV_URBAN_TABLE   = -1.E36
+IMPCONNA_TABLE       = -1.E36
+IMPCONNB_TABLE       = -1.E36
 
     inquire( file='MPTABLE.TBL', exist=file_named ) 
     if ( file_named ) then
@@ -9840,6 +9846,8 @@ BATS_NIR_DIR_TABLE   = BATS_NIR_DIR
 RSURF_SNOW_TABLE     = RSURF_SNOW
  RSURF_EXP_TABLE     = RSURF_EXP
 IMPERV_URBAN_TABLE   = IMPERV_URBAN
+ IMPCONNA_TABLE      = IMPCONNA
+ IMPCONNB_TABLE      = IMPCONNB
 
   end subroutine read_mp_global_parameters
 

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -303,6 +303,7 @@ MODULE MODULE_SF_NOAHMPLSM
      REAL :: BATS_NIR_DIR !cosz factor for direct NIR snow albedo Yang97 eqn. 16
      REAL :: RSURF_SNOW   !surface resistance for snow(s/m)
      REAL :: RSURF_EXP    !exponent in the shape parameter for soil resistance option 1
+     REAL :: IMPERV       !impervious fraction
 
 !------------------------------------------------------------------------------------------!
 ! From the crop section of MPTABLE.TBL
@@ -9261,6 +9262,7 @@ MODULE NOAHMP_TABLES
     REAL :: BATS_NIR_DIR_TABLE  !cosz factor for direct NIR snow albedo Yang97 eqn. 16
     REAL :: RSURF_SNOW_TABLE    !surface resistance for snow(s/m)
     REAL :: RSURF_EXP_TABLE    !exponent in the shape parameter for soil resistance option 1
+    REAL :: IMPERV_URBAN_TABLE  !imperviousness fraction
 
 ! MPTABLE.TBL crop parameters
 
@@ -9766,12 +9768,12 @@ CONTAINS
     REAL :: CO2,O2,TIMEAN,FSATMX,Z0SNO,SSI,SNOW_RET_FAC, &
             SWEMX,TAU0,GRAIN_GROWTH,EXTRA_GROWTH,DIRT_SOOT,&
 	    BATS_COSZ,BATS_VIS_NEW,BATS_NIR_NEW,BATS_VIS_AGE,BATS_NIR_AGE,BATS_VIS_DIR,BATS_NIR_DIR,&
-	    RSURF_SNOW,RSURF_EXP
+	    RSURF_SNOW,RSURF_EXP,IMPERV_URBAN
 
     NAMELIST / noahmp_global_parameters / CO2,O2,TIMEAN,FSATMX,Z0SNO,SSI,SNOW_RET_FAC, &
             SWEMX,TAU0,GRAIN_GROWTH,EXTRA_GROWTH,DIRT_SOOT,&
 	    BATS_COSZ,BATS_VIS_NEW,BATS_NIR_NEW,BATS_VIS_AGE,BATS_NIR_AGE,BATS_VIS_DIR,BATS_NIR_DIR,&
-	    RSURF_SNOW,RSURF_EXP
+	    RSURF_SNOW,RSURF_EXP,IMPERV_URBAN
 
 
     ! Initialize our variables to bad values, so that if the namelist read fails, we come to a screeching halt as soon as we try to use anything.
@@ -9796,6 +9798,7 @@ BATS_VIS_DIR_TABLE   = -1.E36
 BATS_NIR_DIR_TABLE   = -1.E36
 RSURF_SNOW_TABLE     = -1.E36
  RSURF_EXP_TABLE     = -1.E36
+IMPERV_URBAN_TABLE   = -1.E36
 
     inquire( file='MPTABLE.TBL', exist=file_named ) 
     if ( file_named ) then
@@ -9833,6 +9836,7 @@ BATS_VIS_DIR_TABLE   = BATS_VIS_DIR
 BATS_NIR_DIR_TABLE   = BATS_NIR_DIR
 RSURF_SNOW_TABLE     = RSURF_SNOW
  RSURF_EXP_TABLE     = RSURF_EXP
+IMPERV_URBAN_TABLE   = IMPERV_URBAN
 
   end subroutine read_mp_global_parameters
 

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -170,9 +170,11 @@ MODULE MODULE_SF_NOAHMPLSM
                       !   1 -> Liu, et al. 2016
 
   INTEGER :: OPT_IMPERV  ! options for imperviousness infiltration adjustment
-                      ! **0 -> no imperviousness adjustment
+                      !   0 -> no imperviousness adjustment
                       !   1 -> use total imperviousness
                       !   2 -> use effective imperviousness from Alley & Veenhuis
+                      ! **9 -> older model behavior (urban soil parameter adjustment 
+                      !        and mixed runoff adjustment depending on runoff scheme)
 
 !------------------------------------------------------------------------------------------!
 ! Physical Constants:                                                                      !
@@ -6909,6 +6911,9 @@ ENDIF   ! CROPTYPE == 0
   REAL                                    :: SMCTOT !2-m averaged soil moisture (m3/m3)
   REAL                                    :: DZTOT  !2-m soil depth (m)
   REAL, PARAMETER :: A = 4.0
+
+  REAL                                    :: imperv_eff !local impervious adjustment (fraction, 0-1)
+
 ! ----------------------------------------------------------------------
     RUNSRF = 0.0
     PDDUM  = 0.0
@@ -6953,15 +6958,19 @@ ENDIF   ! CROPTYPE == 0
 !surface runoff and infiltration rate using different schemes
 
 !jref impermable surface at urban
+! We are updating surface runoff adjustment as an area-mean
+! of impervious and frozen soil impermeable adjustments.
     IF (OPT_IMPERV == 1) THEN
        ! Use total imperviousness
-       FCR(1) = parameters%imperv 
+       imperv_eff = parameters%imperv
+       FCR(1) = imperv_eff + (1.0 - imperv_eff) * FCR(1)
     ELSE IF (OPT_IMPERV == 2) THEN
        ! Effective imperviousness from Alley & Veenhuis
-       FCR(1) = 0.0015 * ( (100. * parameters%imperv)**1.41 )
-    ELSE  
-       ! Fixed value
-       IF ( parameters%urban_flag ) FCR(1)=0.95 
+       imperv_eff = 0.0015 * ( (100. * parameters%imperv)**1.41 )
+       FCR(1) = imperv_eff + (1.0 - imperv_eff) * FCR(1)
+    ELSE IF (OPT_IMPERV == 9) THEN 
+       ! Fixed value for urban type (older configuration)
+       IF ( parameters%urban_flag ) FCR(1)=0.95
     END IF
 
     IF(OPT_RUN == 1) THEN
@@ -7271,7 +7280,7 @@ ENDIF   ! CROPTYPE == 0
        ELSE IF (OPT_IMPERV == 2) THEN
          ! Effective imperviousness from Alley & Veenhuis
          imperv_eff = 0.0015 * ( (100. * parameters%imperv)**1.41 )
-       ELSE
+       ELSE ! options 0 and 9 both have no impervious adjustment
          ! No imperviousness adjustment
          imperv_eff = 0.0
        END IF

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -6956,7 +6956,7 @@ ENDIF   ! CROPTYPE == 0
 !surface runoff and infiltration rate using different schemes
 
 !jref impermable surface at urban
-    IF ( parameters%urban_flag ) FCR(1)= 0.95
+    IF ( parameters%urban_flag ) FCR(1)= parameters%imperv
 
     IF(OPT_RUN == 1) THEN
        FFF = 6.0

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -6956,7 +6956,19 @@ ENDIF   ! CROPTYPE == 0
 !surface runoff and infiltration rate using different schemes
 
 !jref impermable surface at urban
-    IF ( parameters%urban_flag ) FCR(1)= parameters%imperv
+    IF (OPT_IMPERV == 1) THEN
+       ! Use total imperviousness
+       FCR(1) = parameters%imperv 
+    ELSE IF (OPT_IMPERV == 2) THEN
+       ! Effective imperviousness from Alley & Veenhuis
+       FCR(1) = 0.0015 * ( (100. * parameters%imperv)**1.41 )
+    ELSE IF (OPT_IMPERV == 3) THEN
+       ! Effective imperviousness from Sutherland 2000
+       FCR(1) = parameters%impconnA * ( (100. * parameters%imperv)**parameters%impconnB ) / 100.
+    ELSE  
+       ! Fixed value
+       IF ( parameters%urban_flag ) FCR(1)=0.95 
+    END IF
 
     IF(OPT_RUN == 1) THEN
        FFF = 6.0

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -169,6 +169,12 @@ MODULE MODULE_SF_NOAHMPLSM
                       ! **0 -> No crop model, will run default dynamic vegetation
                       !   1 -> Liu, et al. 2016
 
+  INTEGER :: OPT_IMPERV  ! options for imperviousness infiltration adjustment
+                      ! **0 -> no imperviousness adjustment
+                      !   1 -> use total imperviousness
+                      !   2 -> use effective imperviousness from Alley & Veenhuis
+                      !   3 -> use effective imperviousness from Sutherland
+
 !------------------------------------------------------------------------------------------!
 ! Physical Constants:                                                                      !
 !------------------------------------------------------------------------------------------!
@@ -7252,8 +7258,21 @@ ENDIF   ! CROPTYPE == 0
        INFMAX = INFMAX * FCR
 
 ! imperviousness adjustment
-       ! Effective imperviousness from Sutherland 2000
-       imperv_eff = parameters%impconnA * ( (100. * parameters%imperv)**parameters%impconnB ) / 100.
+
+       IF (OPT_IMPERV == 1) THEN
+         ! Use total imperviousness
+         imperv_eff = parameters%imperv
+       ELSE IF (OPT_IMPERV == 2) THEN
+         ! Effective imperviousness from Alley & Veenhuis
+         imperv_eff = 0.0015 * ( (100. * parameters%imperv)**1.41 )
+       ELSE IF (OPT_IMPERV == 3) THEN
+         ! Effective imperviousness from Sutherland 2000
+         imperv_eff = parameters%impconnA * ( (100. * parameters%imperv)**parameters%impconnB ) / 100.
+       ELSE
+         ! No imperviousness adjustment
+         imperv_eff = 0.0
+       END IF
+
        RUNSRF = QINSUR * imperv_eff
 
        CALL WDFCND2 (parameters,WDF,WCND,SH2O(1),SICEMAX,1)
@@ -9080,7 +9099,7 @@ END SUBROUTINE PSN_CROP
 
   subroutine noahmp_options(idveg     ,iopt_crs  ,iopt_btr  ,iopt_run  ,iopt_sfc  ,iopt_frz , & 
                              iopt_inf  ,iopt_rad  ,iopt_alb  ,iopt_snf  ,iopt_tbot, iopt_stc, &
-			     iopt_rsf , iopt_soil, iopt_pedo, iopt_crop )
+			     iopt_rsf , iopt_soil, iopt_pedo, iopt_crop, iopt_imperv )
 
   implicit none
 
@@ -9102,6 +9121,8 @@ END SUBROUTINE PSN_CROP
   INTEGER,  INTENT(IN) :: iopt_soil !soil parameters set-up option
   INTEGER,  INTENT(IN) :: iopt_pedo !pedo-transfer function (1->Saxton and Rawls)
   INTEGER,  INTENT(IN) :: iopt_crop !crop model option (0->none; 1->Liu et al.)
+  INTEGER,  INTENT(IN) :: iopt_imperv !imperviousness infiltration adjustment (0->none; 1->total imperviousness;
+                                           !2->Alley&Veenhuis;!3->Sutherland)
 
 ! -------------------------------------------------------------------------------------------------
 
@@ -9122,6 +9143,7 @@ END SUBROUTINE PSN_CROP
   opt_soil = iopt_soil
   opt_pedo = iopt_pedo
   opt_crop = iopt_crop
+  opt_imperv = iopt_imperv
   
   end subroutine noahmp_options
  

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -7248,14 +7248,14 @@ ENDIF   ! CROPTYPE == 0
 
        INFMAX = INFMAX * FCR
 
-! jref for urban areas
-!       IF ( parameters%urban_flag ) INFMAX == INFMAX * 0.05
+! imperviousness adjustment
+       RUNSRF = QINSUR * parameters%imperv
 
        CALL WDFCND2 (parameters,WDF,WCND,SH2O(1),SICEMAX,1)
        INFMAX = MAX (INFMAX,WCND)
        INFMAX = MIN (INFMAX,PX)
 
-       RUNSRF= MAX(0., QINSUR - INFMAX)
+       RUNSRF = RUNSRF + MAX(0., (QINSUR * (1. - parameters%imperv)) - INFMAX)
        PDDUM = QINSUR - RUNSRF
 
     END IF

--- a/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/module_sf_noahmplsm.F
@@ -173,7 +173,6 @@ MODULE MODULE_SF_NOAHMPLSM
                       ! **0 -> no imperviousness adjustment
                       !   1 -> use total imperviousness
                       !   2 -> use effective imperviousness from Alley & Veenhuis
-                      !   3 -> use effective imperviousness from Sutherland
 
 !------------------------------------------------------------------------------------------!
 ! Physical Constants:                                                                      !
@@ -310,8 +309,6 @@ MODULE MODULE_SF_NOAHMPLSM
      REAL :: RSURF_SNOW   !surface resistance for snow(s/m)
      REAL :: RSURF_EXP    !exponent in the shape parameter for soil resistance option 1
      REAL :: IMPERV       !impervious fraction
-     REAL :: IMPCONNA     !impervious connectivity A parameter from Sutherland 2000
-     REAL :: IMPCONNB     !impervious connectivity B parameter from Sutherland 2000
 
 !------------------------------------------------------------------------------------------!
 ! From the crop section of MPTABLE.TBL
@@ -6962,9 +6959,6 @@ ENDIF   ! CROPTYPE == 0
     ELSE IF (OPT_IMPERV == 2) THEN
        ! Effective imperviousness from Alley & Veenhuis
        FCR(1) = 0.0015 * ( (100. * parameters%imperv)**1.41 )
-    ELSE IF (OPT_IMPERV == 3) THEN
-       ! Effective imperviousness from Sutherland 2000
-       FCR(1) = parameters%impconnA * ( (100. * parameters%imperv)**parameters%impconnB ) / 100.
     ELSE  
        ! Fixed value
        IF ( parameters%urban_flag ) FCR(1)=0.95 
@@ -7277,9 +7271,6 @@ ENDIF   ! CROPTYPE == 0
        ELSE IF (OPT_IMPERV == 2) THEN
          ! Effective imperviousness from Alley & Veenhuis
          imperv_eff = 0.0015 * ( (100. * parameters%imperv)**1.41 )
-       ELSE IF (OPT_IMPERV == 3) THEN
-         ! Effective imperviousness from Sutherland 2000
-         imperv_eff = parameters%impconnA * ( (100. * parameters%imperv)**parameters%impconnB ) / 100.
        ELSE
          ! No imperviousness adjustment
          imperv_eff = 0.0
@@ -9134,7 +9125,7 @@ END SUBROUTINE PSN_CROP
   INTEGER,  INTENT(IN) :: iopt_pedo !pedo-transfer function (1->Saxton and Rawls)
   INTEGER,  INTENT(IN) :: iopt_crop !crop model option (0->none; 1->Liu et al.)
   INTEGER,  INTENT(IN) :: iopt_imperv !imperviousness infiltration adjustment (0->none; 1->total imperviousness;
-                                           !2->Alley&Veenhuis;!3->Sutherland)
+                                           !2->Alley&Veenhuis)
 
 ! -------------------------------------------------------------------------------------------------
 
@@ -9302,8 +9293,6 @@ MODULE NOAHMP_TABLES
     REAL :: RSURF_SNOW_TABLE    !surface resistance for snow(s/m)
     REAL :: RSURF_EXP_TABLE    !exponent in the shape parameter for soil resistance option 1
     REAL :: IMPERV_URBAN_TABLE  !imperviousness fraction
-    REAL :: IMPCONNA_TABLE      !impervious connectivity A parameter from Sutherland 2000
-    REAL :: IMPCONNB_TABLE      !impervious connectivity B parameter from Sutherland 2000
 
 ! MPTABLE.TBL crop parameters
 
@@ -9809,12 +9798,12 @@ CONTAINS
     REAL :: CO2,O2,TIMEAN,FSATMX,Z0SNO,SSI,SNOW_RET_FAC, &
             SWEMX,TAU0,GRAIN_GROWTH,EXTRA_GROWTH,DIRT_SOOT,&
 	    BATS_COSZ,BATS_VIS_NEW,BATS_NIR_NEW,BATS_VIS_AGE,BATS_NIR_AGE,BATS_VIS_DIR,BATS_NIR_DIR,&
-	    RSURF_SNOW,RSURF_EXP,IMPERV_URBAN,IMPCONNA,IMPCONNB
+	    RSURF_SNOW,RSURF_EXP,IMPERV_URBAN
 
     NAMELIST / noahmp_global_parameters / CO2,O2,TIMEAN,FSATMX,Z0SNO,SSI,SNOW_RET_FAC, &
             SWEMX,TAU0,GRAIN_GROWTH,EXTRA_GROWTH,DIRT_SOOT,&
 	    BATS_COSZ,BATS_VIS_NEW,BATS_NIR_NEW,BATS_VIS_AGE,BATS_NIR_AGE,BATS_VIS_DIR,BATS_NIR_DIR,&
-	    RSURF_SNOW,RSURF_EXP,IMPERV_URBAN,IMPCONNA,IMPCONNB
+	    RSURF_SNOW,RSURF_EXP,IMPERV_URBAN
 
 
     ! Initialize our variables to bad values, so that if the namelist read fails, we come to a screeching halt as soon as we try to use anything.
@@ -9840,8 +9829,6 @@ BATS_NIR_DIR_TABLE   = -1.E36
 RSURF_SNOW_TABLE     = -1.E36
  RSURF_EXP_TABLE     = -1.E36
 IMPERV_URBAN_TABLE   = -1.E36
-IMPCONNA_TABLE       = -1.E36
-IMPCONNB_TABLE       = -1.E36
 
     inquire( file='MPTABLE.TBL', exist=file_named ) 
     if ( file_named ) then
@@ -9880,8 +9867,6 @@ BATS_NIR_DIR_TABLE   = BATS_NIR_DIR
 RSURF_SNOW_TABLE     = RSURF_SNOW
  RSURF_EXP_TABLE     = RSURF_EXP
 IMPERV_URBAN_TABLE   = IMPERV_URBAN
- IMPCONNA_TABLE      = IMPCONNA
- IMPCONNB_TABLE      = IMPCONNB
 
   end subroutine read_mp_global_parameters
 

--- a/trunk/NDHMS/Land_models/NoahMP/run/MPTABLE.TBL
+++ b/trunk/NDHMS/Land_models/NoahMP/run/MPTABLE.TBL
@@ -343,6 +343,8 @@
   RSURF_SNOW = 50.0     !surface resistence for snow [s/m]
   RSURF_EXP = 5.0       !exponent in the shape parameter for soil resistance option 1
   IMPERV_URBAN = 1.0    !impervious fraction to use for urban type [0-1]
+  IMPCONNA = 1.0        !impervious connectivity A parameter from Sutherland 2000 (low to high: 0.01, 0.04, 0.1, 0.4, 1.0) 
+  IMPCONNB = 1.0        !impervious connectivity A parameter from Sutherland 2000 (low to high: 2.0, 1.7, 1.5, 1.2, 1.0)
 /
 
 &noahmp_crop_parameters

--- a/trunk/NDHMS/Land_models/NoahMP/run/MPTABLE.TBL
+++ b/trunk/NDHMS/Land_models/NoahMP/run/MPTABLE.TBL
@@ -343,8 +343,6 @@
   RSURF_SNOW = 50.0     !surface resistence for snow [s/m]
   RSURF_EXP = 5.0       !exponent in the shape parameter for soil resistance option 1
   IMPERV_URBAN = 1.0    !impervious fraction to use for urban type [0-1]
-  IMPCONNA = 1.0        !impervious connectivity A parameter from Sutherland 2000 (low to high: 0.01, 0.04, 0.1, 0.4, 1.0) 
-  IMPCONNB = 1.0        !impervious connectivity A parameter from Sutherland 2000 (low to high: 2.0, 1.7, 1.5, 1.2, 1.0)
 /
 
 &noahmp_crop_parameters

--- a/trunk/NDHMS/Land_models/NoahMP/run/MPTABLE.TBL
+++ b/trunk/NDHMS/Land_models/NoahMP/run/MPTABLE.TBL
@@ -342,7 +342,7 @@
   BATS_NIR_DIR  = 0.4   !cosz factor for direct NIR snow albedo Yang97 eqn. 16
   RSURF_SNOW = 50.0     !surface resistence for snow [s/m]
   RSURF_EXP = 5.0       !exponent in the shape parameter for soil resistance option 1
-
+  IMPERV_URBAN = 1.0    !impervious fraction to use for urban type [0-1]
 /
 
 &noahmp_crop_parameters

--- a/trunk/NDHMS/Land_models/NoahMP/run/MPTABLE.TBL
+++ b/trunk/NDHMS/Land_models/NoahMP/run/MPTABLE.TBL
@@ -342,7 +342,7 @@
   BATS_NIR_DIR  = 0.4   !cosz factor for direct NIR snow albedo Yang97 eqn. 16
   RSURF_SNOW = 50.0     !surface resistence for snow [s/m]
   RSURF_EXP = 5.0       !exponent in the shape parameter for soil resistance option 1
-  IMPERV_URBAN = 1.0    !impervious fraction to use for urban type [0-1]
+  IMPERV_URBAN = 0.95   !impervious fraction to use for urban type [0-1]
 /
 
 &noahmp_crop_parameters

--- a/trunk/NDHMS/OrchestratorLayer/config.f90
+++ b/trunk/NDHMS/OrchestratorLayer/config.f90
@@ -40,7 +40,7 @@ module config_base
      integer            :: soil_data_option = 1
      integer            :: pedotransfer_option = 0
      integer            :: crop_option = 0
-     integer            :: imperv_option = 0
+     integer            :: imperv_option = 9
 
      integer            :: split_output_count = 1 
      integer            :: khour
@@ -884,7 +884,7 @@ contains
      integer            :: soil_data_option = 1
      integer            :: pedotransfer_option = 0
      integer            :: crop_option = 0
-     integer            :: imperv_option = 0
+     integer            :: imperv_option = 9
      integer            :: split_output_count = 1
      integer            :: khour = -999
      integer            :: kday = -999

--- a/trunk/NDHMS/OrchestratorLayer/config.f90
+++ b/trunk/NDHMS/OrchestratorLayer/config.f90
@@ -40,6 +40,7 @@ module config_base
      integer            :: soil_data_option = 1
      integer            :: pedotransfer_option = 0
      integer            :: crop_option = 0
+     integer            :: imperv_option = 0
 
      integer            :: split_output_count = 1 
      integer            :: khour
@@ -876,6 +877,7 @@ contains
      integer            :: soil_data_option = 1
      integer            :: pedotransfer_option = 0
      integer            :: crop_option = 0
+     integer            :: imperv_option = 0
      integer            :: split_output_count = 1
      integer            :: khour = -999
      integer            :: kday = -999
@@ -909,6 +911,7 @@ contains
          glacier_option, surface_resistance_option, &
          
          soil_data_option, pedotransfer_option, crop_option, &
+         imperv_option, &
 
          split_output_count, &
          khour, kday, zlvl, hrldas_setup_file, mmf_runoff_file, &
@@ -1009,6 +1012,7 @@ contains
     noah_lsm%soil_data_option = soil_data_option
     noah_lsm%pedotransfer_option = pedotransfer_option
     noah_lsm%crop_option = crop_option
+    noah_lsm%imperv_option = imperv_option
 
     noah_lsm%split_output_count = split_output_count
 

--- a/trunk/NDHMS/OrchestratorLayer/config.f90
+++ b/trunk/NDHMS/OrchestratorLayer/config.f90
@@ -158,6 +158,7 @@ module config_base
      character(len=256) :: timeSlicePath
      integer            :: nLastObs
      integer            :: bucket_loss
+     integer            :: imperv_adj
 
    contains
 
@@ -444,6 +445,10 @@ contains
       endif
    end if
 
+   if( (self%imperv_adj .lt. 0 ) .or. (self%imperv_adj .gt. 1) ) then
+      call hydro_stop('hydro.namelist ERROR: Invalid imperv_adj specified')
+   endif
+
   end subroutine rt_nlst_check
 
   subroutine init_namelist_rt_field(did)
@@ -457,7 +462,7 @@ contains
          GWBASESWCRT,  GW_RESTART,RSTRT_SWC,TERADJ_SOLAR, &
          sys_cpl, rst_typ, rst_bi_in, rst_bi_out, &
          gwChanCondSw, GwPreCycles, GwSpinCycles, GwPreDiagInterval, gwsoilcpl, &
-         UDMP_OPT, io_form_outputs, bucket_loss
+         UDMP_OPT, io_form_outputs, bucket_loss, imperv_adj
     real:: DTRT_TER,DTRT_CH,dxrt, gwChanCondConstIn, gwChanCondConstOut, gwIhShift
     character(len=256) :: route_topo_f=""
     character(len=256) :: route_chan_f=""
@@ -548,7 +553,7 @@ contains
          CHRTOUT_DOMAIN,CHANOBS_DOMAIN,CHRTOUT_GRID,LSMOUT_DOMAIN,&
          RTOUT_DOMAIN, output_gw, outlake, &
          frxst_pts_out, udmap_file, UDMP_OPT, GWBUCKPARM_file, bucket_loss, &
-         io_config_outputs, io_form_outputs, hydrotbl_f, t0OutputFlag, output_channelBucket_influx
+         io_config_outputs, io_form_outputs, hydrotbl_f, t0OutputFlag, output_channelBucket_influx, imperv_adj
 
 #ifdef WRF_HYDRO_NUDGING
     namelist /NUDGING_nlist/ nudgingParamFile,       netwkReExFile,          &
@@ -584,6 +589,7 @@ contains
     reservoir_rfc_forecasts = .FALSE.
     reservoir_rfc_forecasts_lookback_hours = 24
     reservoir_type_specified = .FALSE.
+    imperv_adj = 0
 
 #ifdef WRF_HYDRO_NUDGING
     ! Default values for NUDGING_nlist
@@ -756,6 +762,7 @@ contains
     nlst(did)%order_to_write = order_to_write
     nlst(did)%compound_channel = compound_channel
     nlst(did)%channel_loss_option = channel_loss_option
+    nlst(did)%imperv_adj = imperv_adj
     ! files
     nlst(did)%route_topo_f = route_topo_f
     nlst(did)%route_chan_f = route_chan_f

--- a/trunk/NDHMS/Routing/Noah_distr_routing.F
+++ b/trunk/NDHMS/Routing/Noah_distr_routing.F
@@ -903,7 +903,7 @@ subroutine disaggregateDomain_drv(did)
                             RT_DOMAIN(did)%subsurface%properties%sldpth, &
                             RT_DOMAIN(did)%soiltypRT, RT_DOMAIN(did)%soiltyp, &
                             rt_domain(did)%ELRT, RT_DOMAIN(did)%iswater, &
-                            rt_domain(did)%IMPERVFRAC, noah_lsm%imperv_option)
+                            rt_domain(did)%IMPERVFRAC, nlst(did)%imperv_adj)
 end subroutine disaggregateDomain_drv
 
 !===================================================================================================
@@ -927,7 +927,7 @@ subroutine disaggregateDomain(IX, JX, NSOIL, IXRT, JXRT, AGGFACTRT, &
                               SMCWLT1, VEGTYP, LKSAT, dist,INFXSWGT,OVROUGHRTFAC, &
                               LKSATFAC, CH_NETRT,SH2OWGT,SMCREFRT, INFXSUBRT,SMCMAXRT, &
                               SMCWLTRT,SMCRT, OVROUGHRT, LAKE_MSKRT, LKSATRT, OV_ROUGH2d,  &
-                              SLDPTH, soiltypRT, soiltyp, elrt, iswater, impervfrac, imperv_option)
+                              SLDPTH, soiltypRT, soiltyp, elrt, iswater, impervfrac, imperv_adj)
 #ifdef MPP_LAND
    use module_mpp_land, only: left_id,down_id,right_id, &
                               up_id,mpp_land_com_real, my_id, io_id, numprocs, &
@@ -946,7 +946,7 @@ subroutine disaggregateDomain(IX, JX, NSOIL, IXRT, JXRT, AGGFACTRT, &
    integer, intent(in)                           :: NSOIL ! number of soil layers
    integer, intent(in)                           :: iswater ! water veg class (from geogrid attrib)
    real, intent(in), dimension(NSOIL)            :: SLDPTH ! array soil layer depth intervals (m)
-   integer, intent(in)                           :: imperv_option ! impervious configuration option from LSM
+   integer, intent(in)                           :: imperv_adj ! impervious configuration option from hydro.namelist
    ! LSM grid parameters:
    real, intent(in),  dimension(IX,JX)           :: area_lsm ! cell area on the coarse grid (m2)
    integer, intent(in), dimension(IX,JX)         :: VEGTYP, soiltyp ! coarse grid veg and soil types
@@ -1176,7 +1176,7 @@ subroutine disaggregateDomain(IX, JX, NSOIL, IXRT, JXRT, AGGFACTRT, &
                   ! Modify based on impervious fraction
                   ! See Liong et al. 1989 for linear weighting of "smoothness" (1/roughness)
                   ! Assuming roughness of 0.02 for impervious and native cell roughness for pervious
-                  if (imperv_option .ne. 0) then
+                  if (imperv_adj .ne. 0) then
                      OVROUGHRT(IXXRT,JYYRT) = 1. / ((1./0.02)*impervfrac(IXXRT,JYYRT) + & ! impervious fraction
                                                           (1./OVROUGHRT(IXXRT,JYYRT))*(1.-impervfrac(IXXRT,JYYRT))) ! pervious fraction
                   endif

--- a/trunk/NDHMS/Routing/Noah_distr_routing.F
+++ b/trunk/NDHMS/Routing/Noah_distr_routing.F
@@ -878,8 +878,7 @@ end subroutine MPP_seq_land_SO8
 
 subroutine disaggregateDomain_drv(did)
    use module_RT_data, only: rt_domain
-   use config_base, only: nlst
-
+   use config_base, only: nlst, noah_lsm
    integer :: did
    call disaggregateDomain( RT_DOMAIN(did)%IX, RT_DOMAIN(did)%JX, nlst(did)%NSOIL, &
                             RT_DOMAIN(did)%IXRT, RT_DOMAIN(did)%JXRT, nlst(did)%AGGFACTRT, &
@@ -903,7 +902,8 @@ subroutine disaggregateDomain_drv(did)
                             RT_DOMAIN(did)%OV_ROUGH2d, &
                             RT_DOMAIN(did)%subsurface%properties%sldpth, &
                             RT_DOMAIN(did)%soiltypRT, RT_DOMAIN(did)%soiltyp, &
-                            rt_domain(did)%ELRT, RT_DOMAIN(did)%iswater)
+                            rt_domain(did)%ELRT, RT_DOMAIN(did)%iswater, &
+                            rt_domain(did)%IMPERVFRAC, noah_lsm%imperv_option)
 end subroutine disaggregateDomain_drv
 
 !===================================================================================================
@@ -927,7 +927,7 @@ subroutine disaggregateDomain(IX, JX, NSOIL, IXRT, JXRT, AGGFACTRT, &
                               SMCWLT1, VEGTYP, LKSAT, dist,INFXSWGT,OVROUGHRTFAC, &
                               LKSATFAC, CH_NETRT,SH2OWGT,SMCREFRT, INFXSUBRT,SMCMAXRT, &
                               SMCWLTRT,SMCRT, OVROUGHRT, LAKE_MSKRT, LKSATRT, OV_ROUGH2d,  &
-                              SLDPTH, soiltypRT, soiltyp, elrt, iswater)
+                              SLDPTH, soiltypRT, soiltyp, elrt, iswater, impervfrac, imperv_option)
 #ifdef MPP_LAND
    use module_mpp_land, only: left_id,down_id,right_id, &
                               up_id,mpp_land_com_real, my_id, io_id, numprocs, &
@@ -946,6 +946,7 @@ subroutine disaggregateDomain(IX, JX, NSOIL, IXRT, JXRT, AGGFACTRT, &
    integer, intent(in)                           :: NSOIL ! number of soil layers
    integer, intent(in)                           :: iswater ! water veg class (from geogrid attrib)
    real, intent(in), dimension(NSOIL)            :: SLDPTH ! array soil layer depth intervals (m)
+   integer, intent(in)                           :: imperv_option ! impervious configuration option from LSM
    ! LSM grid parameters:
    real, intent(in),  dimension(IX,JX)           :: area_lsm ! cell area on the coarse grid (m2)
    integer, intent(in), dimension(IX,JX)         :: VEGTYP, soiltyp ! coarse grid veg and soil types
@@ -967,6 +968,7 @@ subroutine disaggregateDomain(IX, JX, NSOIL, IXRT, JXRT, AGGFACTRT, &
    real, intent(in), dimension(IXRT,JXRT)        :: LKSATFAC ! lateral ksat adj factor
    real, intent(in), dimension(IXRT,JXRT)        :: elrt ! elevation grid (m)
    integer, intent(in), dimension(IXRT,JXRT)     :: CH_NETRT ! channel network routing grid
+   real, intent(in), dimension(IXRT,JXRT)        :: impervfrac ! impervious fraction
    ! Routing states:
    real, intent(in), dimension(IXRT,JXRT)        :: INFXSWGT ! infiltration excess weighting grid
    real, intent(in), dimension(IXRT,JXRT,NSOIL)  :: SH2OWGT ! soil moisture weighting grid
@@ -1170,7 +1172,16 @@ subroutine disaggregateDomain(IX, JX, NSOIL, IXRT, JXRT, AGGFACTRT, &
                IF (VEGTYP(I,J).LE.0) then
                   OVROUGHRT(IXXRT,JYYRT) = 0.1     !COWS mask test
                ELSE
-                  OVROUGHRT(IXXRT,JYYRT) = OV_ROUGH2d(i,j)*OVROUGHRTFAC(IXXRT,JYYRT)
+                  OVROUGHRT(IXXRT,JYYRT) = OV_ROUGH2d(i,j)
+                  ! Modify based on impervious fraction
+                  ! See Liong et al. 1989 for linear weighting of "smoothness" (1/roughness)
+                  ! Assuming roughness of 0.02 for impervious and native cell roughness for pervious
+                  if (imperv_option .ne. 0) then
+                     OVROUGHRT(IXXRT,JYYRT) = 1. / ((1./0.02)*impervfrac(IXXRT,JYYRT) + & ! impervious fraction
+                                                          (1./OVROUGHRT(IXXRT,JYYRT))*(1.-impervfrac(IXXRT,JYYRT))) ! pervious fraction
+                  endif
+                  ! Apply user-supplied adjustment factor
+                  OVROUGHRT(IXXRT,JYYRT) = OVROUGHRT(IXXRT,JYYRT)*OVROUGHRTFAC(IXXRT,JYYRT)
                END IF
 
                ! Lateral ksat

--- a/trunk/NDHMS/Routing/module_HYDRO_io.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_io.F
@@ -5641,7 +5641,8 @@ end subroutine mpp_output_chrt
 #endif
 
       SUBROUTINE READ_ROUTING_seq(IXRT,JXRT,ELRT,CH_NETRT,CH_LNKRT,LKSATFAC,route_topo_f,    &
-            route_chan_f, geo_finegrid_flnm,OVROUGHRTFAC,RETDEPRTFAC,channel_option, UDMP_OPT)
+            route_chan_f, geo_finegrid_flnm,OVROUGHRTFAC,RETDEPRTFAC,IMPERVFRAC, &
+            channel_option, UDMP_OPT)
 
 
         INTEGER, INTENT(IN) :: IXRT,JXRT
@@ -5651,6 +5652,7 @@ end subroutine mpp_output_chrt
 !Dummy inverted grids
         REAL, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: OVROUGHRTFAC
         REAL, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: RETDEPRTFAC
+        REAL, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: IMPERVFRAC
 
         integer         :: I,J, iret, jj, channel_option, UDMP_OPT
         CHARACTER(len=256)        :: var_name
@@ -5711,6 +5713,12 @@ end subroutine mpp_output_chrt
                      trim(geo_finegrid_flnm))
         where (OVROUGHRTFAC <= 0.) OVROUGHRTFAC = 1.0 ! reset grid to = 1.0 if non-valid value exists
 
+!Read in new optional impervious layer
+        var_name = "IMPERVFRAC"
+        IMPERVFRAC = -9999.9
+        call nreadRT2d_real(var_name,IMPERVFRAC,ixrt,jxrt,&
+                     trim(geo_finegrid_flnm))
+        where (IMPERVFRAC < 0.) IMPERVFRAC = 0.0  ! reset grid to = 0.0 if non-valid value exists
 
 #ifdef HYDRO_D
         write(6,*) "finish READ_ROUTING_seq"

--- a/trunk/NDHMS/Routing/module_HYDRO_io.F
+++ b/trunk/NDHMS/Routing/module_HYDRO_io.F
@@ -5642,7 +5642,7 @@ end subroutine mpp_output_chrt
 
       SUBROUTINE READ_ROUTING_seq(IXRT,JXRT,ELRT,CH_NETRT,CH_LNKRT,LKSATFAC,route_topo_f,    &
             route_chan_f, geo_finegrid_flnm,OVROUGHRTFAC,RETDEPRTFAC,IMPERVFRAC, &
-            channel_option, UDMP_OPT)
+            channel_option, UDMP_OPT, imperv_adj)
 
 
         INTEGER, INTENT(IN) :: IXRT,JXRT
@@ -5654,7 +5654,7 @@ end subroutine mpp_output_chrt
         REAL, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: RETDEPRTFAC
         REAL, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: IMPERVFRAC
 
-        integer         :: I,J, iret, jj, channel_option, UDMP_OPT
+        integer         :: I,J, iret, jj, channel_option, UDMP_OPT, imperv_adj
         CHARACTER(len=256)        :: var_name
         CHARACTER(len=*  )       :: route_topo_f
         CHARACTER(len=*  )       :: route_chan_f
@@ -5716,9 +5716,13 @@ end subroutine mpp_output_chrt
 !Read in new optional impervious layer
         var_name = "IMPERVFRAC"
         IMPERVFRAC = -9999.9
-        call nreadRT2d_real(var_name,IMPERVFRAC,ixrt,jxrt,&
-                     trim(geo_finegrid_flnm))
-        where (IMPERVFRAC < 0.) IMPERVFRAC = 0.0  ! reset grid to = 0.0 if non-valid value exists
+        if (imperv_adj > 0) then
+          call nreadRT2d_real(var_name,IMPERVFRAC,ixrt,jxrt,&
+                     trim(geo_finegrid_flnm), fatalErr=.true.)
+          where (IMPERVFRAC < 0.) IMPERVFRAC = 0.0  ! reset grid to = 0.0 if non-valid value exists
+        else
+          IMPERVFRAC = 0.0
+        endif
 
 #ifdef HYDRO_D
         write(6,*) "finish READ_ROUTING_seq"

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -715,7 +715,7 @@ subroutine LandRT_ini(did)
              rt_domain(did)%LKSATFAC,trim(nlst(did)%route_topo_f),&
              nlst(did)%route_chan_f,nlst(did)%geo_finegrid_flnm  ,  &
              rt_domain(did)%OVROUGHRTFAC,rt_domain(did)%RETDEPRTFAC, rt_domain(did)%IMPERVFRAC, &
-             nlst(did)%channel_option, nlst(did)%udmp_opt)
+             nlst(did)%channel_option, nlst(did)%udmp_opt, nlst(did)%imperv_adj)
 
 
    !yw CALL READ_ROUTING_old(rt_domain(did)%IXRT,rt_domain(did)%JXRT,rt_domain(did)%ELRT,rt_domain(did)%overland%streams_and_lakes%ch_netrt, &

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -654,7 +654,7 @@ end subroutine getChanDim
 subroutine LandRT_ini(did)
 
   use module_noah_chan_param_init_rt
-  use config_base, only: nlst
+  use config_base, only: nlst, noah_lsm
   use module_RT_data, only: rt_domain
   use module_gw_gw2d_data, only: gw2d
 #ifdef HYDRO_D
@@ -1202,10 +1202,14 @@ subroutine LandRT_ini(did)
         end do
      end do
 
+     !Apply impervious adjustment to retdeprt (AD)
+     if (noah_lsm%imperv_option .ne. 0) then
+       rt_domain(did)%overland%properties%retention_depth = rt_domain(did)%overland%properties%retention_depth*(1.-rt_domain(did)%impervfrac)
+     end if
 
      !Apply calibration scaling factors to sfc roughness and retention depth here...
      rt_domain(did)%overland%properties%retention_depth = rt_domain(did)%overland%properties%retention_depth * rt_domain(did)%RETDEPRTFAC
-     rt_domain(did)%overland%properties%roughness = rt_domain(did)%overland%properties%roughness * rt_domain(did)%OVROUGHRTFAC
+     ! Removing roughness parameter update since it has not been populated yet... currently happens in Noah_dist_routing (AD)
 
    !ADCHANGE: Moved this channel cell setting from OV_RTNG so it is outside
    !of overland routine (frequently called) and time loop.

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -183,6 +183,10 @@ CONTAINS
      !rt_domain(did)%LKSATRT     = 0.0
      allocate( rt_domain(did)%LKSATFAC    (IXRT,JXRT) )
      rt_domain(did)%LKSATFAC    = 0.0
+
+     allocate( rt_domain(did)%IMPERVFRAC    (IXRT,JXRT) )
+     rt_domain(did)%IMPERVFRAC    = 0.0
+
      !allocate( rt_domain(did)%subsurface%state%qsubrt      (IXRT,JXRT) )
      !rt_domain(did)%subsurface%state%qsubrt      = 0.0
      !allocate( rt_domain(did)%subsurface%properties%zwattablrt  (IXRT,JXRT) )
@@ -710,7 +714,7 @@ subroutine LandRT_ini(did)
              rt_domain(did)%CH_LNKRT, &
              rt_domain(did)%LKSATFAC,trim(nlst(did)%route_topo_f),&
              nlst(did)%route_chan_f,nlst(did)%geo_finegrid_flnm  ,  &
-             rt_domain(did)%OVROUGHRTFAC,rt_domain(did)%RETDEPRTFAC, &
+             rt_domain(did)%OVROUGHRTFAC,rt_domain(did)%RETDEPRTFAC, rt_domain(did)%IMPERVFRAC, &
              nlst(did)%channel_option, nlst(did)%udmp_opt)
 
 

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -1203,7 +1203,7 @@ subroutine LandRT_ini(did)
      end do
 
      !Apply impervious adjustment to retdeprt (AD)
-     if (noah_lsm%imperv_option .ne. 0) then
+     if (nlst(did)%imperv_adj .ne. 0) then
        rt_domain(did)%overland%properties%retention_depth = rt_domain(did)%overland%properties%retention_depth*(1.-rt_domain(did)%impervfrac)
      end if
 

--- a/trunk/NDHMS/template/HYDRO/hydro.namelist
+++ b/trunk/NDHMS/template/HYDRO/hydro.namelist
@@ -134,6 +134,9 @@ OVRTSWCRT = 1
 ! NOTE: Currently subsurface flow is only steepest descent
 rt_option = 1
 
+! Specify whether to adjust overland flow parameters based on imperviousness
+imperv_adj = 0
+
 ! Switch to activate channel routing...(0=no, 1=yes)
 CHANRTSWCRT = 1
 

--- a/trunk/NDHMS/template/NoahMP/namelist.hrldas
+++ b/trunk/NDHMS/template/NoahMP/namelist.hrldas
@@ -34,7 +34,7 @@ TBOT_OPTION                       = 2
 TEMP_TIME_SCHEME_OPTION           = 3
 GLACIER_OPTION                    = 2
 SURFACE_RESISTANCE_OPTION         = 4
-IMPERV_OPTION                     = 0
+IMPERV_OPTION                     = 9  !(0->none; 1->total; 2->Alley&Veenhuis; 9->orig)
 
 ! Timesteps in units of seconds
 FORCING_TIMESTEP = 3600

--- a/trunk/NDHMS/template/NoahMP/namelist.hrldas
+++ b/trunk/NDHMS/template/NoahMP/namelist.hrldas
@@ -34,6 +34,7 @@ TBOT_OPTION                       = 2
 TEMP_TIME_SCHEME_OPTION           = 3
 GLACIER_OPTION                    = 2
 SURFACE_RESISTANCE_OPTION         = 4
+IMPERV_OPTION                     = 0
 
 ! Timesteps in units of seconds
 FORCING_TIMESTEP = 3600


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: impervious, urban, runoff, infiltration, overland flow

SOURCE: Aubrey D, NCAR 

DESCRIPTION OF CHANGES:
This commit adds new capability to adjust infiltration/runoff partitioning in NoahMP and overland flow (retention depth and roughness) based in user-supplied impervious fraction layers.
There is one new OPTIONAL physics option in namelist.hrldas for NoahMP:
IMPERV_OPTION:
- 0 -> no imperviousness adjustment
- 1 -> use total imperviousness
- 2 -> use effective imperviousness from Alley & Veenhuis
- 9 -> older model behavior (urban soil parameter adjustment and mixed runoff adjustment depending on runoff scheme), DEFAULT
If the option is missing, it will default to option 9 (old behavior).

There is one new OPTIONAL physics option in hydro.namelist for overland routing:
imperv_adj:
- 0 -> off (no adjustment, DEFAULT)
- 1 -> adjust max retention depth and overland roughness based in impervious fraction
If the option is missing, it will default to option 0 (no adjustment).

ISSUE: The GitHub Issue that this PR addresses.
N/A

TESTS CONDUCTED:
Tested small basin and NWM CONUS domain to confirm: (1) missing options default back to master solution, (2) impervious adjustment options require new parameters and will error if not found, (3) impervious adjustments schemes are behaving as expected, (4) code passes ncores and perfect restarts.

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [NA] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
