### PR TITLE
Don't read CROCUS namelist if not HRLDAS-coupled

### DIFF
--- a/trunk/NDHMS/OrchestratorLayer/config.f90
+++ b/trunk/NDHMS/OrchestratorLayer/config.f90
@@ -646,7 +646,9 @@ contains
 #endif
     close(12)
 
-    call read_crocus_namelist(crocus_opts)
+    if (sys_cpl == 1) then
+       call read_crocus_namelist(crocus_opts)
+    endif
 ! #ifdef MPP_LAND
 !     endif
 ! #endif


### PR DESCRIPTION
Quick fix to an issue with WRF Coupling where the configuration manager attempts to read the Crocus namelist from the `namelist.hrldas` file, which doesn't exist when not using a HRLDAS (Noah, NoahMP) coupling.