### PR TITLE
bugfix: add Crocus to CMake files

### DIFF
--- a/trunk/NDHMS/Land_models/NoahMP/phys/CMakeLists.txt
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/CMakeLists.txt
@@ -1,8 +1,13 @@
 cmake_minimum_required (VERSION 2.8)
 
+add_subdirectory("surfex")
+
 add_library(noahmp_phys STATIC
 	module_sf_noahmpdrv.F
 	module_sf_noahmp_glacier.F
 	module_sf_noahmp_groundwater.F
 	module_sf_noahmplsm.F
+	module_snowcro.F
 )
+
+target_link_libraries(noahmp_phys crocus_surfex)

--- a/trunk/NDHMS/Land_models/NoahMP/phys/surfex/CMakeLists.txt
+++ b/trunk/NDHMS/Land_models/NoahMP/phys/surfex/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required (VERSION 2.8)
+
+add_library(crocus_surfex STATIC
+  ini_csts.F
+  modd_csts.F
+  modd_snow_metamo.F
+  modd_snow_par.F
+  modd_surf_atm.F
+  mode_snow3l.F
+  mode_surf_coefs.F
+  mode_thermos.F
+  tridiag_ground_snowcro.F
+)


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: bugfix, CMake, Crocus

SOURCE: Soren Rasmussen, NCAR 

DESCRIPTION OF CHANGES:  Added Crocus filenames to the appropriate CMake files.

ISSUE: Fixes #610 

TESTS CONDUCTED: CMake builds, runs with Croton


### Checklist

 - [X] Closes issue #610 (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
