### PR TITLE
New channel option to bypass actual channel routing solver and just produce inflows (for t-route coupling)

### DIFF
--- a/trunk/NDHMS/Data_Rec/module_namelist.F
+++ b/trunk/NDHMS/Data_Rec/module_namelist.F
@@ -720,6 +720,10 @@ subroutine rt_nlst_check(nlst)
       call hydro_stop('hydro.namelist ERROR: Invalid CHANRTSWCRT specified')
    endif
    if(nlst%CHANRTSWCRT .eq. 1) then
+      if ( nlst%channel_option .eq. -1 ) then
+         nlst%channel_option = 2
+         nlst%channel_bypass = .TRUE.
+      endif
       if( (nlst%channel_option .lt. 1 ) .or. (nlst%channel_option .gt. 3) ) then
          call hydro_stop('hydro.namelist ERROR: Invalid channel_option specified')
       endif

--- a/trunk/NDHMS/Data_Rec/module_namelist.F
+++ b/trunk/NDHMS/Data_Rec/module_namelist.F
@@ -720,7 +720,7 @@ subroutine rt_nlst_check(nlst)
       call hydro_stop('hydro.namelist ERROR: Invalid CHANRTSWCRT specified')
    endif
    if(nlst%CHANRTSWCRT .eq. 1) then
-      if ( nlst%channel_option .eq. -1 ) then
+      if ( nlst%channel_option .eq. 5 ) then
          nlst%channel_option = 2
          nlst%channel_bypass = .TRUE.
       endif

--- a/trunk/NDHMS/Data_Rec/namelist.inc
+++ b/trunk/NDHMS/Data_Rec/namelist.inc
@@ -74,6 +74,8 @@
           integer :: rtFlag
           integer ::khour
 
+          logical :: channel_bypass = .FALSE.
+
 !#ifdef WRF_HYDRO_NUDGING
        character(len=256) :: nudgingParamFile
        character(len=256) :: netwkReExFile

--- a/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
+++ b/trunk/NDHMS/HYDRO_drv/module_HYDRO_drv.F
@@ -960,7 +960,7 @@ if (nlst(did)%CHANRTSWCRT.eq.1 .or. nlst(did)%CHANRTSWCRT.eq.2) then
        , rt_domain(did)%nlinksize,            nlst(did)%OVRTSWCRT &
        ,                                     nlst(did)%SUBRTSWCRT &
        , nlst(did)%channel_only , nlst(did)%channelBucket_only &
-       )
+       , nlst(did)%channel_bypass )
 
 else
 

--- a/trunk/NDHMS/OrchestratorLayer/config.f90
+++ b/trunk/NDHMS/OrchestratorLayer/config.f90
@@ -158,6 +158,8 @@ module config_base
      integer            :: nLastObs
      integer            :: bucket_loss
 
+     logical            :: channel_bypass = .FALSE.
+
    contains
 
      procedure, pass(self) :: check => rt_nlst_check
@@ -332,6 +334,10 @@ contains
       call hydro_stop('hydro.namelist ERROR: Invalid CHANRTSWCRT specified')
    endif
    if(self%CHANRTSWCRT .eq. 1) then
+      if ( self%channel_option .eq. -1 ) then
+         self%channel_option = 2
+         self%channel_bypass = .TRUE.
+      endif
       if( (self%channel_option .lt. 1 ) .or. (self%channel_option .gt. 3) ) then
          call hydro_stop('hydro.namelist ERROR: Invalid channel_option specified')
       endif

--- a/trunk/NDHMS/OrchestratorLayer/config.f90
+++ b/trunk/NDHMS/OrchestratorLayer/config.f90
@@ -334,7 +334,7 @@ contains
       call hydro_stop('hydro.namelist ERROR: Invalid CHANRTSWCRT specified')
    endif
    if(self%CHANRTSWCRT .eq. 1) then
-      if ( self%channel_option .eq. -1 ) then
+      if ( self%channel_option .eq. 5 ) then
          self%channel_option = 2
          self%channel_bypass = .TRUE.
       endif

