### PR TITLE
Remove 'FATAL ERROR' from SMCRT depletion message

### DIFF
--- a/trunk/NDHMS/Routing/Noah_distr_routing.F
+++ b/trunk/NDHMS/Routing/Noah_distr_routing.F
@@ -1142,7 +1142,7 @@ subroutine disaggregateDomain(IX, JX, NSOIL, IXRT, JXRT, AGGFACTRT, &
                               SMCRT(IXXRT,JYYRT,KRT),SMCMAXRT(IXXRT,JYYRT,KRT)
                      call hydro_stop("In disaggregateDomain() - SMCMAX exceeded upon disaggregation3")
                   ELSE IF (SMCRT(IXXRT,JYYRT,KRT).LE.0.) THEN
-                     print *, "FATAL ERROR: SMCRT fully depleted upon disaggregation...", &
+                     print *, "SMCRT fully depleted upon disaggregation...", &
                          ixxrt,jyyrt,krt,&
                          "SMCRT=",SMCRT(IXXRT,JYYRT,KRT),"SH2OWGT=",SH2OWGT(IXXRT,JYYRT,KRT),&
                          "SH2O=",SH2OX(I,J,KRT)


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: messaging

SOURCE: Ryan @ NCAR

DESCRIPTION OF CHANGES: 

Remove the "FATAL ERROR" text from the SMCRT depletion condition logging
