### PR TITLE
Crocus TG initialization

### DIFF
--- a/src/Land_models/NoahMP/phys/module_snowcro.F
+++ b/src/Land_models/NoahMP/phys/module_snowcro.F
@@ -1097,7 +1097,7 @@ DO JJ = 1,SIZE(ZSNOW)
     PSNOWSWE(JJ,JST)  = 0.
     PSNOWHEAT(JJ,JST) = 0.
     PSNOWRHO(JJ,JST)  = 999.
-    PSNOWTEMP(JJ,JST) = 0.
+    PSNOWTEMP(JJ,JST) = XTT
     PSNOWDZ(JJ,JST)   = 0.
   ENDDO  !  end loop unactive snow layers
 !


### PR DESCRIPTION
KEYWORDS: crocus, snow

SOURCE: Aubrey D, NCAR

DESCRIPTION OF CHANGES: TG goes to 0 when all remaining snow melts during crocus call. Set background temperature fields to freezing instead of 0.

ISSUE: Fixes #660 

TESTS CONDUCTED: Tested over multiple years in NWM-AK domain. Fixes TG 0 cells and no impact on streamflow.

NOTES: Potentially answer-changing only when Crocus is active.

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [x] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [na] Tests added (unit tests and/or regression/integration tests)
 - [x] Backwards compatible
 - [na] Requires new files? If so, how to generate them.
 - [na] Documentation included
 - [na] Short description in the Development section of `NEWS.md`
