### PR TITLE
Add scrape of outer edge of domain so water doesn't pile up.

### DIFF
--- a/src/Routing/Noah_distr_routing_overland.F
+++ b/src/Routing/Noah_distr_routing_overland.F
@@ -647,7 +647,6 @@ end do
 
 
 #ifdef MPP_LAND
-    ! use double precision to solve the underflow problem.
     call MPP_LAND_COM_REAL(edge_adjust,XX,YY,99)
 #endif
     QBDRY = QBDRY - edge_adjust ! making this negative term more negative

--- a/src/Routing/Noah_distr_routing_overland.F
+++ b/src/Routing/Noah_distr_routing_overland.F
@@ -256,9 +256,6 @@ subroutine ov_rtng( &
     REAL	:: DT_FRAC,SUM_INFXS,sum_head
     !INTEGER SO8RT_D(IXRT,JXRT,3), rt_option
 
-
-
-
     !DJG ----------------------------------------------------------------------
     ! DJG BEGIN 1-D or 2-D OVERLAND FLOW ROUTING LOOP
     !DJG ---------------------------------------------------------------------
@@ -473,6 +470,7 @@ SUBROUTINE ROUTE_OVERLAND1(dt,                                &
     REAL, INTENT(IN), DIMENSION(XX,YY,8) :: SO8RT
     REAL*8, DIMENSION(XX,YY) :: QBDRY_tmp, DH
     REAL*8, DIMENSION(XX,YY) :: DH_tmp
+    REAL, DIMENSION(XX,YY) :: edge_adjust ! mm
 
     !!! Declare Local Variables
 
@@ -554,6 +552,7 @@ SUBROUTINE ROUTE_OVERLAND1(dt,                                &
 
                     !yw changed as following:
                     tmp_adjust=qqsfc*1000
+
                     if((h(i,j) - tmp_adjust) <0 )  then
 #ifdef HYDRO_D
                         print*, "Error Warning: surface head is negative:  ",i,j,ixx0,jyy0, &
@@ -581,10 +580,13 @@ SUBROUTINE ROUTE_OVERLAND1(dt,                                &
                             QBDRY_tmp(IXX0,JYY0)=QBDRY_tmp(IXX0,JYY0) - qqsfc*1000.
                             QBDRYT=QBDRYT - qqsfc
                             DH_tmp(IXX0,JYY0)= DH_tmp(IXX0,JYY0)-tmp_adjust
+
                         end if
                     end if
+
                     !! End loop to route sfc water
                 end if
+
         end do
     end do
 
@@ -602,6 +604,55 @@ SUBROUTINE ROUTE_OVERLAND1(dt,                                &
 #endif
 
     H = H + DH
+
+!!! Scrape the outermost edges
+edge_adjust = 0.0
+do j=1,YY,YY-1
+   do i=1,XX
+#ifdef MPP_LAND
+      if( ((i.eq.XX).and.(right_id .lt. 0)) .or. &
+          ((i.eq.1) .and.(left_id  .lt. 0)) .or. &
+          ((j.eq.1) .and.(down_id  .lt. 0)) .or. &
+          ((j.eq.YY).and.(up_id    .lt. 0)) ) then
+#else
+          if ((i.eq.XX).or.(i.eq.1).or.(j.eq.1)   &
+               .or.(j.eq.YY )) then
+#endif
+              if (h(i,j) .GT. retent_dep(i,j)) then
+                 edge_adjust(i,j) = h(i,j) - retent_dep(i,j) ! positive mm
+              end if
+
+          end if
+   end do
+end do
+
+do i=1,XX,XX-1
+   do j=1,YY
+#ifdef MPP_LAND
+      if( ((i.eq.XX).and.(right_id .lt. 0)) .or. &
+          ((i.eq.1) .and.(left_id  .lt. 0)) .or. &
+          ((j.eq.1) .and.(down_id  .lt. 0)) .or. &
+          ((j.eq.YY).and.(up_id    .lt. 0)) ) then
+#else
+          if ((i.eq.XX).or.(i.eq.1).or.(j.eq.1)   &
+               .or.(j.eq.YY )) then
+#endif
+              if (h(i,j) .GT. retent_dep(i,j)) then
+                 edge_adjust(i,j) = h(i,j) - retent_dep(i,j) ! positive mm
+              end if
+
+          end if
+   end do
+end do
+
+
+#ifdef MPP_LAND
+    ! use double precision to solve the underflow problem.
+    call MPP_LAND_COM_REAL(edge_adjust,XX,YY,99)
+#endif
+    QBDRY = QBDRY - edge_adjust ! making this negative term more negative
+    H = H - edge_adjust ! making this positive term less positive
+!!! End outermost edge scrape
 
     return
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: overland flow

SOURCE: Aubrey D., NCAR 

DESCRIPTION OF CHANGES:
In the 1D overland flow scheme, the outer edge cells are not properly treated (they are in 2D scheme). This can cause water to pile up on the edges, particularly with limited infiltration (e.g., glacier cells). We do a brute force method here to scrape water above maximum retention depth from these outer cells and capture it in QBDRY. This should someday be updated to match the 2D approach.

ISSUE: The GitHub Issue that this PR addresses. For issue number 123, it would be:
```
Partially fixes #657
```

TESTS CONDUCTED:
Tested fix over NWM-Alaska cutout domain and water no longer piles up on edge. Tested NWM-CONUS and confirmed minimal impacts (only along edges), passes ncores, passes perfect restart.

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [x] Closes issue #657  (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [na] Tests added (unit tests and/or regression/integration tests)
 - [x] Backwards compatible
 - [na] Requires new files? If so, how to generate them.
 - [na] Documentation included
 - [na] Short description in the Development section of `NEWS.md`
