### PR TITLE
Bugfix Issue 650 SIGFPE

### DIFF
--- a/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/trunk/NDHMS/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -126,7 +126,7 @@ module module_NoahMP_hrldas_driver
   INTEGER                                 ::  IOPT_SOIL ! soil configuration option
   INTEGER                                 ::  IOPT_PEDO ! soil pedotransfer function option
   INTEGER                                 ::  IOPT_CROP ! crop model option (0->none; 1->Liu et al.)
-  INTEGER                                 ::  IOPT_IMPERV !imperviousness infiltration adjustment (0->none; 1->total; 
+  INTEGER                                 ::  IOPT_IMPERV !imperviousness infiltration adjustment (0->none; 1->total;
                                                                                         !2->Alley&Veenhuis; 9->old)
   REAL,    ALLOCATABLE, DIMENSION(:,:,:)  ::  T_PHY     ! 3D atmospheric temperature valid at mid-levels [K]
   REAL,    ALLOCATABLE, DIMENSION(:,:,:)  ::  QV_CURR   ! 3D water vapor mixing ratio [kg/kg_dry]
@@ -320,7 +320,7 @@ module module_NoahMP_hrldas_driver
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  QSPRINGXY
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  QSLATXY
   REAL                                    ::  WTDDT  = 30.0    ! frequency of groundwater call [minutes]
-  INTEGER                                 ::  STEPWTD          ! step of groundwater call
+  INTEGER                                 ::  STEPWTD = 1      ! step of groundwater call
 
 !------------------------------------------------------------------------
 ! Crocus


### PR DESCRIPTION
TYPE: Bug fix

KEYWORDS: SIGFPE, erroneous arithmetic operation, MOD remainder function

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Initialize `STEPWTD` to one to avoid `SIGFPE` caused by using zero as the divisor in the Fortran intrinsic `mod` function. As explained in issue #650, the variable `STEPWTD` gets set in the following line, which doesn't get run with certain namelist options.
```
STEPWTD = max(STEPWTD,1)
```
Since the minimum value of `STEPWTD` should be one, `STEPWTD` can be initialized as one to fix the bug and void any other side-effects.

ISSUE: Fixes #650 

TESTS CONDUCTED: Ran successfully with Croton, NY testcase. 

### Checklist

 - [X] Closes issue #650 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