--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -212,6 +212,14 @@ subroutine output_chrt_NWM(domainId)
       call nwmCheck(diagFlag,1,'ERROR: Invalid IOC flag provided by namelist file.')
    endif
 
+   ! Turn off streamflow, velocity, head for special external channel routing config
+   if (nlst(domainId)%channel_bypass) then
+      fileMeta%outFlag(1) = 0
+      fileMeta%outFlag(2) = 0
+      fileMeta%outFlag(4) = 0
+      fileMeta%outFlag(5) = 0
+   endif
+
    ! call the GetModelConfigType function
    modelConfigType = GetModelConfigType(nlst(1)%io_config_outputs)
 

--- a/trunk/NDHMS/Routing/module_channel_routing.F
+++ b/trunk/NDHMS/Routing/module_channel_routing.F
@@ -1610,7 +1610,8 @@ end subroutine drive_CHANNEL
        , qSfcLatRunoff,     qBucket                  &
        , QLateral, velocity, qloss                   &
        , HLINK                                       &
-       , nsize , OVRTSWCRT, SUBRTSWCRT, channel_only, channelBucket_only)
+       , nsize , OVRTSWCRT, SUBRTSWCRT, channel_only, channelBucket_only, &
+       channel_bypass)
 
        use module_UDMAP, only: LNUMRSL, LUDRSL
        use config_base, only: nlst
@@ -1651,6 +1652,8 @@ end subroutine drive_CHANNEL
        real                                      :: Km, X
        real , intent(INOUT), dimension(:,:)  :: QLINK
        real , intent(INOUT), dimension(:)    :: HLINK
+
+       logical, intent(in) :: channel_bypass
 
 #ifdef WRF_HYDRO_NUDGING
        !! inout for applying previous nudge to upstream components of flow at gages
@@ -1882,6 +1885,8 @@ if(nlst(1)%output_channelBucket_influx .eq. 1 .or. &
 if(nlst(1)%output_channelBucket_influx .eq. 3) &
      accBucket(1:NLINKSL) = accBucket(1:NLINKSL) + qout_gwsubbas(1:NLINKSL) * DT
 
+! Skip this section if we are NOT running any actual channel routing
+if (.not. channel_bypass) then
 
 !---------------------------------------------
 !       QLateral = QLateral / nsteps
@@ -1908,7 +1913,6 @@ do nt = 1, nsteps
 #ifdef MPP_LAND
    endif
 #endif
-
 
    do k = 1,NLINKSL
 
@@ -2025,6 +2029,8 @@ do nt = 1, nsteps
 !#endif
 
 end do  ! nsteps
+
+endif ! channel_bypass
 
 if (KT .eq. 1) KT = KT + 1
 

--- a/trunk/NDHMS/template/HYDRO/hydro.namelist
+++ b/trunk/NDHMS/template/HYDRO/hydro.namelist
@@ -137,7 +137,8 @@ rt_option = 1
 ! Switch to activate channel routing...(0=no, 1=yes)
 CHANRTSWCRT = 1
 
-! Specify channel routing option: 1=Muskingam-reach, 2=Musk.-Cunge-reach, 3=Diff.Wave-gridded
+! Specify channel routing option: 1=Muskingam-reach, 2=Musk.-Cunge-reach, 3=Diff.Wave-gridded,
+! 5=Bypass channel routing (only active for UDMP=1 and reach configuration)
 channel_option = 3
 
 ! Specify the reach file for reach-based routing options (e.g.: "Route_Link.nc")


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: channel routing, t-route

SOURCE: Aubrey D, NCAR

DESCRIPTION OF CHANGES:
Create new channel option to bypass the actual channel routing function and just run the channel routines to generate the fluxes coming into the reach. This option is intended to save a minor amount of compute time when coupling to an external channel routing model.

ISSUE: N/A

TESTS CONDUCTED: 
Tested on small basin and CONUS NWM to confirm behaving as expected and runtime savings. Approximate runtime reduction of 5% for NWM CONUS retro config.

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [na] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [x] Backwards compatible
 - [na] Requires new files? If so, how to generate them.
 - [ ] Documentation included - NAMELIST updated
 - [ ] Short description in the Development section of `NEWS.md`
