### PR TITLE
Backport WRF coupler update to recent MPP_LAND_INIT changes (#602)

### DIFF
--- a/trunk/NDHMS/CPL/WRF_cpl/module_wrf_HYDRO.F
+++ b/trunk/NDHMS/CPL/WRF_cpl/module_wrf_HYDRO.F
@@ -22,10 +22,11 @@
 module module_WRF_HYDRO
 
 #ifdef MPP_LAND
+    use mpi
     use module_mpp_land, only: global_nx, global_ny, decompose_data_real, &
                  write_io_real, my_id, mpp_land_bcast_real1, IO_id, &
                 mpp_land_bcast_real, mpp_land_bcast_int1, mpp_land_init
-    use module_CPL_LAND, only: CPL_LAND_INIT, cpl_outdate
+    use module_CPL_LAND, only: CPL_LAND_INIT, cpl_outdate, HYDRO_COMM_WORLD
     use module_hydro_stop, only: HYDRO_stop
 #endif
     use module_HYDRO_drv, only: HYDRO_ini, HYDRO_exe
@@ -77,6 +78,7 @@ CONTAINS
 
         integer :: i,j
         
+        integer :: ierr
 
 !output flux and state variable
 
@@ -98,15 +100,15 @@ CONTAINS
 
   
         if(.not. RT_DOMAIN(did)%initialized) then
-           
-           call MPP_LAND_INIT()
-
            !yw nlst_rt(did)%nsoil = config_flags%num_soil_layers
            !nlst_rt(did)%nsoil = model_config_rec%num_metgrid_soil_levels
            nlst(did)%nsoil = grid%num_soil_layers
 
          
 #ifdef MPP_LAND
+           call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
+           call MPP_LAND_INIT(grid%e_we - grid%s_we - 1, grid%e_sn - grid%s_sn - 1)
+
            call mpp_land_bcast_int1 (nlst(did)%nsoil)
 #endif
            allocate(nlst(did)%zsoil8(nlst(did)%nsoil))


### PR DESCRIPTION
Changes:
* duplicate WRF's MPI communicator to HYDRO_COMM_WORLD
* call MPP_LAND_INIT with global grid size from WRF `domain` object

Context:
This is already in the master branch, but would be great to get into a v5.2.x bugfix release.  

I was hoping to get this in prior to the upcoming training, but noticed some odd behavior (i.e. a segfault w/ np=2, but not np=1 or np=4) when I built a version of the coupled system using Docker.  Was trying to troubleshoot that for a bit, but didn't have enough time (and/or understanding of the relevant code / architecture - looks like there's a good bit of duplication w/ stuff in hydro and stuff from WRF, but w/ different implementations and not enough overlap to fully replace?) and it sounds like this problem I ran into is a non-issue w/ Intel + IMPI on Cheyenne.

For the training I think we're going to push ahead w/ the unreleased code, but it'd still be nice to get this in if folks are comfortable with it.  While potentially a little buggy w/ GNU + openMPI, at least it works in most cases.  In an ideal world we'd probably troubleshoot a bit more, but not sure if anyone has time to take a look.  