### PR TITLE
Remove trailing whitespace

### DIFF
--- a/src/CPL/CLM_cpl/clm_drv_HYDRO.F
+++ b/src/CPL/CLM_cpl/clm_drv_HYDRO.F
@@ -4,7 +4,7 @@
 !  Abstract:
 !  History Log:
 !  <brief list of changes to this source file>
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
@@ -12,13 +12,13 @@
 !  Output Files:
 !        <list file names and briefly describe the information they
 !        include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
        subroutine clm_drv_HYDRO()

--- a/src/CPL/CLM_cpl/module_clm_HYDRO.F
+++ b/src/CPL/CLM_cpl/module_clm_HYDRO.F
@@ -3,20 +3,20 @@
 !  Abstract:
 !  History Log:
 !  <brief list of changes to this source file>
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_CLM_HYDRO
@@ -29,7 +29,7 @@ module module_CLM_HYDRO
     use subgridAveMod, only: c2g_1d, c2g_2d
 
 
-! NDHMS  module   
+! NDHMS  module
      use module_mpp_land, only: global_nx, global_ny, decompose_data_real, &
                  write_io_real, my_id
     use module_hydro_stop, only: HYDRO_stop
@@ -40,7 +40,7 @@ module module_CLM_HYDRO
     integer :: numg, numl, numc, nump
     INTEGER, PARAMETER :: double=8
     real(kind=double), pointer :: r2p(:,:) , r1p(:)
-     
+
     integer ::  begl, endl, begc, endc, begp, endp
     real(kind=double), allocatable, dimension(:) :: clm_g1d
     real(kind=double), allocatable, dimension(:,:) :: clm_g2d
@@ -105,7 +105,7 @@ CONTAINS
         ix = rt_domain(did)%ix
         jx = rt_domain(did)%jx
 
-        ! get the initial data from CLM 
+        ! get the initial data from CLM
             call get_proc_global(numg, numl, numc, nump)
 
             call get_proc_bounds(begg, endg, begl, endl, begc, endc, begp, endp)
@@ -136,7 +136,7 @@ CONTAINS
 
 #endif
 
-            r1p => clm3%g%l%c%cwf%qflx_drain  
+            r1p => clm3%g%l%c%cwf%qflx_drain
             call c2g_1d(begc, endc, begl, endl, begg, endg, r1p(begc:endc), clm_g1d, &
                 'urbanf', 'unity')
             call clm2ND2d(clm_g1d,nn,RT_DOMAIN(did)%SOLDRAIN,ix,jx)
@@ -144,8 +144,8 @@ CONTAINS
 
 #ifdef HYDRO_D
             write(6,*) "finish qflx_drain "
-#endif 
-            r2p =>clm3%g%l%c%ces%t_soisno 
+#endif
+            r2p =>clm3%g%l%c%ces%t_soisno
                 call c2g_2d(begc, endc, begl, endl, begg, endg, nlevgrnd, r2p(begc:endc,1:nlevgrnd), clm_g2d, &
                 'urbanh', 'unity')
             call clm2ND3d (clm_g2d,nn,nlevgrnd,zsoi(1:nlevgrnd), &
@@ -156,7 +156,7 @@ CONTAINS
             write(6,*) "finish t_soisno   "
 #endif
 
-            r2p => clm3%g%l%c%cws%h2osoi_vol  
+            r2p => clm3%g%l%c%cws%h2osoi_vol
                 call c2g_2d(begc, endc, begl, endl, begg, endg, nlevgrnd, r2p(begc:endc,1:nlevgrnd), clm_g2d, &
                 'urbanh', 'unity')
             call clm2ND3d (clm_g2d,nn,nlevgrnd,zsoi(1:nlevgrnd), &
@@ -167,17 +167,17 @@ CONTAINS
 
 #endif
 
-            r2p => clm3%g%l%c%cws%h2osoi_liq  
+            r2p => clm3%g%l%c%cws%h2osoi_liq
             call c2g_2d(begc, endc, begl, endl, begg, endg, nlevgrnd, r2p(begc:endc,1:nlevgrnd), clm_g2d, &
                 'urbanh', 'unity')
             call clm2ND3d (clm_g2d, nn,nlevgrnd,zsoi(1:nlevgrnd), &
                      ix,jx, nlst(did)%nsoil,abs(rt_domain(did)%subsurface%properties%zsoil(1:nlst(did)%nsoil)),&
                      RT_DOMAIN(did)%SH2OX)
             RT_DOMAIN(did)%SH2OX =  RT_DOMAIN(did)%SH2OX /1000.
- #ifdef HYDRO_D  
+ #ifdef HYDRO_D
             write(6,*) "finish h2osoi_liq "
 
-            write(6,*) "before call HYDRO_exe" 
+            write(6,*) "before call HYDRO_exe"
 
 #endif
 
@@ -185,24 +185,24 @@ CONTAINS
             call HYDRO_exe(did)
 
 #ifdef HYDRO_D
-            write(6,*) "after call HYDRO_exe" 
+            write(6,*) "after call HYDRO_exe"
 
 #endif
 ! add for update the CLM state variable.
 
            clm_lev = 10
 
-            r2p =>clm3%g%l%c%ces%t_soisno 
+            r2p =>clm3%g%l%c%ces%t_soisno
             call Toclm3d (clm_g2d,nn,clm_lev,zsoi(1:clm_lev), &
                      ix,jx, nlst(did)%nsoil,abs(rt_domain(did)%subsurface%properties%zsoil(1:nlst(did)%nsoil)),&
                      RT_DOMAIN(did)%STC)
             call g2c_2d(begc, endc, begl, endl, begg, endg,clm_lev,r2p(begc:endc,1:clm_lev), clm_g2d, &
                 'urbanh', 'unity')
 
-            
 
 
-            r2p => clm3%g%l%c%cws%h2osoi_vol  
+
+            r2p => clm3%g%l%c%cws%h2osoi_vol
             call Toclm3d (clm_g2d,nn,clm_lev,zsoi(1:clm_lev), &
                      ix,jx, nlst(did)%nsoil,abs(rt_domain(did)%subsurface%properties%zsoil(1:nlst(did)%nsoil)), &
                      RT_DOMAIN(did)%SMC)
@@ -211,7 +211,7 @@ CONTAINS
 
 
 
-            r2p => clm3%g%l%c%cws%h2osoi_liq  
+            r2p => clm3%g%l%c%cws%h2osoi_liq
             call Toclm3d(clm_g2d,nn,clm_lev,zsoi(1:clm_lev), &
                      ix,jx, nlst(did)%nsoil,abs(rt_domain(did)%subsurface%properties%zsoil(1:nlst(did)%nsoil)),&
                      RT_DOMAIN(did)%SH2OX*1000)
@@ -230,7 +230,7 @@ CONTAINS
             write(6,*) "end of drive ndhms"
 #endif
 
-     return 
+     return
      end subroutine clm_cpl_HYDRO
 
       subroutine Toclm3d (v1d_out,nn,kk1,z1_in,ix,jx,kk2,z2,v2_in)
@@ -245,8 +245,8 @@ CONTAINS
           REAL ,dimension(kk1):: z1
 
           z1 = z1_in
-         
-! v1 is the out from interp3D 
+
+! v1 is the out from interp3D
              call Interp3D (z2,v2_in,kk2,z1,v1,ix,jx,kk1)
 
 
@@ -259,7 +259,7 @@ CONTAINS
       end subroutine Toclm3d
 
       subroutine Toclm2d(v1,ix,jx,v1d_out,nn)
-         use module_mpp_land, only: my_id,IO_id,mpp_land_bcast_real 
+         use module_mpp_land, only: my_id,IO_id,mpp_land_bcast_real
          implicit none
          integer ix,jx, nn
          real v1(ix,jx)
@@ -288,14 +288,14 @@ CONTAINS
 #endif
          return
       end subroutine Toclm2d
-      
+
       subroutine TO1d(vg2d,v1d,nx,ny)
          implicit none
          integer nx,ny, n, i,j
          real vg2d(nx,ny)
          real v1d(nx*ny)
-             do j = 1,ny 
-             do i = 1,nx 
+             do j = 1,ny
+             do i = 1,nx
                 n = (j-1)*nx + i
                 v1d(n) = vg2d(i,j)
              enddo
@@ -313,11 +313,11 @@ CONTAINS
           real(kind=double), dimension(kk1) :: z1_in
           real, dimension(kk1) :: z1
           real, dimension(kk2) :: z2
-        
- 
+
+
           z1 = z1_in
 
-          do k = 1, kk1 
+          do k = 1, kk1
              call clm2ND2d(v1d_in(:,k),nn,v1(:,:,k),ix,jx)
           end do
              call Interp3D (z1(1:kk1),v1,kk1,z2(1:kk2),vout,ix,jx,kk2)
@@ -328,7 +328,7 @@ CONTAINS
 
       subroutine clm2ND2d (v1d_in,nn,vout,ix,jx)
           use clmtype, only: grlnd
-          use module_mpp_land, only: my_id,IO_id,mpp_land_bcast_real 
+          use module_mpp_land, only: my_id,IO_id,mpp_land_bcast_real
           implicit none
           integer :: ix,jx,nn, n
           real vout(ix,jx)
@@ -348,12 +348,12 @@ CONTAINS
             ! need to stop
           endif
           call gather_1d_real(v1d_in,nn,g1d,gni*gnj)
-!  transfer 1d   to 2d 
+!  transfer 1d   to 2d
 
           if(my_id.eq.IO_id) then
              do j = 1,gnj
              do i = 1,gni
-                n = (j-1)*gni + i  
+                n = (j-1)*gni + i
                 v2d_g(i,j) = g1d(n)
              enddo
              enddo
@@ -362,7 +362,7 @@ CONTAINS
 !         if(my_id .eq. 0) then
 !            call output_nc(v2d_g,gni,gnj, "test", "test.nc")
 !         endif
-           
+
 ! domain decomposition
           call decompose_data_real(v2d_g,vout)
 
@@ -372,7 +372,7 @@ CONTAINS
       subroutine Interp3D (z1,v1,kk1,z,vout,ix,jx,kk)
 !  input: z1,v1,kk1,z,ix,jx,kk
 !  output: vout
-!  interpolate based on soil layer: z1 and z 
+!  interpolate based on soil layer: z1 and z
 !  z :  soil layer of output variable.
 !  z1: array of soil layers of input variable.
          implicit none
@@ -382,7 +382,7 @@ CONTAINS
 
 !        write(6,*) "k, kk1 ", k, kk1
 !        write(6,*) "z1(kk1), z(k) ", z1(kk1), z(k)
-       
+
          do j = 1, jx
             do i = 1, ix
               do k = 1, kk
@@ -401,7 +401,7 @@ CONTAINS
          real:: outV, outZ, w1, w2
 
          if(outZ .le. inZ(1)) then
-             if(inZ(2) .eq. inZ(1)) then 
+             if(inZ(2) .eq. inZ(1)) then
                 write(6,*) "FATAL ERROR: inZ(2)=inZ(1) ", inZ(2),inZ(1)
                !stop 99
                stop("In module_clm_HYDRO.F interpLayer() - inZ(2)=inZ(1)")
@@ -411,21 +411,21 @@ CONTAINS
              outV = inV(1)*w1-inV(2)*w2
              return
          elseif(outZ .ge. inZ(inK)) then
-             if(inZ(inK-1) .eq. inZ(inK)) then 
+             if(inZ(inK-1) .eq. inZ(inK)) then
                 write(6,*) "FATAL ERROR: inZ(inK-1)=inZ(inK) ", inZ(inK-1),inZ(inK)
                 !stop 99
                 stop("FATAL ERROR: In module_clm_HYDRO.F interpLayer() - inZ(inK-1)=inZ(inK)")
              end if
-             w1 = (outZ-inZ(inK-1))/(inZ(inK)-inZ(inK-1)) 
+             w1 = (outZ-inZ(inK-1))/(inZ(inK)-inZ(inK-1))
              w2 = (outZ-inZ(inK))  /(inZ(inK)-inZ(inK-1))
              outV = inV(inK)*w1 -inV(inK-1)* w2
              return
-         else  
+         else
             do k = 2, inK
              if((inZ(k) .ge. outZ).and.(inZ(k-1) .le. outZ) ) then
                 k1  = k-1
                 k2 = k
-             if(inZ(k1) .eq. inZ(k2)) then 
+             if(inZ(k1) .eq. inZ(k2)) then
                 write(6,*) "FATAL ERROR: inZ(k1)=inZ(k2) ", inZ(k1),inZ(k2)
                 !stop 99
                 stop("FATAL ERROR: In module_clm_HYDRO.F interpLayer()- inZ(k1)=inZ(k2)") 
@@ -433,8 +433,8 @@ CONTAINS
                 w1 = (outZ-inZ(k1))/(inZ(k2)-inZ(k1))
                 w2 = (inZ(k2)-outZ)/(inZ(k2)-inZ(k1))
                 outV = inV(k2)*w1 + inV(k1)*w2
-                return 
-             end if 
+                return
+             end if
             end do
          endif
       end subroutine interpLayer
@@ -448,11 +448,11 @@ CONTAINS
       integer cmdate
 
       cpl_land_dt  = 1.0* get_step_size()
-      
-      call get_curr_date(yr, mo, da, sec)     
 
-    
-      hr = sec/3600 
+      call get_curr_date(yr, mo, da, sec)
+
+
+      hr = sec/3600
 
       sec = mod(sec,3600)
       mn = sec/60
@@ -461,7 +461,7 @@ CONTAINS
 
       if(yr .lt. 1000) yr = 2000+yr
       write(cpl_outdate(1:4),'(I4)') yr
-     
+
       if(mo .lt. 10 ) then
          write(cpl_outdate(5:7),'("-0",I1)') mo
       else
@@ -473,7 +473,7 @@ CONTAINS
       else
          write(cpl_outdate(8:10),'("-",I2)') da
       endif
-          
+
       if(hr .lt. 10 ) then
          write(cpl_outdate(11:13),'("_0",I1)') hr
       else
@@ -491,11 +491,11 @@ CONTAINS
       else
          write(cpl_outdate(17:19),'(":",I2)') ss
       endif
-          
-          
-          
+
+
+
 !      write(cpl_outdate,'(I4,"-",I2,"-",I2,"_",I2,":",I2,":",I2)' )     &
-!            yr, mo, da, hr, mn, ss 
+!            yr, mo, da, hr, mn, ss
 
 #ifdef HYDRO_D
       write(6,*) "cpl_outdate = ",cpl_outdate
@@ -571,12 +571,12 @@ CONTAINS
        end do
     else if (c2l_scale_type == 'urbanf') then
        do c = lbc,ubc
-          l = clandunit(c) 
+          l = clandunit(c)
           if (ltype(l) == isturb) then
              if (ctype(c) == icol_sunwall) then
-                scale_c2l(c) = 3.0 * canyon_hwr(l) 
+                scale_c2l(c) = 3.0 * canyon_hwr(l)
              else if (ctype(c) == icol_shadewall) then
-                scale_c2l(c) = 3.0 * canyon_hwr(l) 
+                scale_c2l(c) = 3.0 * canyon_hwr(l)
              else if (ctype(c) == icol_road_perv .or. ctype(c) == icol_road_imperv) then
                 scale_c2l(c) = 3.0
              else if (ctype(c) == icol_roof) then
@@ -588,7 +588,7 @@ CONTAINS
        end do
     else if (c2l_scale_type == 'urbans') then
        do c = lbc,ubc
-          l = clandunit(c) 
+          l = clandunit(c)
           if (ltype(l) == isturb) then
              if (ctype(c) == icol_sunwall) then
                 scale_c2l(c) = (3.0 * canyon_hwr(l)) / (2.*canyon_hwr(l) + 1.)
@@ -605,7 +605,7 @@ CONTAINS
        end do
     else if (c2l_scale_type == 'urbanh') then
        do c = lbc,ubc
-          l = clandunit(c) 
+          l = clandunit(c)
           if (ltype(l) == isturb) then
              if (ctype(c) == icol_sunwall) then
                 scale_c2l(c) = spval
@@ -629,12 +629,12 @@ CONTAINS
              l = clandunit(c)
              g = cgridcell(c)
              if(wtgcell(c) .ne. 0) then
-                carr(c) = garr(g) 
+                carr(c) = garr(g)
              endif
           end if
     end do
     end subroutine g2c_1d
-   
+
     subroutine gather_1d_real(l1d,lnn,g1d,gnn)
        use spmdGathScatMod
        use clmtype   , only : grlnd, nameg
@@ -655,7 +655,7 @@ CONTAINS
        g1d = gp_yw
        deallocate(lp_yw)
        deallocate(gp_yw)
-    end subroutine gather_1d_real 
+    end subroutine gather_1d_real
 
     subroutine scatter_1d_r(l1d,lnn,g1d,gnn)
        use spmdGathScatMod, only: scatter_1darray_real
@@ -673,7 +673,7 @@ CONTAINS
        allocate(lp_yw(begg:endg) )
        allocate(gp_yw(gnn) )
 
-       
+
        gp_yw(:) = g1d(:)
 
 
@@ -682,11 +682,11 @@ CONTAINS
        call scatter_1darray_real(lp_yw, gp_yw, grlnd)
 
 
-       l1d = lp_yw(begg:endg) 
+       l1d = lp_yw(begg:endg)
 
        deallocate(lp_yw)
        deallocate(gp_yw)
-    end subroutine scatter_1d_r 
+    end subroutine scatter_1d_r
 
       subroutine output_nc(array,idim,jdim, var_name, file_name)
       implicit none
@@ -784,12 +784,12 @@ CONTAINS
        end do
     else if (c2l_scale_type == 'urbanf') then
        do c = lbc,ubc
-          l = clandunit(c) 
+          l = clandunit(c)
           if (ltype(l) == isturb) then
              if (ctype(c) == icol_sunwall) then
-                scale_c2l(c) = 3.0 * canyon_hwr(l) 
+                scale_c2l(c) = 3.0 * canyon_hwr(l)
              else if (ctype(c) == icol_shadewall) then
-                scale_c2l(c) = 3.0 * canyon_hwr(l) 
+                scale_c2l(c) = 3.0 * canyon_hwr(l)
              else if (ctype(c) == icol_road_perv .or. ctype(c) == icol_road_imperv) then
                 scale_c2l(c) = 3.0
              else if (ctype(c) == icol_roof) then
@@ -801,7 +801,7 @@ CONTAINS
        end do
     else if (c2l_scale_type == 'urbans') then
        do c = lbc,ubc
-          l = clandunit(c) 
+          l = clandunit(c)
           if (ltype(l) == isturb) then
              if (ctype(c) == icol_sunwall) then
                 scale_c2l(c) = (3.0 * canyon_hwr(l)) / (2.*canyon_hwr(l) + 1.)
@@ -818,7 +818,7 @@ CONTAINS
        end do
     else if (c2l_scale_type == 'urbanh') then
        do c = lbc,ubc
-          l = clandunit(c) 
+          l = clandunit(c)
           if (ltype(l) == isturb) then
              if (ctype(c) == icol_sunwall) then
                 scale_c2l(c) = spval
@@ -856,12 +856,12 @@ CONTAINS
                 g = cgridcell(c)
                    !garr(g,j) = garr(g,j) + carr(c,j) * scale_c2l(c) * scale_l2g(l) * wtgcell(c)
                    !w_yw = scale_c2l(c) * scale_l2g(l) * wtgcell(c)
-                   w_yw = scale_c2l(c) * scale_l2g(l) 
-                   if(w_yw .ne. 0) then 
+                   w_yw = scale_c2l(c) * scale_l2g(l)
+                   if(w_yw .ne. 0) then
                       ! carr(c,j) =  garr(g,j) / w_yw *sumwt(g)
                       yw_r = garr(g,j) / w_yw
                       if(abs(yw_r - carr(c,j)) .lt. 400 .and. yw_r .ne. 0 ) then
-                         carr(c,j) =  garr(g,j) / w_yw 
+                         carr(c,j) =  garr(g,j) / w_yw
                       endif
                    endif
             end if
@@ -941,12 +941,12 @@ CONTAINS
        end do
     else if (c2l_scale_type == 'urbanf') then
        do c = lbc,ubc
-          l = clandunit(c) 
+          l = clandunit(c)
           if (ltype(l) == isturb) then
              if (ctype(c) == icol_sunwall) then
-                scale_c2l(c) = 3.0 * canyon_hwr(l) 
+                scale_c2l(c) = 3.0 * canyon_hwr(l)
              else if (ctype(c) == icol_shadewall) then
-                scale_c2l(c) = 3.0 * canyon_hwr(l) 
+                scale_c2l(c) = 3.0 * canyon_hwr(l)
              else if (ctype(c) == icol_road_perv .or. ctype(c) == icol_road_imperv) then
                 scale_c2l(c) = 3.0
              else if (ctype(c) == icol_roof) then
@@ -958,7 +958,7 @@ CONTAINS
        end do
     else if (c2l_scale_type == 'urbans') then
        do c = lbc,ubc
-          l = clandunit(c) 
+          l = clandunit(c)
           if (ltype(l) == isturb) then
              if (ctype(c) == icol_sunwall) then
                 scale_c2l(c) = (3.0 * canyon_hwr(l)) / (2.*canyon_hwr(l) + 1.)
@@ -975,7 +975,7 @@ CONTAINS
        end do
     else if (c2l_scale_type == 'urbanh') then
        do c = lbc,ubc
-          l = clandunit(c) 
+          l = clandunit(c)
           if (ltype(l) == isturb) then
              if (ctype(c) == icol_sunwall) then
                 scale_c2l(c) = spval
@@ -1013,13 +1013,13 @@ CONTAINS
                     g = cgridcell(c)
                     !garr(g,j) = garr(g,j) + carr(c,j) * scale_c2l(c) * scale_l2g(l) * wtgcell(c)
                     !w_yw = scale_c2l(c) * scale_l2g(l) * wtgcell(c)
-                    w_yw = scale_c2l(c) * scale_l2g(l) 
-                    if(w_yw .ne. 0) then 
+                    w_yw = scale_c2l(c) * scale_l2g(l)
+                    if(w_yw .ne. 0) then
                     if(abs(garr(g,j)) .gt. minv .and. abs(garr(g,j)) .lt. maxv) then 
                        ! carr(c,j) =  garr(g,j) / w_yw *sumwt(g)
-                             yw_r =  garr(g,j) / w_yw 
+                             yw_r =  garr(g,j) / w_yw
                              if(yw_r .gt. 0) then
-                                carr(c,j) =  garr(g,j) / w_yw 
+                                carr(c,j) =  garr(g,j) / w_yw
                              endif
                     endif
                     endif

--- a/src/CPL/LIS_cpl/lis_drv_HYDRO.F
+++ b/src/CPL/LIS_cpl/lis_drv_HYDRO.F
@@ -3,20 +3,20 @@
 !  Abstract:
 !  History Log:
 !  <brief list of changes to this source file>
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !2345678

--- a/src/CPL/LIS_cpl/module_lis_HYDRO.F
+++ b/src/CPL/LIS_cpl/module_lis_HYDRO.F
@@ -3,24 +3,24 @@
 !  Abstract:
 !  History Log:
 !  <brief list of changes to this source file>
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_lis_HYDRO
-    use noah271_lsmMod, only : noah271_struc 
+    use noah271_lsmMod, only : noah271_struc
 !   use LIS_coreMod, only : LIS_rc, LIS_domain, LIS_masterproc, &
 !         LIS_ews_ind, LIS_ewe_ind, LIS_nss_ind, LIS_nse_ind
     use LIS_coreMod
@@ -34,12 +34,12 @@ module module_lis_HYDRO
        use config_base, only : nlst
        use module_HYDRO_drv, only: HYDRO_ini, HYDRO_exe
 
-!!! temp use 
+!!! temp use
        use module_yw, only: SFHEAD1RT,INFXS1RT, soldrain
     contains
 
     subroutine lis_cpl_HYDRO(n)
-       
+
 
 
         implicit none
@@ -123,7 +123,7 @@ module module_lis_HYDRO
         else
            write(cpl_outdate(15:17),'(I2,":")') LIS_rc%mn
         endif
-       
+
         if(LIS_rc%ss .lt. 10) then
            write(cpl_outdate(18:19),'("0",I1)') LIS_rc%ss
         else
@@ -141,15 +141,15 @@ module module_lis_HYDRO
             jts = LIS_nss_ind(LIS_rc%nnest,my_id+1)
             jte = LIS_nse_ind(LIS_rc%nnest,my_id+1)
 
-!           write(6,*) "LIS_ews_ind",LIS_ews_ind 
-!           write(6,*) "LIS_ewe_ind",LIS_ewe_ind 
-!           write(6,*) "LIS_nss_ind",LIS_nss_ind 
-!           write(6,*) "LIS_nse_ind",LIS_nse_ind 
+!           write(6,*) "LIS_ews_ind",LIS_ews_ind
+!           write(6,*) "LIS_ewe_ind",LIS_ewe_ind
+!           write(6,*) "LIS_nss_ind",LIS_nss_ind
+!           write(6,*) "LIS_nse_ind",LIS_nse_ind
 
         if(.not. RT_DOMAIN(did)%initialized) then
 !           write(6,*) "yyyywww step 3"
 #ifdef HYDRO_D
-            write(6,*) "ix,jx, cpl_land_dt",ix,jx, LIS_rc%ts  
+            write(6,*) "ix,jx, cpl_land_dt",ix,jx, LIS_rc%ts
 
 !           write(6,*) "yyyywww step 4 before HYDRO_ini= "
             write(6,*) "its,ite,jts,jte", its,ite,jts,jte
@@ -174,7 +174,7 @@ module module_lis_HYDRO
             endif
 !           write(6,*) "yyyywww step 5 my_id= ", my_id
 
-            nlst(did)%dt = LIS_rc%ts   
+            nlst(did)%dt = LIS_rc%ts
 
 !         write(6,*) "LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%glbnch_red(n)", &
 !                LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%glbnch_red(n)
@@ -196,24 +196,24 @@ module module_lis_HYDRO
 !       write(6,*) "size(noah271_struc(n)%noah%smc(1)),n,ix,jx" , size(noah271_struc(n)%noah%smc(1)),n,ix,jx
 !       write(6,*) "nlst(did)%nsoil = ", nlst(did)%nsoil
 
-            ! get the initial data from LIS 
+            ! get the initial data from LIS
             do k = 1 , nlst(did)%nsoil
                 call lis2HYDRO(RT_DOMAIN(did)%SMC(:,:,k),noah271_struc(n)%noah%smc(k),size(noah271_struc(n)%noah%smc(k)),n,ix,jx)
                 call lis2HYDRO(RT_DOMAIN(did)%stc(:,:,k),noah271_struc(n)%noah%stc(k),size(noah271_struc(n)%noah%stc(k)), n,ix,jx)
                 call lis2HYDRO(RT_DOMAIN(did)%SH2OX(:,:,k),noah271_struc(n)%noah%sh2o(k),size(noah271_struc(n)%noah%sh2o(k)),n,ix,jx)
             enddo
-       
-#ifdef HYDRO_D       
+
+#ifdef HYDRO_D
         write(6,*) "NDHMS lis date ", LIS_rc%yr, LIS_rc%mo, LIS_rc%da, LIS_rc%hr, LIS_rc%mn, LIS_rc%ss 
 #endif
 !       write(11,*) "RT_DOMAIN(did)%stc",RT_DOMAIN(did)%stc(:,:,1)
 !       write(12,*) "noah271_struc(n)%noah%stc(1)",noah271_struc(n)%noah%stc(1)
-!       call land_finish() 
+!       call land_finish()
 
         call lis2HYDRO(RT_DOMAIN(did)%infxsrt(:,:),INFXS1RT,size(INFXS1RT),n,ix,jx)
         call lis2HYDRO(RT_DOMAIN(did)%soldrain(:,:),SOLDRAIN,size(SOLDRAIN),n,ix,jx)
-        
-    
+
+
         call HYDRO_exe(did)
 
 ! add for update the land surface model state variable.
@@ -226,7 +226,7 @@ module module_lis_HYDRO
 
         call HYDRO2lis_2d(rt_domain(did)%overland%control%surface_water_head_lsm(:,:),SFHEAD1RT,size(SFHEAD1RT),n,ix,jx)
 
-     return 
+     return
      end subroutine lis_cpl_HYDRO
 
      subroutine HYDRO2lis_2d(var,v1d,size1,n,ix,jx)
@@ -238,14 +238,14 @@ module module_lis_HYDRO
 
 !        call LIS_gather_gridded_output(n, p1,tmpVar)
           do r=1,jx
-             do c=1,ix                
+             do c=1,ix
                 if(LIS_domain(n)%gindex(c,r).ne.-1) then
                    v1d(LIS_domain(n)%gindex(c,r)) = var(c,r)
                 endif
              enddo
           enddo
 
-     end subroutine HYDRO2lis_2d        
+     end subroutine HYDRO2lis_2d
 
      subroutine lis2HYDRO(var,v1d,size1,n,ix,jx)
         implicit none
@@ -253,7 +253,7 @@ module module_lis_HYDRO
         real, dimension(ix,jx) :: var
 !       real, dimension(jx,ix) :: tmpVar
         real ::  v1d (size1)
-  
+
 
 !       do i = 1, ix
 !          tmpVar(:,i) = Var(i,:)
@@ -261,13 +261,13 @@ module module_lis_HYDRO
 !       call LIS_gather_tiled_vector_output(n,v1d,tmpVar)
 
           do r=1,jx
-             do c=1,ix                
+             do c=1,ix
                 if(LIS_domain(n)%gindex(c,r).ne.-1) then
                    var(c,r) = v1d(LIS_domain(n)%gindex(c,r))
                 endif
              enddo
           enddo
-         
+
       end subroutine  lis2HYDRO
 
 end module module_lis_HYDRO

--- a/src/CPL/NUOPC_cpl/WRFHydro_ESMF_Extensions.F90
+++ b/src/CPL/NUOPC_cpl/WRFHydro_ESMF_Extensions.F90
@@ -366,7 +366,7 @@ contains
     type(ESMF_FileStatus_Flag), intent(in),  optional :: status
     integer,                    intent(in),  optional :: timeslice
     type(ESMF_IOFmt_Flag),      intent(in),  optional :: iofmt
-    logical,                    intent(in),  optional :: relaxedflag 
+    logical,                    intent(in),  optional :: relaxedflag
     logical,                    intent(in),  optional :: nclScript
     type(MapDesc),              intent(in),  optional :: map
     integer,                    intent(out), optional :: rc
@@ -415,7 +415,7 @@ contains
 !     If {\tt .true.}, then no error is returned even if the call cannot write
 !     the file due to library limitations. Default is {\tt .false.}.
 !   \item[{[nclScript]}]
-!     If {\tt .true.} then NUOPC will write an NCL script that can be used to 
+!     If {\tt .true.} then NUOPC will write an NCL script that can be used to
 !     generate grid graphics. Default is {\tt .false.}.
 !   \item[{[map]}]
 !     Derived type including the map name and boundary coordinates.
@@ -604,7 +604,7 @@ contains
   title,nclFile,uniformRect,writeCorners,rc)
 ! ! ARGUMENTS
     character(len=*),intent(in)          :: gridFile
-    character(len=*),intent(in)          :: mapName         
+    character(len=*),intent(in)          :: mapName
     real,intent(in)                      :: minCoords(2)
     real,intent(in)                      :: maxCoords(2)
     character(len=*),intent(in),optional :: title
@@ -1220,8 +1220,8 @@ contains
     integer, intent(out),optional         :: rc
 ! !DESCRIPTION:
 !   Check NetCDF file for varname
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -1283,8 +1283,8 @@ contains
     integer, intent(out),optional         :: rc
 ! !DESCRIPTION:
 !   Read NetCDF variable into ESMF field
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -1320,8 +1320,8 @@ contains
     integer, intent(out),optional         :: rc
 ! !DESCRIPTION:
 !   Read NetCDF var into ESMF array
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -1382,7 +1382,7 @@ contains
         msg="Cannot read NetCDF because rank is not supported", &
         CONTEXT, rcToReturn=rc)
       return
-    endif 
+    endif
 
   end subroutine
 #undef METHOD
@@ -1403,8 +1403,8 @@ contains
     integer, intent(out),optional         :: rc
 ! !DESCRIPTION:
 !   Read NetCDF variable into I4 array
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -1511,8 +1511,8 @@ contains
     integer, intent(out),optional         :: rc
 ! !DESCRIPTION:
 !   Read NetCDF variable into I8 array
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -1619,8 +1619,8 @@ contains
     integer, intent(out),optional         :: rc
 ! !DESCRIPTION:
 !   Read NetCDF variable into R4 array
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -1727,8 +1727,8 @@ contains
     integer, intent(out),optional         :: rc
 ! !DESCRIPTION:
 !   Read NetCDF variable into R8 array
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -1834,8 +1834,8 @@ contains
     integer, intent(out),optional        :: rc
 ! !DESCRIPTION:
 !   Write ESMF state information to PET Logs
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -1877,8 +1877,8 @@ contains
     integer,intent(out),optional :: rc
 ! !DESCRIPTION:
 !   Write ESMF state information to PET Logs
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -1913,8 +1913,8 @@ contains
 
     call ESMF_StateGet(state, nestedFlag=nestedFlag, &
       itemCount=itemCount, name=stateName, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, PASSTHRU)) return  ! bail out  
-   
+    if (ESMF_LogFoundError(rcToCheck=rc, PASSTHRU)) return  ! bail out
+
     if (itemCount > 0 ) then
 
       allocate(itemNameList(itemCount),itemTypeList(itemCount),stat=stat)
@@ -1981,8 +1981,8 @@ contains
     integer, intent(out), optional          :: rc
 ! !DESCRIPTION:
 !   Write ESMF state connection to PET logs
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2058,8 +2058,8 @@ contains
     integer, intent(out), optional         :: rc
 ! !DESCRIPTION:
 !   Write ESMF grid information to PET logs
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2155,7 +2155,7 @@ contains
     do tileIndex=1,tileCount
     do dimIndex=1,dimCount
       write (logMsg,"(A,A,A,4(I0,A))") trim(llabel)//": ", &
-        trim(gridName), &       
+        trim(gridName), &
         " (tile,dim,minIndexPTile,maxIndexPTile)=(", &
         tileIndex,",",dimIndex,",", &
         minIndexPTile(dimIndex,tileIndex),",", &
@@ -2186,8 +2186,8 @@ contains
     integer,intent(out),optional         :: rc
 ! !DESCRIPTION:
 !   Write ESMF field information to PET logs
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2227,8 +2227,8 @@ contains
     integer,intent(out),optional         :: rc
 ! !DESCRIPTION:
 !   Write ESMF field information to PET logs
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2334,8 +2334,8 @@ contains
     integer, intent(out), optional          :: rc
 ! !DESCRIPTION:
 !   Write ESMF field local vals to PET logs
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2355,7 +2355,7 @@ contains
     endif
 
     call ESMF_FieldGet(field,array=array,name=fieldName,rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, PASSTHRU)) return  ! bail out    
+    if (ESMF_LogFoundError(rcToCheck=rc, PASSTHRU)) return  ! bail out
 
     call WRFHYDRO_ESMF_LogArrayLclVal(array,fieldName=fieldName,label=llabel,rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, PASSTHRU)) return  ! bail out
@@ -2378,8 +2378,8 @@ contains
     integer, intent(out), optional          :: rc
 ! !DESCRIPTION:
 !   Write ESMF array local vals to PET logs
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2528,8 +2528,8 @@ contains
     integer, intent(out), optional             :: rc
 ! !DESCRIPTION:
 !   Write I41D array local vals to log
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2579,8 +2579,8 @@ contains
     integer, intent(out), optional             :: rc
 ! !DESCRIPTION:
 !   Write I42D array local vals to log
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2630,8 +2630,8 @@ contains
     integer, intent(out), optional             :: rc
 ! !DESCRIPTION:
 !   Write I43D array local vals to log
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2681,8 +2681,8 @@ contains
     integer, intent(out), optional             :: rc
 ! !DESCRIPTION:
 !   Write I81D array local vals to log
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2732,8 +2732,8 @@ contains
     integer, intent(out), optional             :: rc
 ! !DESCRIPTION:
 !   Write I82D array local vals to log
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2783,8 +2783,8 @@ contains
     integer, intent(out), optional             :: rc
 ! !DESCRIPTION:
 !   Write I83D array local vals to log
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2834,8 +2834,8 @@ contains
     integer, intent(out), optional          :: rc
 ! !DESCRIPTION:
 !   Write R41D array local vals to log
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2885,8 +2885,8 @@ contains
     integer, intent(out), optional          :: rc
 ! !DESCRIPTION:
 !   Write R41D array local vals to log
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2936,8 +2936,8 @@ contains
     integer, intent(out), optional          :: rc
 ! !DESCRIPTION:
 !   Write R43D array local vals to log
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -2987,8 +2987,8 @@ contains
     integer, intent(out), optional          :: rc
 ! !DESCRIPTION:
 !   Write R81D array local vals to log
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -3038,8 +3038,8 @@ contains
     integer, intent(out), optional          :: rc
 ! !DESCRIPTION:
 !   Write R81D array local vals to log
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -3089,8 +3089,8 @@ contains
     integer, intent(out), optional          :: rc
 ! !DESCRIPTION:
 !   Write R83D array local vals to log
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !
@@ -3139,8 +3139,8 @@ contains
     integer, intent(out),optional        :: rc
 ! !DESCRIPTION:
 !   Write ESMF CplList to PET logs
-!   
-!   The arguments are:                     
+!
+!   The arguments are:
 !   \begin{description}
 !   \end{description}
 !

--- a/src/CPL/NUOPC_cpl/WRFHydro_NUOPC_Cap.F90
+++ b/src/CPL/NUOPC_cpl/WRFHydro_NUOPC_Cap.F90
@@ -9,15 +9,15 @@
 !!
 !! @section Overview Overview
 !!
-!! The Weather Research and Forecasting Hydrological (WRF-Hydro) model is a 
-!! hydrometerological forecasting model developed and maintained by the 
-!! National Center for Atmospheric Research (NCAR). The WRF-Hydro cap wraps 
-!! the WRF-Hydro model with NUOPC compliant interfaces. The result is a 
-!! WRF-Hydro model capable of coupling with other models using National 
+!! The Weather Research and Forecasting Hydrological (WRF-Hydro) model is a
+!! hydrometerological forecasting model developed and maintained by the
+!! National Center for Atmospheric Research (NCAR). The WRF-Hydro cap wraps
+!! the WRF-Hydro model with NUOPC compliant interfaces. The result is a
+!! WRF-Hydro model capable of coupling with other models using National
 !! Unified Operational Prediction Capability (NUOPC).
 !!
-!! This page documents the technical design of the specialized NUOPC model and 
-!! the WRF-Hydro gluecode. For generic NUOPC model documentation please see 
+!! This page documents the technical design of the specialized NUOPC model and
+!! the WRF-Hydro gluecode. For generic NUOPC model documentation please see
 !! the NUOPC reference manual: https://www.earthsystemcog.org/projects/nuopc/refmans.
 !!
 !!
@@ -67,8 +67,8 @@
 !!
 !! @subsection InitializeP3 InitializeP3
 !!
-!! During initialize phase 3 import and export fields are realized if they are 
-!! connected through NUOPC. Realized fields are created on the WRF-Hydro grid. 
+!! During initialize phase 3 import and export fields are realized if they are
+!! connected through NUOPC. Realized fields are created on the WRF-Hydro grid.
 !!
 !! @subsection DataInitialize DataInitialize
 !!
@@ -79,7 +79,7 @@
 !! @subsection SetClock SetClock
 !!
 !! During set clock the cap creates a new clock using the timestep configured
-!! in te WRF-Hydro configuration file. The restart write time step is also 
+!! in te WRF-Hydro configuration file. The restart write time step is also
 !! created and the restart write time accumulation tracker is reset to zero.
 !!
 !!
@@ -175,20 +175,20 @@
 !! WRF-Hydro diagnostics output is written to standard out. To increase the
 !! diagnostic output compile WRF-Hydro with -DHYDRO_D.
 !!
-!! WRF-Hydro writes several output files.  Please see the 
+!! WRF-Hydro writes several output files.  Please see the
 !! [WRF-Hydro documentation] (https://www.ral.ucar.edu/projects/wrf_hydro).
 !!
 !! @section Dependencies Dependencies
 !!
 !! Dependencies
-!! - [ESMF v7.0.0+] (https://www.earthsystemcog.org/projects/esmf/) 
+!! - [ESMF v7.0.0+] (https://www.earthsystemcog.org/projects/esmf/)
 !! - [NetCDF v4.3.0+] (http://www.unidata.ucar.edu/software/netcdf/docs/)
 !! - [NetCDF FORTRAN] (http://www.unidata.ucar.edu/software/netcdf/docs/building_netcdf_fortran.html)
 !!
 !! @subsection ESMF ESMF
 !!
-!! See the [ESMF User's Guide] 
-!! (http://www.earthsystemmodeling.org/esmf_releases/public/last/ESMF_usrdoc). 
+!! See the [ESMF User's Guide]
+!! (http://www.earthsystemmodeling.org/esmf_releases/public/last/ESMF_usrdoc).
 !!
 !! @section BuildingAndInstalling Building and Installing
 !!
@@ -200,8 +200,8 @@
 !! - nuopcinstall
 !! - nuopcclean
 !!
-!! The build system in [Makefile] (@ref Makefile) wraps the WRF-Hydro build 
-!! system and adds the nuopc, nuopcinstall, and nuopcclean targets. Before 
+!! The build system in [Makefile] (@ref Makefile) wraps the WRF-Hydro build
+!! system and adds the nuopc, nuopcinstall, and nuopcclean targets. Before
 !! building make sure to configure the internal model.
 !!
 !! To build and install into the current directory run:
@@ -219,7 +219,7 @@
 !!
 !! @section References
 !!
-!! - [WRF-Hydro] (https://www.ral.ucar.edu/projects/wrf_hydro) 
+!! - [WRF-Hydro] (https://www.ral.ucar.edu/projects/wrf_hydro)
 !! - [ESPS] (https://www.earthsystemcog.org/projects/esps)
 !! - [ESMF] (https://www.earthsystemcog.org/projects/esmf)
 !! - [NUOPC] (https://www.earthsystemcog.org/projects/nuopc/)
@@ -1059,7 +1059,7 @@ module WRFHydro_NUOPC
           "_imp_D"//trim(nStr)//"_"//trim(currTimeStr), rc=rc)
       if (ESMF_STDERRORCHECK(rc)) return
       call NUOPC_SetTimestamp(is%wrap%NStateImp(1), time=currTime, rc=rc)
-      if (ESMF_STDERRORCHECK(rc)) return  ! bail out      
+      if (ESMF_STDERRORCHECK(rc)) return  ! bail out
       importUpdated = .TRUE.
     elseif (is%wrap%init_import.eq.FILLV_MODEL) then
       if (is%wrap%memr_import.eq.MEMORY_COPY) then
@@ -1215,7 +1215,7 @@ module WRFHydro_NUOPC
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! override timestep
-    if (is%wrap%timeStepInt /= 0) then 
+    if (is%wrap%timeStepInt /= 0) then
       call ESMF_TimeIntervalSet(timestep, &
         s=is%wrap%timeStepInt, rc=rc)
       if (ESMF_STDERRORCHECK(rc)) return  ! bail out

--- a/src/CPL/NUOPC_cpl/WRFHydro_NUOPC_Gluecode.F90
+++ b/src/CPL/NUOPC_cpl/WRFHydro_NUOPC_Gluecode.F90
@@ -190,7 +190,7 @@ contains
       return  ! bail out
     endif
 
-    call get_file_dimension(fileName=nlst(did)%geo_static_flnm,& 
+    call get_file_dimension(fileName=nlst(did)%geo_static_flnm,&
       ix=nx_global(1),jx=ny_global(1))
     call MPP_LAND_INIT(nx_global(1),ny_global(1))
 
@@ -444,7 +444,7 @@ contains
           infxsrt=rt_domain(did)%infxsrt,soldrain=rt_domain(did)%soldrain)
       endif
     endif
-  
+
     ! Call the WRF-HYDRO run routine
     call HYDRO_exe(did=did)
 

--- a/src/CPL/Noah_cpl/hrldas_drv_HYDRO.F
+++ b/src/CPL/Noah_cpl/hrldas_drv_HYDRO.F
@@ -3,20 +3,20 @@
 !  Abstract:
 !  History Log:
 !  <brief list of changes to this source file>
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !2345678
@@ -80,7 +80,7 @@
           use config_base, only: nlst
           implicit none
           character(len=*) :: olddate, inFile
-          integer :: idim, jdim 
+          integer :: idim, jdim
           real, dimension(idim,jdim):: greenfrac
           integer:: mm, dd, did
           integer :: months
@@ -109,22 +109,22 @@
           integer :: i, j, mm2,daytot
           real :: ddfrac
           character(len=24), parameter :: name = "GREENFRAC"
-      
+
 !          units = "fraction"
 
           iret = nf_open(trim(fileName), NF_NOWRITE, ncid)
           if(iret /= 0) then
               write(6,*) "FATAL ERROR: failed to open file in get_greenfrac: ", trim(fileName)
               call hydro_stop("In hrldas_drv_HYDRO.F get_greenfrac_netcdf() - failed to open file") 
-          endif 
-            
+          endif
+
           iret = nf_inq_varid(ncid,  trim(name),  varid)
           if (iret /= 0) then
              print*, 'name = "', trim(name)//'"'
              print*, "MODULE_NOAHLSM_HRLDAS_INPUT:  get_greenfrac_netcdf:  nf_inq_varid"
              call hydro_stop("In hrldas_drv_HYDRO.F get_greenfrac_netcdf() - nf_inq_varid problem")
           endif
-      
+
           iret = nf_get_var_real(ncid, varid, xtmp)
           if (iret /= 0) then
 
@@ -132,14 +132,14 @@
              print*, "MODULE_NOAHLSM_HRLDAS_INPUT:  get_greenfrac_netcdf:  nf_get_var_real"
              call hydro_stop("In hrldas_drv_HYDRO.F get_greenfrac_netcdf() - nf_get_var_real problem")
           endif
-      
-      
-          if (mm.lt.12) then 
+
+
+          if (mm.lt.12) then
             mm2 = mm+1
           else
             mm2 = 1
                 end if
-      
+
           !DJG_DES Set up dates for daily interpolation...
                 if (mm.eq.1.OR.mm.eq.3.OR.mm.eq.5.OR.mm.eq.7.OR.mm.eq.8.OR.mm.eq.10.OR.mm.eq.12) then
                    daytot = 31
@@ -150,17 +150,17 @@
                 end if
                 ddfrac = float(dd)/float(daytot)
                 if (ddfrac.gt.1.0) ddfrac = 1.0   ! Assumes Feb. 29th change is same as Feb 28th
-      
+
 #ifdef HYDRO_D
                print *,"DJG_DES Made it past netcdf read...month = ",mm,mm2,dd,daytot,ddfrac
 #endif
-      
+
           do i = 1, idim
              do j = 1, jdim
                 array(i,j) = xtmp(i,j,mm)   !GREENFRAC in geogrid in units of fraction from month 1
                 array2(i,j) = xtmp(i,j,mm2)   !GREENFRAC in geogrid in units of fraction from month 1
                 diff(i,j) = array2(i,j) - array(i,j)
-                array3(i,j) = array(i,j) + ddfrac * diff(i,j) 
+                array3(i,j) = array(i,j) + ddfrac * diff(i,j)
              enddo
           enddo
           iret=nf_close(ncid)
@@ -179,12 +179,12 @@
           real,dimension(ix,jx,nsoil):: smc,stc,sh2ox
           real,dimension(ix,jx):: cmc, t1, weasd, snodep, lai, fpar ,SHDMIN,SHDMAX
           integer, dimension(ix,jx) ::    vegtyp
-          logical :: FNDSNOWH 
+          logical :: FNDSNOWH
 !yw          real, dimension(50) :: shdtbl
 !yw          data shdtbl /0.1,0.8,0.8,0.8,0.8,0.8,0.8,0.7,0.7,0.5,  &
 !yw              0.8,0.7,0.95,0.7,0.8,0,0.6,0.6,0.1, &
 !yw              0.6,0.6,0.6,0.3,0,0.5,0,0,           &
-!yw              0,0,0,0,0,0,0,0,0,0,0,0,0,          & 
+!yw              0,0,0,0,0,0,0,0,0,0,0,0,0,          &
 !yw              0,0,0,0,0,0,0,0,0,0/
 
 
@@ -197,23 +197,23 @@
               write(6,*) "initialization from the file  : ", trim(fileName)
 
 #endif
-          endif 
+          endif
 
            iret = nf_inq_varid(ncid,"VEGFRA",  varid)
-           if (iret == 0) then 
+           if (iret == 0) then
                iret = nf_get_var_real(ncid, varid, fpar)
                if(maxval(fpar) .gt. 10 .and. (maxval(fpar) .lt. 1000)) fpar = fpar/100.
            endif
 
            iret = nf_inq_varid(ncid,"SHDMIN",  varid)
-           if (iret == 0) then 
+           if (iret == 0) then
                iret = nf_get_var_real(ncid, varid, SHDMIN)
                if(maxval(SHDMIN) .gt. 10 .and. (maxval(SHDMIN) .lt. 1000)) SHDMIN = SHDMIN / 100.
            endif
-             
+
 
            iret = nf_inq_varid(ncid,"SHDMAX",  varid)
-           if (iret == 0) then 
+           if (iret == 0) then
               iret = nf_get_var_real(ncid, varid, SHDMAX)
                if(maxval(SHDMAX) .gt. 10 .and. (maxval(SHDMAX) .lt. 1000)) SHDMAX = SHDMAX / 100.
            endif
@@ -239,7 +239,7 @@
              FNDSNOWH = .true.
           else
              FNDSNOWH = .false.
-          endif  
+          endif
 
           iret = nf_inq_varid(ncid,"SNOW",  varid)
           if (iret == 0) then
@@ -248,13 +248,13 @@
 #endif
              iret = nf_get_var_real(ncid, varid, weasd)
              weasd = weasd * 1.0E-3    ! transfer the unit from mm to m
-          endif  
-         
-         
+          endif
+
+
 !         where(snodep < weasd) snodep = weasd * 10
-!            write(6,*) "SNOW(20,1)=",weasd(20,1) 
-!            write(6,*) "SNOWH(20,1)=",snodep(20,1) 
-          
+!            write(6,*) "SNOW(20,1)=",weasd(20,1)
+!            write(6,*) "SNOWH(20,1)=",snodep(20,1)
+
           iret = nf_inq_varid(ncid,"TSK",  varid)
           if (iret == 0) iret = nf_get_var_real(ncid, varid, t1)
 
@@ -272,7 +272,7 @@
 
           iret=nf_close(ncid)
 
-!yw    added for 
+!yw    added for
              where( abs(t1) .gt. 500) t1 = 282
              where( abs(stc) .gt. 500) stc = 282
              where( abs(SMC) .gt. 1) SMC = 0.25
@@ -280,11 +280,11 @@
              where( abs(SH2OX) .gt. 500) SH2OX = 0.25
 
 
- 
+
        end subroutine HYDRO_HRLDAS_ini
 
        subroutine getHydroNameList(varName,pVar)
-          use module_hrldas_HYDRO, only: getNameList 
+          use module_hrldas_HYDRO, only: getNameList
           implicit none
           integer ::  pVar
           character(len=*)  ::varName

--- a/src/CPL/Noah_cpl/module_hrldas_HYDRO.F
+++ b/src/CPL/Noah_cpl/module_hrldas_HYDRO.F
@@ -3,25 +3,25 @@
 !  Abstract:
 !  History Log:
 !  <brief list of changes to this source file>
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_HRLDAS_HYDRO
 
-! NDHMS  module   
+! NDHMS  module
 #ifdef MPP_LAND
     use module_mpp_land, only: global_nx, global_ny, decompose_data_real, &
                  write_io_real, my_id, mpp_land_bcast_real1, IO_id, &
@@ -39,7 +39,7 @@ module module_HRLDAS_HYDRO
     integer :: numg, numl, numc, nump
     INTEGER, PARAMETER :: double=8
     real(kind=double), pointer :: r2p(:,:) , r1p(:)
-     
+
     integer ::  begl, endl, begc, endc, begp, endp
 
     real, allocatable, dimension(:,:) :: vg_test
@@ -67,7 +67,7 @@ CONTAINS
         integer :: i,j
 
         real*8 :: t1, t2, dact
-        integer :: clock_count_1, clock_count_2, clock_rate 
+        integer :: clock_count_1, clock_count_2, clock_rate
         save dact
 
 
@@ -95,7 +95,7 @@ CONTAINS
         end do
         call decompose_data_real(infxsrt,RT_DOMAIN(did)%infxsrt)
         call decompose_data_real(soldrain,RT_DOMAIN(did)%soldrain)
-	
+
 	if(nlst(did)%GWBASESWCRT == 3)&
         call decompose_data_real(qsgw,gw2d(did)%qsgw)
 #else
@@ -107,7 +107,7 @@ CONTAINS
         if(nlst(did)%GWBASESWCRT == 3) &
 	  gw2d(did)%qsgw = qsgw
 #endif
-  
+
 #ifdef MPP_LAND
 #ifdef HYDRO_D
         if(my_id .eq. IO_id) then
@@ -154,7 +154,7 @@ CONTAINS
 !           grid%xice(its:ite,jts:jte) = rt_domain(did)%sice
 
 
-     return 
+     return
      end subroutine hrldas_cpl_HYDRO
 
     subroutine hrldas_cpl_HYDRO_ini(STC,SMC,SH2OX,infxsrt,sfcheadrt,soldrain,ii,jj,kk,kt,dt, olddate,zsoil)
@@ -181,7 +181,7 @@ CONTAINS
         did = 1
 
 
-        if(.not. RT_DOMAIN(did)%initialized) then  
+        if(.not. RT_DOMAIN(did)%initialized) then
            call MPP_LAND_INIT()
            nlst(did)%dt = dt
            nlst(did)%olddate(1:19) = olddate(1:19)
@@ -193,8 +193,8 @@ CONTAINS
 #endif
            allocate(nlst(did)%zsoil8(nlst(did)%nsoil))
            nlst(did)%zsoil8(1:nlst(did)%nsoil) = zsoil(1:nlst(did)%nsoil)
-           
-           
+
+
            call HYDRO_ini(ntime,did,ix0=1,jx0=1)
 
            if(nlst(did)%rtFlag .eq. 0) return
@@ -206,7 +206,7 @@ CONTAINS
             endif
 
            RT_DOMAIN(did)%initialized = .true.
-   
+
            IF (nlst(did)%GWBASESWCRT .eq. 0 &
                .and. nlst(did)%SUBRTSWCRT .eq.0  &
                .and. nlst(did)%OVRTSWCRT .eq. 0 ) return
@@ -233,7 +233,7 @@ CONTAINS
                  where( SH2OX .le. 0.0001) SH2OX = 0.25
                  where( SMC .le. 0.0001) SMC = 0.25
               endif
-           endif 
+           endif
 #else
            sfcheadrt = rt_domain(did)%overland%control%surface_water_head_lsm
            infxsrt = rt_domain(did)%infxsrt
@@ -254,7 +254,7 @@ CONTAINS
 #endif
         endif
 
-     return 
+     return
      end subroutine hrldas_cpl_HYDRO_ini
 
      subroutine open_print_mpp(iunit)
@@ -263,11 +263,11 @@ CONTAINS
        character(len=16) fileout
        character(len=32) diag_prefix
 #ifdef NCEP_WCOSS
-       integer len, status 
+       integer len, status
 #endif
 
        if(open_unit_status == 999) return
-       open_unit_status = 999 
+       open_unit_status = 999
 
 
 #ifdef NCEP_WCOSS
@@ -295,10 +295,10 @@ CONTAINS
        diag_prefix = 'diag_hydro.'
 #endif
 
-#ifdef MPP_LAND  
-       write(fileout,'(a11,i0.5)') TRIM(diag_prefix),my_id    
+#ifdef MPP_LAND
+       write(fileout,'(a11,i0.5)') TRIM(diag_prefix),my_id
 #else
-       write(fileout,'(a11,i0.5)') TRIM(diag_prefix),0    
+       write(fileout,'(a11,i0.5)') TRIM(diag_prefix),0
 #endif
        open(iunit,file=fileout,form="formatted")
      end subroutine open_print_mpp
@@ -306,7 +306,7 @@ CONTAINS
      subroutine getNameList(varName,pVar)
           implicit none
           integer :: pVar
-          integer :: did 
+          integer :: did
           character(len=*) :: varName
           did = 1
           if(varName .eq. "GWSPINCYCLES") then

--- a/src/CPL/WRF_cpl/module_wrf_HYDRO.F
+++ b/src/CPL/WRF_cpl/module_wrf_HYDRO.F
@@ -3,20 +3,20 @@
 !  Abstract:
 !  History Log:
 !  <brief list of changes to this source file>
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_WRF_HYDRO
@@ -39,10 +39,10 @@ module module_WRF_HYDRO
     USE module_configure, ONLY : grid_config_rec_type
     !yw USE module_configure, only : config_flags
     USE module_configure, only: model_config_rec
- 
+
 
     implicit none
-     
+
     !yw   added for check soil moisture and soiltype
     integer ::  checkSOIL_flag
 
@@ -50,7 +50,7 @@ module module_WRF_HYDRO
     character(len=19) :: cpl_outdate
 #endif
 !
-! added to consider the adaptive time step from WRF model. 
+! added to consider the adaptive time step from WRF model.
     real    :: dtrt_ter0  , dtrt_ch0
     integer ::  mm0
 
@@ -59,7 +59,7 @@ module module_WRF_HYDRO
 
 CONTAINS
 
-!wrf_cpl_HYDRO will not call the off-line lsm 
+!wrf_cpl_HYDRO will not call the off-line lsm
 !ywGW subroutine wrf_cpl_HYDRO(HYDRO_dt,grid, config_flags, its,ite,jts,jte)
     subroutine wrf_cpl_HYDRO(HYDRO_dt,grid,its,ite,jts,jte)
 
@@ -77,7 +77,7 @@ CONTAINS
         integer ntime
 
         integer :: i,j
-        
+
         integer :: ierr
 
 !output flux and state variable
@@ -95,16 +95,16 @@ CONTAINS
 
         ntime = 1
 
-    
+
             nlst(did)%dt = HYDRO_dt
 
-  
+
         if(.not. RT_DOMAIN(did)%initialized) then
            !yw nlst_rt(did)%nsoil = config_flags%num_soil_layers
            !nlst_rt(did)%nsoil = model_config_rec%num_metgrid_soil_levels
            nlst(did)%nsoil = grid%num_soil_layers
 
-         
+
 #ifdef MPP_LAND
            call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
            call MPP_LAND_INIT(grid%e_we - grid%s_we - 1, grid%e_sn - grid%s_sn - 1)
@@ -131,8 +131,8 @@ CONTAINS
                write(6,*) "sf_surface_physics is ", grid%sf_surface_physics
 #endif
 
-           if(grid%sf_surface_physics .eq. 5) then    
-                ! clm4 
+           if(grid%sf_surface_physics .eq. 5) then
+                ! clm4
                call HYDRO_ini(ntime,did=did,ix0=1,jx0=1)
            else
                call HYDRO_ini(ntime,did,ix0=ix,jx0=jx,vegtyp=grid%IVGTYP(its:ite,jts:jte),soltyp=grid%isltyp(its:ite,jts:jte))
@@ -159,7 +159,7 @@ CONTAINS
                mm0 = mm
             endif
 
-            dtrt_ter0 = nlst(did)%dtrt_ter  
+            dtrt_ter0 = nlst(did)%dtrt_ter
 
             if(nlst(did)%dtrt_ch .ge. HYDRO_dt) then
                nlst(did)%dtrt_ch = HYDRO_dt
@@ -170,7 +170,7 @@ CONTAINS
                mm0 = mm
             endif
 
-            dtrt_ch0 = nlst(did)%dtrt_ch  
+            dtrt_ch0 = nlst(did)%dtrt_ch
         endif
 
             if((mm0*nlst(did)%dtrt_ter) .ne. HYDRO_dt) then   ! WRF model time step changed.
@@ -195,7 +195,7 @@ CONTAINS
                endif
             endif
 
-#ifdef HYDRO_D 
+#ifdef HYDRO_D
         write(6,*) "mm, nlst(did)%dt = ",mm, nlst(did)%dt
 #endif
 
@@ -204,7 +204,7 @@ CONTAINS
 
         nn = nlst(did)%nsoil
 
-        ! get the data from WRF 
+        ! get the data from WRF
 
 
 
@@ -217,10 +217,10 @@ CONTAINS
                 RT_DOMAIN(did)%STC(:,:,k) = grid%TSLB(its:ite,k,jts:jte) 
                 RT_DOMAIN(did)%smc(:,:,k) = grid%smois(its:ite,k,jts:jte) 
                 RT_DOMAIN(did)%sh2ox(:,:,k) = grid%sh2o(its:ite,k,jts:jte) 
-            end do 
+            end do
             rt_domain(did)%infxsrt = grid%infxsrt(its:ite,jts:jte)
             rt_domain(did)%soldrain = grid%soldrain(its:ite,jts:jte)
-       endif  
+       endif
 
             call HYDRO_exe(did)
 
@@ -230,7 +230,7 @@ CONTAINS
                 ! grid%TSLB(its:ite,k,jts:jte) = RT_DOMAIN(did)%STC(:,:,k)
                 grid%smois(its:ite,k,jts:jte) = RT_DOMAIN(did)%smc(:,:,k)
                 grid%sh2o(its:ite,k,jts:jte) = RT_DOMAIN(did)%sh2ox(:,:,k)
-            end do 
+            end do
 
 ! update WRF variable after running routing model.
             grid%sfcheadrt(its:ite,jts:jte) = rt_domain(did)%overland%control%surface_water_head_lsm
@@ -257,7 +257,7 @@ CONTAINS
       subroutine wrf2lsm (z1,v1,kk1,z,vout,ix,jx,kk,vegtyp)
 !  input: z1,v1,kk1,z,ix,jx,kk
 !  output: vout
-!  interpolate based on soil layer: z1 and z 
+!  interpolate based on soil layer: z1 and z
 !  z :  soil layer of output variable.
 !  z1: array of soil layers of input variable.
          implicit none
@@ -265,7 +265,7 @@ CONTAINS
          integer:: kk1, ix,jx,kk, vegtyp(ix,jx)
          real :: z1(kk1), z(kk), v1(ix,kk1,jx),vout(ix,jx,kk)
 
-       
+
          do j = 1, jx
             do i = 1, ix
                 do k = 1, kk
@@ -279,7 +279,7 @@ CONTAINS
       subroutine lsm2wrf (z1,v1,kk1,z,vout,ix,jx,kk,vegtyp)
 !  input: z1,v1,kk1,z,ix,jx,kk
 !  output: vout
-!  interpolate based on soil layer: z1 and z 
+!  interpolate based on soil layer: z1 and z
 !  z :  soil layer of output variable.
 !  z1: array of soil layers of input variable.
          implicit none
@@ -287,7 +287,7 @@ CONTAINS
          integer:: kk1, ix,jx,kk, vegtyp(ix,jx)
          real :: z1(kk1), z(kk), v1(ix,jx,kk1),vout(ix,kk,jx)
 
-       
+
          do j = 1, jx
             do i = 1, ix
                  do k = 1, kk
@@ -310,11 +310,11 @@ CONTAINS
              outV = inV(1)*w1-inV(2)*w2
              return
          elseif(outZ .ge. inZ(inK)) then
-             w1 = (outZ-inZ(inK-1))/(inZ(inK)-inZ(inK-1)) 
+             w1 = (outZ-inZ(inK-1))/(inZ(inK)-inZ(inK-1))
              w2 = (outZ-inZ(inK))  /(inZ(inK)-inZ(inK-1))
              outV = inV(inK)*w1 -inV(inK-1)* w2
              return
-         else  
+         else
             do k = 2, inK
              if((inZ(k) .ge. outZ).and.(inZ(k-1) .le. outZ) ) then
                 k1  = k-1
@@ -322,8 +322,8 @@ CONTAINS
                 w1 = (outZ-inZ(k1))/(inZ(k2)-inZ(k1))
                 w2 = (inZ(k2)-outZ)/(inZ(k2)-inZ(k1))
                 outV = inV(k2)*w1 + inV(k1)*w2
-                return 
-             end if 
+                return
+             end if
             end do
          endif
       end subroutine interpLayer
@@ -364,7 +364,7 @@ CONTAINS
        close(71)
 
 #else
-      open(13, form="formatted") 
+      open(13, form="formatted")
 !read OV_ROUGH first
           read(13,*) nn
           read(13,*)
@@ -407,7 +407,7 @@ CONTAINS
 
       end subroutine lsm_wrf_input
 
-      subroutine  checkSoil(did) 
+      subroutine  checkSoil(did)
           implicit none
           integer :: did
           where(rt_domain(did)%smc(:,:,1) <=0) RT_DOMAIN(did)%VEGTYP = 16

--- a/src/CPL/WRF_cpl/module_wrf_HYDRO_downscale.F
+++ b/src/CPL/WRF_cpl/module_wrf_HYDRO_downscale.F
@@ -3,20 +3,20 @@
 !  Abstract:
 !  History Log:
 !  <brief list of changes to this source file>
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_WRF_HYDRO
@@ -34,13 +34,13 @@ module module_WRF_HYDRO
     USE module_domain, ONLY : domain, domain_clock_get
 
     implicit none
-     
+
     !yw   added for check soil moisture and soiltype
     integer ::  checkSOIL_flag
 
 !
-! added to consider the adaptive time step from WRF model. 
-    real    :: dtrt0  
+! added to consider the adaptive time step from WRF model.
+    real    :: dtrt0
     integer ::  mm0, itime
 
 
@@ -48,7 +48,7 @@ module module_WRF_HYDRO
 
 CONTAINS
 
-!wrf_cpl_HYDRO_finescale will not call the off-line lsm 
+!wrf_cpl_HYDRO_finescale will not call the off-line lsm
     subroutine wrf_cpl_HYDRO_finescale(HYDRO_dt,grid,its,ite,jts,jte)
        use module_NoahMP_hrldas_driver, only: noah_timestep , land_driver_ini
        implicit none
@@ -64,7 +64,7 @@ CONTAINS
         integer ntime
 
         integer :: i,j
-        
+
 
 !output flux and state variable
 
@@ -79,10 +79,10 @@ CONTAINS
 
         ntime = 1
 
-    
+
             nlst(did)%dt = HYDRO_dt
 
-        itime = itime + 1 
+        itime = itime + 1
         if(.not. RT_DOMAIN(did)%initialized) then
            itime = 1
 
@@ -124,7 +124,7 @@ CONTAINS
                mm0 = mm
             endif
 
-            dtrt0 = nlst(did)%dtrt  
+            dtrt0 = nlst(did)%dtrt
         endif
 
             if((mm0*nlst(did)%dtrt) .ne. HYDRO_dt) then   ! WRF model time step changed.
@@ -138,7 +138,7 @@ CONTAINS
                endif
             endif
 
-#ifdef HYDRO_D 
+#ifdef HYDRO_D
         write(6,*) "mm, nlst(did)%dt = ",mm, nlst(did)%dt
 #endif
 
@@ -158,7 +158,7 @@ subroutine wrf2l_finemesh(,its,ite,jts,jte, T_PHY0,U_PHY0,V_PHY0,p_hyd_w0,RAINBL
           emiss0, albedo0   )
        use module_NoahMP_hrldas_driver, only: P8W, T_PHY, U_PHY, V_PHY, QV_CURR, RAINBL_tmp, LAI, VEGFRA, finemesh,finemesh_factor, &
               emiss,albedo
-       
+
        implicit none
        real, domain(:,:),INTENT(IN) :: T_PHY0,U_PHY0,V_PHY0,p_hyd_w0,RAINBL0,QV_CURR0,LAI0,VEGFRA0, &
              emiss0, albedo0, TSK0,HFX0, QFX0,LH0,GRDFLX0,SMSTAV0,SMSTOT0,SFCRUNOFF0, UDRUNOFF0, SNOWC0, SMOIS0, SH2O0, &
@@ -247,10 +247,10 @@ subroutine wrf2finegrid(wrfGrid,fineGrid,ix,jx,AGGFACTRT)
    real, dimension(:,:), intent(out)::fineGrid
    integer:: i,j,ii,jj,ix,jx, AGGFACTRT
    do j = 1, jx
-      do i = 1, ix 
+      do i = 1, ix
               do ii       =AGGFACTRT-1,0,-1
               do jj       =AGGFACTRT-1,0,-1
-                  IXXRT=I*AGGFACTRT-ii       
+                  IXXRT=I*AGGFACTRT-ii
                   JYYRT=J*AGGFACTRT-jj
                   fineGrid(ixxrt,jyyrt) = wrfGrid(i,j)
               enddo
@@ -265,11 +265,11 @@ subroutine finegrid2wrf(fineGrid,wrfGrid,ix,jx,AGGFACTRT)
    real, dimension(:,:), intent(in)::fineGrid
    integer:: i,j,ii,jj,ix,jx, AGGFACTRT
    do j = 1, jx
-      do i = 1, ix 
+      do i = 1, ix
               wrfGrid(k,j) = 0.0
               do ii       =AGGFACTRT-1,0,-1
               do jj       =AGGFACTRT-1,0,-1
-                  IXXRT=I*AGGFACTRT-ii       
+                  IXXRT=I*AGGFACTRT-ii
                   JYYRT=J*AGGFACTRT-jj
                   wrfGrid(i,j) = wrfGrid(i,j) + fineGrid(ixxrt,jyyrt)
               enddo
@@ -286,7 +286,7 @@ end subroutine finegrid2wrf
       subroutine wrf2lsm (z1,v1,kk1,z,vout,ix,jx,kk,vegtyp)
 !  input: z1,v1,kk1,z,ix,jx,kk
 !  output: vout
-!  interpolate based on soil layer: z1 and z 
+!  interpolate based on soil layer: z1 and z
 !  z :  soil layer of output variable.
 !  z1: array of soil layers of input variable.
          implicit none
@@ -294,7 +294,7 @@ end subroutine finegrid2wrf
          integer:: kk1, ix,jx,kk, vegtyp(ix,jx)
          real :: z1(kk1), z(kk), v1(ix,kk1,jx),vout(ix,jx,kk)
 
-       
+
          do j = 1, jx
             do i = 1, ix
                 do k = 1, kk
@@ -308,7 +308,7 @@ end subroutine finegrid2wrf
       subroutine lsm2wrf (z1,v1,kk1,z,vout,ix,jx,kk,vegtyp)
 !  input: z1,v1,kk1,z,ix,jx,kk
 !  output: vout
-!  interpolate based on soil layer: z1 and z 
+!  interpolate based on soil layer: z1 and z
 !  z :  soil layer of output variable.
 !  z1: array of soil layers of input variable.
          implicit none
@@ -316,7 +316,7 @@ end subroutine finegrid2wrf
          integer:: kk1, ix,jx,kk, vegtyp(ix,jx)
          real :: z1(kk1), z(kk), v1(ix,jx,kk1),vout(ix,kk,jx)
 
-       
+
          do j = 1, jx
             do i = 1, ix
                  do k = 1, kk
@@ -339,11 +339,11 @@ end subroutine finegrid2wrf
              outV = inV(1)*w1-inV(2)*w2
              return
          elseif(outZ .ge. inZ(inK)) then
-             w1 = (outZ-inZ(inK-1))/(inZ(inK)-inZ(inK-1)) 
+             w1 = (outZ-inZ(inK-1))/(inZ(inK)-inZ(inK-1))
              w2 = (outZ-inZ(inK))  /(inZ(inK)-inZ(inK-1))
              outV = inV(inK)*w1 -inV(inK-1)* w2
              return
-         else  
+         else
             do k = 2, inK
              if((inZ(k) .ge. outZ).and.(inZ(k-1) .le. outZ) ) then
                 k1  = k-1
@@ -351,8 +351,8 @@ end subroutine finegrid2wrf
                 w1 = (outZ-inZ(k1))/(inZ(k2)-inZ(k1))
                 w2 = (inZ(k2)-outZ)/(inZ(k2)-inZ(k1))
                 outV = inV(k2)*w1 + inV(k1)*w2
-                return 
-             end if 
+                return
+             end if
             end do
          endif
       end subroutine interpLayer

--- a/src/CPL/WRF_cpl/wrf_drv_HYDRO.F
+++ b/src/CPL/WRF_cpl/wrf_drv_HYDRO.F
@@ -3,27 +3,27 @@
 !  Abstract:
 !  History Log:
 !  <brief list of changes to this source file>
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !2345678
 !ywGW       subroutine wrf_drv_HYDRO(HYDRO_dt,grid, config_flags, its,ite,jts,jte)
        subroutine wrf_drv_HYDRO(HYDRO_dt,grid, its,ite,jts,jte)
           use module_wrf_HYDRO, only: wrf_cpl_HYDRO
-          USE module_domain, ONLY : domain 
+          USE module_domain, ONLY : domain
           USE module_configure, ONLY : grid_config_rec_type
        implicit none
           integer:: its,ite,jts,jte
@@ -36,7 +36,7 @@
           if(grid%num_nests .lt. 1) then
 
 !ywGW             call wrf_cpl_HYDRO(HYDRO_dt, grid, config_flags, its,ite,jts,jte)  
-             call wrf_cpl_HYDRO(HYDRO_dt, grid, its,ite,jts,jte)  
+             call wrf_cpl_HYDRO(HYDRO_dt, grid, its,ite,jts,jte)
 
           endif
        end subroutine wrf_drv_HYDRO
@@ -50,8 +50,7 @@
           TYPE ( domain ), INTENT(INOUT) :: grid
 
           if(grid%num_nests .lt. 1) then
-!            call wrf_cpl_HYDRO_ini(grid,its,ite,jts,jte)  
+!            call wrf_cpl_HYDRO_ini(grid,its,ite,jts,jte)
           endif
 
        end subroutine wrf_drv_HYDRO_ini
-

--- a/src/HYDRO_drv/module_HYDRO_drv.F
+++ b/src/HYDRO_drv/module_HYDRO_drv.F
@@ -977,7 +977,7 @@ else
        RT_DOMAIN(did)%HLINK, RT_DOMAIN(did)%ELRT,RT_DOMAIN(did)%CHANLEN,&
        RT_DOMAIN(did)%MannN,RT_DOMAIN(did)%So, RT_DOMAIN(did)%ChSSlp, &
        RT_DOMAIN(did)%Bw,RT_DOMAIN(did)%Tw,RT_DOMAIN(did)%Tw_CC, RT_DOMAIN(did)%n_CC, &
-       RT_DOMAIN(did)%ChannK,& 
+       RT_DOMAIN(did)%ChannK,&
        RT_DOMAIN(did)%RESHT, &
        RT_DOMAIN(did)%ZELEV, RT_DOMAIN(did)%CVOL, &
        RT_DOMAIN(did)%NLAKES, RT_DOMAIN(did)%QLAKEI, RT_DOMAIN(did)%QLAKEO,&

--- a/src/Land_models/Noah/GRAPHICS/HORIZ/kwm_date_utilities.F
+++ b/src/Land_models/Noah/GRAPHICS/HORIZ/kwm_date_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_date_utilities
@@ -23,7 +23,7 @@ contains
   subroutine geth_newdate (ndate, odate, idt)
     implicit none
 
-!  From old date ('YYYY-MM-DD HH:MM:SS.ffff') and 
+!  From old date ('YYYY-MM-DD HH:MM:SS.ffff') and
 !  delta-time, compute the new date.
 
 !  on entry     -  odate  -  the old hdate.
@@ -379,7 +379,7 @@ contains
        else if (nlen.eq.13) then
           write(ndate,13) yrnew, monew, dynew, hrnew
 13        format(i4,'-',i2.2,'-',i2.2,'_',i2.2)
-          
+
        else if (nlen.eq.10) then
           write(ndate,10) yrnew, monew, dynew
 10        format(i4,'-',i2.2,'-',i2.2)
@@ -387,7 +387,7 @@ contains
        end if
 
        if (olen.ge.11) ndate(11:11) = sp
-       
+
     else
 
        if (nlen.gt.20) then
@@ -406,7 +406,7 @@ contains
        else if (nlen.eq.10) then
           write(ndate,210) yrnew, monew, dynew, hrnew
 210       format(i4,i2.2,i2.2,i2.2)
-          
+
        else if (nlen.eq.8) then
           write(ndate,8) yrnew, monew, dynew
 8         format(i4,i2.2,i2.2)
@@ -421,7 +421,7 @@ contains
   subroutine geth_idts (newdate, olddate, idt)
     implicit none
 
-!  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'), 
+!  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'),
 !  compute the time difference.
 
 !  on entry     -  newdate  -  the new hdate.
@@ -551,7 +551,7 @@ contains
              end if
           end if
        end if
-       
+
 !  Break down new hdate into parts
 
        read(ndate(6:7),  '(i2)') monew
@@ -586,7 +586,7 @@ contains
              end if
           end if
        end if
-       
+
 !  Break down new hdate into parts
 
        read(ndate(5:6),  '(i2)') monew
@@ -794,7 +794,7 @@ contains
     integer, intent(in) :: year ! Four-digit year
 
     nfeb = 28 ! By default, February has 28 days ...
-    if (mod(year,4).eq.0) then  
+    if (mod(year,4).eq.0) then
        nfeb = 29  ! But every four years, it has 29 days ...
        if (mod(year,100).eq.0) then
           nfeb = 28  ! Except every 100 years, when it has 28 days ...

--- a/src/Land_models/Noah/GRAPHICS/HORIZ/kwm_string_utilities.F
+++ b/src/Land_models/Noah/GRAPHICS/HORIZ/kwm_string_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_string_utilities
@@ -68,7 +68,7 @@ contains
           return_string(j:j) = string(i:i)
        endif
     enddo
-    
+
   end function unblank
 
 !KWM  character function upcase(h)
@@ -87,7 +87,7 @@ contains
     implicit none
     character(len=*), intent(in) :: h
     integer :: i
-    
+
     return_string = ""
 
     do i = 1, len_trim(h)

--- a/src/Land_models/Noah/GRAPHICS/HORIZ/lccone.F
+++ b/src/Land_models/Noah/GRAPHICS/HORIZ/lccone.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 subroutine lccone (fsplat,ssplat,sign,confac)

--- a/src/Land_models/Noah/GRAPHICS/HORIZ/llxy_generic.F
+++ b/src/Land_models/Noah/GRAPHICS/HORIZ/llxy_generic.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 subroutine lltoxy_generic (xlat,xlon,x,y,&
@@ -88,7 +88,7 @@ subroutine lltoxy_generic (xlat,xlon,x,y,&
   else
      londiff = (xlon-cenlon)*degrad
   endif
-     
+
 
   if (project(1:2) .eq. 'ME') then
 
@@ -104,8 +104,8 @@ subroutine lltoxy_generic (xlat,xlon,x,y,&
 !KWM     di = re*(rlon-rfln)
 !KWM     y = refy + dj/dskm
 !KWM     x = refx + di/dskm
-     
-     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms 
+
+     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms
      ! of thousandths of degrees!
      !  Calculate the distance from the horizontal axis to (J,I)
      dj = xlat-reflat
@@ -259,7 +259,7 @@ subroutine xytoll_generic (x,y,xlat,xlon,&
 
 ! If the projection is cylindrical equidistant ('CE') then ...
   else if (project(1:2) .eq. 'CE') then
-     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms 
+     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms
      ! of thousandths of degrees!
      di = (x-refx) * dskm
      !  Calculate the distance from the horizontal axis to (J,I)
@@ -281,7 +281,7 @@ subroutine xytoll_generic (x,y,xlat,xlon,&
      tt2 = tan((pi2 - rflt  )*0.5)    ! Tangent Term 2.
      ct1 = -cos(flat1) * re/confac   ! cosine Term 1.
 
-     ! Calculate the (projected) distance from the pole to 
+     ! Calculate the (projected) distance from the pole to
      ! the reference lat/lon.
      drp = ct1 * (tt2/tt1)**confac
      ! Now from the pole to the reference y along the center lon.
@@ -320,7 +320,7 @@ subroutine xytoll_generic (x,y,xlat,xlon,&
      dii = drp * sin(rcln-rfln)
      di = dii + ((x-refx)*dskm)
      ! Calculate the Big Messy quantity as would be done for LC
-     ! projections.  This quantity is different in value, same 
+     ! projections.  This quantity is different in value, same
      ! in purpose of BM above
      bm = (1.0/re) * sqrt(di*di + dj*dj) / (1.0 + cos(pi2-flat1))
      !  Calculate the desired latitude in radians

--- a/src/Land_models/Noah/GRAPHICS/HORIZ/module_2ddata.F
+++ b/src/Land_models/Noah/GRAPHICS/HORIZ/module_2ddata.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_2ddata
@@ -235,4 +235,3 @@ contains
 !
 
 end module module_2ddata
-

--- a/src/Land_models/Noah/GRAPHICS/HORIZ/module_plot2d_graphics.F
+++ b/src/Land_models/Noah/GRAPHICS/HORIZ/module_plot2d_graphics.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_plot2d_graphics
@@ -76,7 +76,7 @@ contains
     call set(0., 1., 0., 1., 0., 1., 0., 1., 1)
     ! call gscr(1, 1, 0., 0., 0.)
     call pcseti("CC", 1)
-   
+
     if ( (fieldinfo%name == "SOIL_M") .or. (fieldinfo%name == "SOIL_T") .or. &
          (fieldinfo%name == "SOIL_W")) then
        write(txt, '(A, " -- Level ", I2)') trim(fieldinfo%name), fieldinfo%level
@@ -275,7 +275,7 @@ contains
     ! maxf = maxval(fld, mask=(fld/=-1.E33))
     ! minf = minval(fld, mask=(fld/=-1.E33))
 
-    ! Find contour minimum, contour maximum as an integer number of 
+    ! Find contour minimum, contour maximum as an integer number of
     ! contour_intervals from zero
 
     ncon = (cmax-cmin)/cint
@@ -343,7 +343,7 @@ contains
        !      polygon should remain transparent (i.e. not filled).
        !
        if (ifll.ge.1) then
-#ifdef dead          
+#ifdef dead
           if (ifll.le.nconarea.and.icoindcp(ifll).ge.0) then
              call gsfaci(icoindcp(ifll))
 #else
@@ -430,7 +430,7 @@ contains
              exit
           endif
        enddo
-       
+
        !call gscr(1, i+2, float(i)/float(n-1), float(i)/float(n-1), float(i)/float(n-1))
        !call gscr(1, i+2, float(i)/float(n-1), float(i)/float(n-1), float(i)/float(n-1))
     enddo
@@ -489,7 +489,7 @@ contains
           stringname = trim(string(idx:))
           stringname = downcase(trim(stringname))
           stringname = unblank(trim(stringname))
-          
+
           readlist_count = readlist_count + 1
           readlist_r(readlist_count) = float(r)/255.
           readlist_g(readlist_count) = float(g)/255.
@@ -521,7 +521,7 @@ contains
 ! Opens workstation 1 as a CGM workstation.
 ! Opens workstation 2 as a WISS.
 ! Defines a couple of colors, and sets a couple of NCAR Graphics parameters
-! 
+!
 ! If you want the gmeta file to be called something other than "gmeta",
 ! give this subroutine the optional argument.
     implicit none
@@ -540,7 +540,7 @@ contains
     call gopwk(2,120,3)
     call gacwk(1)
     call gacwk(2)
-    
+
     ! call define_color("white")
     ! call define_color("black")
     call gscr(1, 0, 1., 1., 1.) ! White
@@ -673,4 +673,3 @@ contains
 
 
 end module module_plot2d_graphics
-

--- a/src/Land_models/Noah/GRAPHICS/HORIZ/plt2d.F
+++ b/src/Land_models/Noah/GRAPHICS/HORIZ/plt2d.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !
@@ -61,7 +61,7 @@ program plt2d
   do while (nowdate <= plot_enddate)
      print*, 'Date = ', nowdate
 
-     do 
+     do
         call read_plotinfo_namelist(namelist_filename, namelist_fortran_unit, ierr, fldname, soil_level)
         if (ierr /= 0) exit
 
@@ -74,7 +74,7 @@ program plt2d
            fldptr = fldptr - fldptr2
            nullify(fldptr2)
         endif
-     
+
         call draw_field(fldptr, gridinfo%idim, gridinfo%jdim, gridinfo)
         nullify(fldptr)
 
@@ -84,7 +84,7 @@ program plt2d
   enddo
 
   call close_ncargks()
-  
+
 end program plt2d
 
 !
@@ -110,7 +110,7 @@ subroutine read_fileinfo_namelist(namelist_filename, namelist_fortran_unit, &
 
   open(namelist_fortran_unit, file=namelist_filename, status='old', form='formatted', action='read')
 
-  read(namelist_fortran_unit, file_info) 
+  read(namelist_fortran_unit, file_info)
 
 end subroutine read_fileinfo_namelist
 
@@ -147,7 +147,7 @@ subroutine read_plotinfo_namelist(namelist_filename, namelist_fortran_unit, ierr
      open(namelist_fortran_unit, file=namelist_filename, status='old', form='formatted', action='read')
   endif
 
-  read(namelist_fortran_unit, plot_info, iostat=ierr) 
+  read(namelist_fortran_unit, plot_info, iostat=ierr)
   if (ierr/=0) then
      close(namelist_fortran_unit)
      return
@@ -197,11 +197,10 @@ end subroutine read_plotinfo_namelist
 !KWM
 !KWM  call getset(xl, xr, xb, xt, wl, wr, wb, wt, ml)
 !KWM  call set(xl, xr, xb, xt, 1.0, float(gridinfo%idim), 1.0, float(gridinfo%jdim), ml)
-!KWM  
+!KWM
 !KWM
 !KWMend subroutine plotmap
 !KWM
 !
 ! ############################################################################################################
 !
-

--- a/src/Land_models/Noah/GRAPHICS/TIME_SERIES/kwm_date_utilities.F
+++ b/src/Land_models/Noah/GRAPHICS/TIME_SERIES/kwm_date_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_date_utilities
@@ -23,7 +23,7 @@ contains
   subroutine geth_newdate (ndate, odate, idt)
     implicit none
 
-!  From old date ('YYYY-MM-DD HH:MM:SS.ffff') and 
+!  From old date ('YYYY-MM-DD HH:MM:SS.ffff') and
 !  delta-time, compute the new date.
 
 !  on entry     -  odate  -  the old hdate.
@@ -379,7 +379,7 @@ contains
        else if (nlen.eq.13) then
           write(ndate,13) yrnew, monew, dynew, hrnew
 13        format(i4,'-',i2.2,'-',i2.2,'_',i2.2)
-          
+
        else if (nlen.eq.10) then
           write(ndate,10) yrnew, monew, dynew
 10        format(i4,'-',i2.2,'-',i2.2)
@@ -387,7 +387,7 @@ contains
        end if
 
        if (olen.ge.11) ndate(11:11) = sp
-       
+
     else
 
        if (nlen.gt.20) then
@@ -406,7 +406,7 @@ contains
        else if (nlen.eq.10) then
           write(ndate,210) yrnew, monew, dynew, hrnew
 210       format(i4,i2.2,i2.2,i2.2)
-          
+
        else if (nlen.eq.8) then
           write(ndate,8) yrnew, monew, dynew
 8         format(i4,i2.2,i2.2)
@@ -421,7 +421,7 @@ contains
   subroutine geth_idts (newdate, olddate, idt)
     implicit none
 
-!  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'), 
+!  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'),
 !  compute the time difference.
 
 !  on entry     -  newdate  -  the new hdate.
@@ -550,7 +550,7 @@ contains
              end if
           end if
        end if
-       
+
 !  Break down new hdate into parts
 
        read(ndate(6:7),  '(i2)') monew
@@ -585,7 +585,7 @@ contains
              end if
           end if
        end if
-       
+
 !  Break down new hdate into parts
 
        read(ndate(5:6),  '(i2)') monew
@@ -793,7 +793,7 @@ contains
     integer, intent(in) :: year ! Four-digit year
 
     nfeb = 28 ! By default, February has 28 days ...
-    if (mod(year,4).eq.0) then  
+    if (mod(year,4).eq.0) then
        nfeb = 29  ! But every four years, it has 29 days ...
        if (mod(year,100).eq.0) then
           nfeb = 28  ! Except every 100 years, when it has 28 days ...

--- a/src/Land_models/Noah/GRAPHICS/TIME_SERIES/kwm_string_utilities.F
+++ b/src/Land_models/Noah/GRAPHICS/TIME_SERIES/kwm_string_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_string_utilities
@@ -68,7 +68,7 @@ contains
           return_string(j:j) = string(i:i)
        endif
     enddo
-    
+
   end function unblank
 
 !KWM  character function upcase(h)
@@ -87,7 +87,7 @@ contains
     implicit none
     character(len=*), intent(in) :: h
     integer :: i
-    
+
     return_string = ""
 
     do i = 1, len_trim(h)

--- a/src/Land_models/Noah/GRAPHICS/TIME_SERIES/lccone.F
+++ b/src/Land_models/Noah/GRAPHICS/TIME_SERIES/lccone.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 subroutine lccone (fsplat,ssplat,sign,confac)

--- a/src/Land_models/Noah/GRAPHICS/TIME_SERIES/ldasout_timeseries.F
+++ b/src/Land_models/Noah/GRAPHICS/TIME_SERIES/ldasout_timeseries.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 program ldasout_timeseries
@@ -43,7 +43,7 @@ program ldasout_timeseries
   call init_ncargks("test.cgm")
 
   loopcount = 0
-  do 
+  do
      call read_plotinfo_namelist(namelist_fortran_unit, ierr)
      if (ierr /= 0) exit
      loopcount = loopcount + 1
@@ -214,7 +214,7 @@ subroutine read_fileinfo_namelist(namelist_fortran_unit, ldasout_flnm_template, 
 
   open(namelist_fortran_unit, file="namelist.pltts", status='old', form='formatted', action='read')
 
-  read(namelist_fortran_unit, file_info) 
+  read(namelist_fortran_unit, file_info)
 
   pltts_parameter%startdate = plot_startdate
   pltts_parameter%enddate = plot_enddate
@@ -258,13 +258,13 @@ subroutine read_plotinfo_namelist(namelist_fortran_unit, ierr)
      open(namelist_fortran_unit, file="namelist.pltts", status='old', form='formatted', action='read')
   endif
 
-  read(namelist_fortran_unit, plot_info, iostat=ierr) 
+  read(namelist_fortran_unit, plot_info, iostat=ierr)
   if (ierr/=0) then
      print*, 'Read ierr = ', ierr
      close(namelist_fortran_unit)
      return
   endif
-  
+
   if (ts_lat > -1.E25) then
      pltts_parameter%latitude = ts_lat
   endif

--- a/src/Land_models/Noah/GRAPHICS/TIME_SERIES/llxy_generic.F
+++ b/src/Land_models/Noah/GRAPHICS/TIME_SERIES/llxy_generic.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 subroutine lltoxy_generic (xlat,xlon,x,y,&
@@ -88,7 +88,7 @@ subroutine lltoxy_generic (xlat,xlon,x,y,&
   else
      londiff = (xlon-cenlon)*degrad
   endif
-     
+
 
   if (project(1:2) .eq. 'ME') then
 
@@ -104,8 +104,8 @@ subroutine lltoxy_generic (xlat,xlon,x,y,&
 !KWM     di = re*(rlon-rfln)
 !KWM     y = refy + dj/dskm
 !KWM     x = refx + di/dskm
-     
-     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms 
+
+     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms
      ! of thousandths of degrees!
      !  Calculate the distance from the horizontal axis to (J,I)
      dj = xlat-reflat
@@ -259,7 +259,7 @@ subroutine xytoll_generic (x,y,xlat,xlon,&
 
 ! If the projection is cylindrical equidistant ('CE') then ...
   else if (project(1:2) .eq. 'CE') then
-     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms 
+     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms
      ! of thousandths of degrees!
      di = (x-refx) * dskm
      !  Calculate the distance from the horizontal axis to (J,I)
@@ -281,7 +281,7 @@ subroutine xytoll_generic (x,y,xlat,xlon,&
      tt2 = tan((pi2 - rflt  )*0.5)    ! Tangent Term 2.
      ct1 = -cos(flat1) * re/confac   ! cosine Term 1.
 
-     ! Calculate the (projected) distance from the pole to 
+     ! Calculate the (projected) distance from the pole to
      ! the reference lat/lon.
      drp = ct1 * (tt2/tt1)**confac
      ! Now from the pole to the reference y along the center lon.
@@ -320,7 +320,7 @@ subroutine xytoll_generic (x,y,xlat,xlon,&
      dii = drp * sin(rcln-rfln)
      di = dii + ((x-refx)*dskm)
      ! Calculate the Big Messy quantity as would be done for LC
-     ! projections.  This quantity is different in value, same 
+     ! projections.  This quantity is different in value, same
      ! in purpose of BM above
      bm = (1.0/re) * sqrt(di*di + dj*dj) / (1.0 + cos(pi2-flat1))
      !  Calculate the desired latitude in radians

--- a/src/Land_models/Noah/GRAPHICS/TIME_SERIES/module_plotts_graphics.F
+++ b/src/Land_models/Noah/GRAPHICS/TIME_SERIES/module_plotts_graphics.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_plotts_graphics
@@ -91,7 +91,7 @@ contains
     else
        stop "Too many colors."
     endif
-    
+
   end function color_index
 
   type(named_color) function get_x11_color(name) result (c)
@@ -142,7 +142,7 @@ contains
           stringname = trim(string(idx:))
           stringname = downcase(trim(stringname))
           stringname = unblank(trim(stringname))
-          
+
           readlist_count = readlist_count + 1
           readlist_r(readlist_count) = float(r)/255.
           readlist_g(readlist_count) = float(g)/255.
@@ -174,7 +174,7 @@ contains
 ! Opens workstation 1 as a CGM workstation.
 ! Opens workstation 2 as a WISS.
 ! Defines a couple of colors, and sets a couple of NCAR Graphics parameters
-! 
+!
 ! If you want the gmeta file to be called something other than "gmeta",
 ! give this subroutine the optional argument.
     implicit none
@@ -195,8 +195,8 @@ contains
     call gacwk(1)
     call gacwk(2)
     global_ncols = 0
-    
-    
+
+
     ! call define_color("white")
     ! call define_color("black")
     ! call gscr(1, 0, 1., 1., 1.) ! White

--- a/src/Land_models/Noah/GRAPHICS/TIME_SERIES/module_ptdata.F
+++ b/src/Land_models/Noah/GRAPHICS/TIME_SERIES/module_ptdata.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module pt_data
@@ -247,4 +247,3 @@ contains
   end subroutine errhandler
 
 end module pt_data
-

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/consolidate_grib.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/consolidate_grib.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 program consolidate
@@ -36,7 +36,7 @@ program consolidate
   type (geo_em_type) :: geo_em
 
 
-  integer, parameter :: MAXTEMPLATE = 10      
+  integer, parameter :: MAXTEMPLATE = 10
 
   type DataBuffer
      character(len=256)                         :: label
@@ -135,7 +135,7 @@ program consolidate
   character(len=256), dimension(MAXTEMPLATE) :: PCPfile_primary
 
 
-  namelist /files/ startdate, enddate, & 
+  namelist /files/ startdate, enddate, &
        DataDir, full_ic_frq, rainfall_interp, rescale_shortwave, wrfinput_flnm, &
        geo_em_flnm, Tfile_template, Ufile_template, Vfile_template,             &
        Pfile_template, Qfile_template, LWfile_template, SWfile_secondary,       &
@@ -191,7 +191,7 @@ program consolidate
      write(*,*)
      stop
   endif
-  read(12,files) 
+  read(12,files)
   close(12)
 
 !--------------------------------------------------------------------------
@@ -505,7 +505,7 @@ program consolidate
   deallocate(wrfinput%use, stat=ierr)
   deallocate(wrfinput%veg, stat=ierr)
   deallocate(geo_em%veg, stat=ierr)
-  
+
   call grib2_clear_parameter_table
 
 
@@ -523,7 +523,7 @@ contains
     character(len=64) :: val
     integer :: vcount
 
-    ! 
+    !
     ! Open the file
     !
     open(12, file=filename, status='old', form='formatted', iostat=ierr)
@@ -670,8 +670,8 @@ contains
     !
     ! Copy the databuffer type from <in> to <out>
     !
-    ! We do this to be explicit in allocating new memory for 
-    ! pointer array <out%field>, and copying the data from 
+    ! We do this to be explicit in allocating new memory for
+    ! pointer array <out%field>, and copying the data from
     ! <in%field> to <out%field> (instead of merely pointing
     ! <out%field> => <in%field>
     implicit none
@@ -695,7 +695,7 @@ contains
        nullify(out%field)
     endif
 
-    
+
   end subroutine copy_data_buffer
 
 !==============================================================================
@@ -720,9 +720,9 @@ contains
     integer :: jdim
 
     ! The fatality level in the DataBuffer structure indicates what sort
-    ! of errors are fatal and what sort of errors we want to try to 
+    ! of errors are fatal and what sort of errors we want to try to
     ! recover from.
-    ! 
+    !
     ! fatality==0 means that any problem is a fatal error, and we stop.
     !
     ! fatality==2 means that if we cannot find a matching file, and we
@@ -831,7 +831,7 @@ contains
        return
 
     endif
-    
+
     ! We did not find data.  Let's try to temporally interpolate.
 
     ! A "prev" buffer must exist for us.  Check that.
@@ -847,7 +847,7 @@ contains
        endif
 
        write(*,'("Field label= ",A)') trim(current%label)
-       write(*,'("No previous data.")') 
+       write(*,'("No previous data.")')
        stop
     endif
 
@@ -895,7 +895,7 @@ contains
        endif
 
        if (current%label == "RAINRATE") then
-          ! Don't temporally interpolate the rain rate.  
+          ! Don't temporally interpolate the rain rate.
           allocate(current%field(size(prev%field,1), size(prev%field,2)))
           ! Take the "post" field, because that field should be the accumulation
           ! between "prev" and "post"
@@ -955,7 +955,7 @@ contains
     nullify(datastruct%data)
 
     if (current%label == "RAINRATE") then
-       ! Don't temporally interpolate the rain rate.  
+       ! Don't temporally interpolate the rain rate.
        ! Simply carry the previous value forward.
        allocate(current%field(size(prev%field,1), size(prev%field,2)))
        current%field = post%field
@@ -963,7 +963,7 @@ contains
        call temporal_interpolation(prev, post, current)
     endif
 
-    ! We have the data we want, and prev and post are both up-to-date, 
+    ! We have the data we want, and prev and post are both up-to-date,
     ! so we can exit.
 
   end subroutine process
@@ -1368,7 +1368,7 @@ contains
 
     datastruct%nx = grib%mapinfo%nx
     datastruct%ny = grib%mapinfo%ny
-    
+
     call map_init(datastruct%proj)
 !KWM    datastruct%proj%lat1 = grib%mapinfo%lat1
 !KWM    if (grib%mapinfo%lon1 > 180) then
@@ -1421,7 +1421,7 @@ contains
        endif
        datastruct%hdate(15:16) = "00"
        ! TEST:  Set zero data values to missing data for GCIP SW fields
-       ! where (datastruct%data <= 0) datastruct%data = -1.E36 
+       ! where (datastruct%data <= 0) datastruct%data = -1.E36
     endif
 
 !KWM    if (description == "Plant Canopy Surface Water") then
@@ -1447,14 +1447,14 @@ contains
           if (processing(1:12) == "Accumulation") then
              oldmax = maxval(datastruct%data, mask=(datastruct%data > -1.E25))
              write(*,'(13x, "Maxval adjusted from ", F12.6)', advance="no") oldmax
-             where (datastruct%data > -1.E25) 
+             where (datastruct%data > -1.E25)
                 datastruct%data = datastruct%data * (1.0 / float(p2_seconds - p1_seconds))
              endwhere
              newmax = maxval(datastruct%data, mask=(datastruct%data > -1.E25))
              write(*,'(" to ", F12.6, ":    factor of ", I8)') newmax, NINT(oldmax/newmax)
              ! Change the units to mm/s, reflecting the rescaling we just did.
              datastruct%units = "mm s{-1}"
-          else 
+          else
              stop "Precip Problem A?"
           endif
        else
@@ -1734,7 +1734,7 @@ subroutine output_timestring_to_netcdf(ncid, hdate)
   implicit none
   integer,                     intent(in) :: ncid
   character(len=*),            intent(in) :: hdate
-  
+
   integer,          parameter                :: DateStrLen = 19
   character(len=1), dimension(DateStrLen, 1) :: output_hdate
   integer                                    :: dimid_datestrlen
@@ -1747,7 +1747,7 @@ subroutine output_timestring_to_netcdf(ncid, hdate)
   do i = 1, len(hdate)
      output_hdate(i,1) = hdate(i:i)
   enddo
-  
+
   ierr = nf90_inq_dimid(ncid, "Time", dimid_time)
   call error_handler(ierr, "OUTPUT_TIMESTRING_TO_NETCDF: Problem finding dimension 'Time'")
 
@@ -1853,7 +1853,7 @@ end subroutine fillsm
 !==============================================================================
 
 subroutine interp_rainfall_nearest_neighbor(datastruct, newarr, mix, mjx, wrfinput)
-  ! 
+  !
   ! Fill array <newarr> with rainfall data from <datastruct>
   !
   use module_input_data_structure
@@ -1938,14 +1938,14 @@ subroutine interp_rainfall(datastruct, newarr, mix, mjx, wrfinput)
   ! field's grid cells to various WRF grid cells as necessary.
 
   ! We recompute the mapping information every time, in case our source grid has changed.
-     
+
   ILOOP : do i = 1, datastruct%nx
      JLOOP : do j = 1, datastruct%ny
         ! Compute (x,y) in WRF grid of point (gx,gy) in precip grid.
 !KWM        call datastruct_xytoll(float(i), float(j), xlat, xlon, datastruct)
         call ij_to_latlon(datastruct%proj, float(i), float(j), xlat, xlon)
         call latlon_to_ij(wrfinput%proj, xlat, xlon, x, y)
-        ! Now X and Y are the x and y coordinates in the WRF 
+        ! Now X and Y are the x and y coordinates in the WRF
         ! grid of the RAINFALL point i, j.
 
         if ((x > -2) .and. (y > -2) .and. (x < mix+2) .and. (y < mjx+2)) then
@@ -2094,7 +2094,7 @@ subroutine another_interp_rainfall(datastruct, newarr, mix, mjx, wrfinput)
            call ij_to_latlon(datastruct%proj, float(i), float(j), xlat, xlon)
            call latlon_to_ij(wrfinput%proj, xlat, xlon, mxa(i,j), mya(i,j))
 
-           ! Now MX and MY are the x and y coordinates in the WRF 
+           ! Now MX and MY are the x and y coordinates in the WRF
            ! grid of the RAINFALL point i, j.
 
         if ((mxa(i,j) > -2) .and. (mya(i,j) > -2) .and. (mxa(i,j) < mix+2) .and. (mya(i,j) < mjx+2)) then
@@ -2343,4 +2343,3 @@ end subroutine close_flnm
 
 !==============================================================================
 !==============================================================================
-

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/arguments_module.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/arguments_module.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module arguments_module
@@ -278,7 +278,7 @@ contains
     else
 ! STRING is a default string value.
 ! Handle the case of optional unflagged string arguments.
-    
+
        if (numarg > 0) then
           if (harg(1)(1:1) == "-") then
              call print_help
@@ -326,7 +326,7 @@ contains
     integer :: nval, i, ierr
 
     call initialize
-    
+
     if (numarg /= 1) then
        write(*,'(/,"A final command-line argument MUST be present.")')
        call print_help
@@ -359,7 +359,7 @@ contains
     enddo
 
   end subroutine argsub
-    
+
 !==============================================================================
 
   subroutine print_help
@@ -417,4 +417,3 @@ end module arguments_module
 !KWM  print*, 'flnm = ', trim(flnm)
 !KWM
 !KWMend program test1
-

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/gbytesys.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/gbytesys.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !-----------------------------------------------------------------------

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/get_unused_unit.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/get_unused_unit.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 integer function get_unused_unit() result(iunit)

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/kwm_date_utilities.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/kwm_date_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_date_utilities
@@ -23,7 +23,7 @@ contains
   subroutine geth_newdate (ndate, odate, idt)
     implicit none
 
-!  From old date ('YYYY-MM-DD HH:MM:SS.ffff') and 
+!  From old date ('YYYY-MM-DD HH:MM:SS.ffff') and
 !  delta-time, compute the new date.
 
 !  on entry     -  odate  -  the old hdate.
@@ -379,7 +379,7 @@ contains
        else if (nlen.eq.13) then
           write(ndate,13) yrnew, monew, dynew, hrnew
 13        format(i4,'-',i2.2,'-',i2.2,'_',i2.2)
-          
+
        else if (nlen.eq.10) then
           write(ndate,10) yrnew, monew, dynew
 10        format(i4,'-',i2.2,'-',i2.2)
@@ -387,7 +387,7 @@ contains
        end if
 
        if (olen.ge.11) ndate(11:11) = sp
-       
+
     else
 
        if (nlen.gt.20) then
@@ -406,7 +406,7 @@ contains
        else if (nlen.eq.10) then
           write(ndate,210) yrnew, monew, dynew, hrnew
 210       format(i4,i2.2,i2.2,i2.2)
-          
+
        else if (nlen.eq.8) then
           write(ndate,8) yrnew, monew, dynew
 8         format(i4,i2.2,i2.2)
@@ -421,7 +421,7 @@ contains
   subroutine geth_idts (newdate, olddate, idt)
     implicit none
 
-!  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'), 
+!  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'),
 !  compute the time difference.
 
 !  on entry     -  newdate  -  the new hdate.
@@ -551,7 +551,7 @@ contains
              end if
           end if
        end if
-       
+
 !  Break down new hdate into parts
 
        read(ndate(6:7),  '(i2)') monew
@@ -586,7 +586,7 @@ contains
              end if
           end if
        end if
-       
+
 !  Break down new hdate into parts
 
        read(ndate(5:6),  '(i2)') monew
@@ -794,7 +794,7 @@ contains
     integer, intent(in) :: year ! Four-digit year
 
     nfeb = 28 ! By default, February has 28 days ...
-    if (mod(year,4).eq.0) then  
+    if (mod(year,4).eq.0) then
        nfeb = 29  ! But every four years, it has 29 days ...
        if (mod(year,100).eq.0) then
           nfeb = 28  ! Except every 100 years, when it has 28 days ...

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/kwm_grid_utilities.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/kwm_grid_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 
@@ -97,14 +97,14 @@ contains
           endif
        enddo
     enddo
-    
+
     ! STL = ARRAY( I-1:I+2 , J-1:J+2 )
 
     ! if (ANY(STL<-1.E25)) then
     !    val = -1.E36
     !    return
     ! endif
-    
+
     ! Corner points missing are OK.  Any other points missing and we have a problem.
     if ((ANY(STL(:,2:3)<-1.E25)) .or. (ANY(STL(2:3,:)<-1.E25))) then
        val = -1.E36
@@ -138,7 +138,7 @@ contains
   end function bint_p
 
   REAL FUNCTION ONED(X,A,B,C,D) result(val)
-    ! Points B and C must have good data.  
+    ! Points B and C must have good data.
     ! Points A and D may have the no-data indication (value less than -1.E25)
     implicit none
     real, intent(in) :: X, A, B, C, D
@@ -166,7 +166,7 @@ contains
           val = (1.0-X)*(B+X*(0.5*(C-A)+X*(0.5*(C+A)-B)))+X*(C+(1.0-X)*(0.5 &
                *(B-D)+(1.0-X)*(0.5*(B+D)-C)))
        endif
-       
+
     endif
   END FUNCTION ONED
 
@@ -452,12 +452,12 @@ contains
 
 ! Compute the kernel
 
-! I'd rather do it in one step, going directly to my vector v, 
+! I'd rather do it in one step, going directly to my vector v,
 ! but I don't see how to be able to do that cleanly and still
 ! correct for the error (how much the sum differs from 1.0).
 
 ! First I compute the two-dimensional kernel array.
-    cval = 1./(twopi*sigsq) 
+    cval = 1./(twopi*sigsq)
     do i = 1, fsz
        x = float(hsz-i)
        do j = 1, fsz
@@ -509,7 +509,7 @@ contains
     real, dimension(ix,jx), intent(in)  :: slab1
     real, dimension(ix,jx), intent(out) :: slab2
     integer :: ie,je,i,j
-   
+
     IE=IX-1
     JE=JX-1
     DO I=2,IE
@@ -529,7 +529,7 @@ contains
     SLAB2(1,JX)=SLAB1(1,JE)
     SLAB2(IX,JX)=SLAB1(IE,JE)
     SLAB2(IX,1)=SLAB1(IE,1)
-   
+
   end subroutine crs2dot
 
 end module kwm_grid_utilities

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/kwm_string_utilities.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/kwm_string_utilities.F
@@ -48,7 +48,7 @@ contains
           return_string(j:j) = string(i:i)
        endif
     enddo
-    
+
   end function unblank
 
 !KWM  character function upcase(h)
@@ -67,7 +67,7 @@ contains
     implicit none
     character(len=*), intent(in) :: h
     integer :: i
-    
+
     return_string = " "
 
     do i = 1, len_trim(h)

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/kwm_timing_utilities.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/kwm_timing_utilities.F
@@ -2,27 +2,27 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_timing_utilities
   implicit none
   integer, parameter :: kwm_timing_dimension = 100
   integer, dimension(kwm_timing_dimension) :: Acount, Asum
-  
+
 contains
 
   subroutine timing_start(num)

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_geo_em.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_geo_em.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_geo_em
@@ -53,7 +53,7 @@ contains
   subroutine read_geo_em_file(flnm, geo_em, ierr)
 
 !---------------------------------------------------------------
-!  At the moment, all we need from the geo_em file is the 
+!  At the moment, all we need from the geo_em file is the
 !  array of monthly green vegetation fractions.
 !
 !  We also read projection/grid information, to ensure that

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_grib.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_grib.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_grib
@@ -50,7 +50,7 @@ contains
     !      ierr:      An error flag.  ierr == 0 -- File opened successfully.
     !                                 ierr == 1 -- There was some problem opening the file.
     !                                 ierr == 2 -- The specified file does not exist.
-    ! 
+    !
     ! Side effects:
     !      - File <filename> is opened for reading
     !      - The file stream pointer for <filename>, contained within structure <fd>,
@@ -70,7 +70,7 @@ contains
        ierr = 2
        return
     endif
-    
+
     call c_gribopen(trim(filename)//char(0), fd, ierr)
 
   end subroutine gribopen
@@ -89,7 +89,7 @@ contains
 
   subroutine getgrib(fd, grib, ierr)
     implicit none
-    ! 
+    !
     ! Purpose:
     !      Read a single grib record, but do no unpacking and no interpretation
     !      of header information beyond the size and edition nuber from GRIB 
@@ -163,13 +163,13 @@ contains
   subroutine findgrib(fd, grib, iloc)
     implicit none
     ! Purpose:
-    !      Seek in an open GRIB file for the string "GRIB", which 
+    !      Seek in an open GRIB file for the string "GRIB", which
     !      indicates the beginning of a GRIB record.
     ! Input:
     !      fd: A file stream pointer to a file opened by subroutine GRIBOPEN
     !
     ! Output:
-    !      iloc:  The location (by byte count) in the file stream <fd> 
+    !      iloc:  The location (by byte count) in the file stream <fd>
     !             at the beginning of this particular GRIB record.  Or,
     !             a negative number indicating a read problem (probably we 
     !             hit the end of the file.
@@ -203,7 +203,7 @@ contains
        return
     endif
 
-    do while ( h4 /= "GRIB") 
+    do while ( h4 /= "GRIB")
        ! Adjust our buffer and read one more byte
        h4(1:3) = h4(2:4)
        call io_fread(fd, h4(4:4), 1, iread, ierr)
@@ -219,7 +219,7 @@ contains
 
     !
     !   To have got this far, we must have found the beginning of a GRIB
-    !   record.  
+    !   record.
     !
 
     !
@@ -298,12 +298,12 @@ contains
 
   subroutine grib_next_field(fd, grib, ierr)
     implicit none
-    ! 
+    !
     ! Purpose:
     !      Unpack the next field in a GRIB file.  The field may already be
     !      available in <grib%buffer>; if not, we read from the file into 
     !      <grib%buffer>.
-    ! 
+    !
 
     integer(kind=8), intent(in) :: fd
     type (GribStruct), intent(inout) :: grib
@@ -320,7 +320,7 @@ contains
           ! print*, 'Try to read a new record'
           ! Get the next complete GRIB record (which may contain more than one field,
           ! which is why we have the complication of the outer do loop here).
-          call getgrib(fd, grib, ierr) 
+          call getgrib(fd, grib, ierr)
           if (ierr /= 0) return
        else
           ! See if we're at "7777"  If so, deallocate things and read a new record.
@@ -437,7 +437,7 @@ contains
 
 !=================================================================================
 !=================================================================================
-  
+
   subroutine grib_time_information(grib, reference_date, valid_date, process, processing, p1_seconds, p2_seconds)
     implicit none
     type (GribStruct),  intent(in)  :: grib
@@ -447,7 +447,7 @@ contains
     character(len=256), intent(out) :: processing
     integer,            intent(out) :: p1_seconds
     integer,            intent(out) :: p2_seconds
-    
+
     select case (grib%edition)
     case default
        write(*,'("MODULE_GRIB:  GRIB_TIME_INFORMATION:  Unrecognized grib%edition", I10)') grib%edition
@@ -457,7 +457,7 @@ contains
     case (2)
        call grib2_time_information(grib, reference_date, valid_date, process, processing, p1_seconds, p2_seconds)
     end select
-    
+
   end subroutine grib_time_information
 
 !=================================================================================
@@ -465,12 +465,12 @@ contains
 
   subroutine grib_valid_date(grib, validdate)
     ! Hmmmm.  This could also be a subfunction of unpacking
-    ! GRIB2 section 4 (GRIB1 Section 1), and making <validdate> 
+    ! GRIB2 section 4 (GRIB1 Section 1), and making <validdate>
     ! an element of <grib> at the top level
     implicit none
     type (GribStruct), intent(in)  :: grib
     character(len=19), intent(out) :: validdate
-    ! 
+    !
 
     select case (grib%edition)
     case default

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_grib1.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_grib1.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_grib1
@@ -56,7 +56,7 @@ contains
 
 !=================================================================================
 !=================================================================================
-  
+
   subroutine grib1_time_information(grib, reference_date, valid_date, process, processing, p1_seconds, p2_seconds)
     implicit none
     type (GribStruct),  intent(in)  :: grib
@@ -143,7 +143,7 @@ contains
     case (20)
        level_type = "Isothermal level"
        level_units = "K"
-       level_value = grib%g1sec1%levelval 
+       level_value = grib%g1sec1%levelval
     case (100)
        level_type = "Isobaric level"
        level_units = "Pa"
@@ -267,7 +267,7 @@ contains
     case (244)
        level_type = "Convective cloud layer"
     end select
-    
+
   end subroutine grib1_level_information
 
 !=================================================================================
@@ -430,7 +430,7 @@ contains
        else
           sec2%orientation = 1
        endif
-       
+
        ! Skip those last four bytes:
        iskip = iskip + (4*8)
 
@@ -466,13 +466,13 @@ contains
        else
           sec2%j_scan_direction = -1
        endif
-       
+
        if ( btest(sec2%scanning_mode, 5) ) then
           sec2%orientation = -1
        else
           sec2%orientation = 1
        endif
-       
+
        idum          = unpack_signed_integer(buffer, 3, iskip)
        sec2%latin1 = real(idum)*1.E-3
        idum          = unpack_signed_integer(buffer, 3, iskip)
@@ -517,13 +517,13 @@ contains
        else
           sec2%j_scan_direction = -1
        endif
-       
+
        if ( btest(sec2%scanning_mode, 5) ) then
           sec2%orientation = -1
        else
           sec2%orientation = 1
        endif
-       
+
        if (sec2%center==0) then
           sec2%latin1 = 60.0
        else
@@ -707,7 +707,7 @@ contains
        mapinfo%xlonc    = -1.E33
        mapinfo%truelat1 = -1.E33
        mapinfo%truelat2 = -1.E33
-    case (3) ! Lambert Conformal 
+    case (3) ! Lambert Conformal
        mapinfo%hproj = "LC"
        mapinfo%supmap_jproj = 3
        mapinfo%nx   = sec2%nx
@@ -792,7 +792,7 @@ contains
           write(*,'("grib%g1sec2%i_scan_direction = ", I12)') grib%g1sec2%i_scan_direction
           stop "GRIB1_SGUP_NOBITMAP:   Problem recognizing grib%g1sec2%i_scan_direction"
        endif
-       
+
        if (grib%g1sec2%j_scan_direction == 1) then
           array = DFAC * (dble(grib%g1sec4%reference_value) + (dble(IX)*BFAC))
        elseif (grib%g1sec2%j_scan_direction == -1) then
@@ -847,7 +847,7 @@ contains
 ! GRIB%G1SEC4%nbits : The number of bits per data value.
 
 
-! 1) There are fewer than NDAT data values, because a bitmap was used.  
+! 1) There are fewer than NDAT data values, because a bitmap was used.
 !    Compute the number of data values (NBM).  There are 11 extra bytes
 !    in the header section 4.  NBM equals the total number of data bits (not
 !    counting the header bits), minus the number of unused buts, and then
@@ -905,7 +905,7 @@ contains
        write(*,'("grib%g1sec2%j_scan_direction = ", I12)') grib%g1sec2%j_scan_direction
        stop "GRIB1_SGUP_BITMAP:  Problem recognizing grib%g1sec2%j_scan_direction"
     endif
-       
+
 
 
 ! Unpack the data according to packing parameters DFAC, BFAC, and XEC4(1), 
@@ -964,7 +964,7 @@ contains
     case (3) ! Average
        ! Average from (reference_time + p1) to (reference time + p2)
        call geth_newdate(validdate, refdate, tfac*(sec1%p1+sec1%p2)/2)
-    case(4) ! Accumulation from refdate + P1 to refdate + P2, 
+    case(4) ! Accumulation from refdate + P1 to refdate + P2,
        ! valid at refdate + P2
        ! call geth_newdate(fdate,     refdate, tfac*sec1(17))
        call geth_newdate(validdate, refdate, tfac*sec1%p2)

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_grib2.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_grib2.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_grib2
@@ -44,7 +44,7 @@ contains
     implicit none
     type (GribStruct), intent(in)  :: grib
     character(len=19), intent(out) :: validdate
-    ! 
+    !
     !Local:
     character(len=19) :: refdate
     integer :: fcst_time
@@ -125,7 +125,7 @@ contains
 
   subroutine fortran_decode_jpeg2000(buffer, buffer_length, decoded)
     implicit none
-    ! 
+    !
     ! Purpose:
     !      Take a character array <buffer> which contains a JPEG2000-encoded field,
     !      and return the decoded field as an integer array.  This subroutine is 
@@ -251,7 +251,7 @@ contains
           p2_seconds = 0
           call geth_newdate(valid_date, grib%sec1%hdate, grib%sec4%time)
           write(text3, '("Forecast valid time:  ", A, 1x, A)') valid_date(1:10), valid_date(12:19)
-          
+
        end select
     case (8)
        select case (grib%sec4%PDT_4_8%statistical_process)
@@ -298,7 +298,7 @@ contains
           case (13)
              p1_seconds = p1_seconds + (grib%sec4%PDT_4_8%length_of_time_range)
           end select
-          
+
        case (2)
           write(processing, '("Maximum in ", I6, 1x, A)') &
                grib%sec4%PDT_4_8%length_of_time_range, interpret_time_unit(grib%sec4%PDT_4_8%time_range_unit)
@@ -306,7 +306,7 @@ contains
           write(processing, '("Minimum in ", I6, 1x, A)') &
                grib%sec4%PDT_4_8%length_of_time_range, interpret_time_unit(grib%sec4%PDT_4_8%time_range_unit)
        case (4)
-          write(processing, '("Difference over ", I6, 1x, A)') & 
+          write(processing, '("Difference over ", I6, 1x, A)') &
               grib%sec4%PDT_4_8%length_of_time_range, interpret_time_unit(grib%sec4%PDT_4_8%time_range_unit)
        end select
     end select
@@ -422,7 +422,7 @@ contains
 
   subroutine unpack_next_grib2_section(isection, grib)
 
-    !  Returns the section number of the section just unpacked 
+    !  Returns the section number of the section just unpacked
     implicit none
     integer, intent(out) :: isection
     type(GribStruct), intent(inout) :: grib
@@ -597,7 +597,7 @@ contains
        !
        ! Significance of Reference Time
        !
-       select case (grib%sec1%srt) 
+       select case (grib%sec1%srt)
        case (0)
           write(*,'("  Analysis at time ",A)') grib%sec1%hdate
        case (1)
@@ -632,7 +632,7 @@ contains
 
     integer :: i
 
-    ! Temporary integers to hold 
+    ! Temporary integers to hold
     integer :: ila1
     integer :: ilo1
     integer :: ila2
@@ -745,7 +745,7 @@ contains
 
     case (30)
 
-       ! Lambert Conformal Grid 
+       ! Lambert Conformal Grid
 
        GT_3_30 => sec3%GT_3_30
 
@@ -976,7 +976,7 @@ contains
     sec4 => grib%sec4
 
     sec4%size = unpack_unsigned_integer(grib%buffer, 4, grib%iskip)
-    section   = unpack_unsigned_integer(grib%buffer, 1, grib%iskip)  
+    section   = unpack_unsigned_integer(grib%buffer, 1, grib%iskip)
     if (section /= 4) then
        write(*,'("Section 4:  We are lost!  ", I4)') section
        stop "Problem"
@@ -1210,7 +1210,7 @@ contains
 
     case (40)
 
-       iref40 = unpack_unsigned_integer(grib%buffer, 4, grib%iskip)     
+       iref40 = unpack_unsigned_integer(grib%buffer, 4, grib%iskip)
        sec5%DRT_5_40%reference_value = xref40
 
        sec5%DRT_5_40%binary_scale_factor = unpack_signed_integer(grib%buffer, 2, grib%iskip)
@@ -1292,7 +1292,7 @@ contains
     sec6 => grib%sec6
 
     sec6%size = unpack_unsigned_integer(grib%buffer, 4, grib%iskip)
-    section   = unpack_unsigned_integer(grib%buffer, 1, grib%iskip)  
+    section   = unpack_unsigned_integer(grib%buffer, 1, grib%iskip)
     if (section /= 6) then
        write(*,'("Section 6:  We are lost!  ", I8)') section
        stop "Problem"
@@ -1307,7 +1307,7 @@ contains
        ! No bitmap.
        ! No action needed here.
     case (254)
-       ! Bitmap previously defined in this GRIB record. 
+       ! Bitmap previously defined in this GRIB record.
        ! No action needed here.  The previously-defined bitmap
        ! should still be stored and used as necessary.
     case (0)

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_grib2_tables.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_grib2_tables.F
@@ -2,23 +2,23 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
-module module_grib2_tables 
+module module_grib2_tables
 
   type table_entry_struct
      integer                   :: product_discipline
@@ -129,10 +129,10 @@ contains
 
 ! Local
     type(table_entry_struct), pointer:: table_pointer
-    
+
     ! Start us off by pointing to the top of the table.
     table_pointer => table
-    
+
     ! Seek for the end of the table.
     do while (associated(table_pointer%next))
        table_pointer => table_pointer%next
@@ -157,11 +157,11 @@ contains
 !=================================================================================
   subroutine grib2_clear_parameter_table
     implicit none
-    
+
 ! Local
     type(table_entry_struct), pointer:: table_pointer
     type(table_entry_struct), pointer:: next_pointer
-    
+
     ! Start us off by pointing to the top of the table.
     table_pointer => table
 
@@ -257,23 +257,23 @@ contains
     case default
        write(text,'("Unrecognized type of surface", I4)') surface_type_code
     case (1)
-       write(text,'("Level:  Ground or water surface")') 
+       write(text,'("Level:  Ground or water surface")')
     case (2)
-       write(text,'("Level:  Cloud base level")') 
+       write(text,'("Level:  Cloud base level")')
     case (3)
-       write(text,'("Level:  Cloud top level")') 
+       write(text,'("Level:  Cloud top level")')
     case (4)
-       write(text,'("Level:  0~S~o~N~C isotherm level")') 
+       write(text,'("Level:  0~S~o~N~C isotherm level")')
     case (5)
-       write(text,'("Level:  Adiabatic lifting condensation level")') 
+       write(text,'("Level:  Adiabatic lifting condensation level")')
     case (6)
-       write(text,'("Level:  Maximum wind level")') 
+       write(text,'("Level:  Maximum wind level")')
     case (7)
-       write(text,'("Level:  Tropopause")') 
+       write(text,'("Level:  Tropopause")')
     case (8)
-       write(text,'("Level:  Nominal top of atmosphere")') 
+       write(text,'("Level:  Nominal top of atmosphere")')
     case (9)
-       write(text,'("Level:  Sea bottom")') 
+       write(text,'("Level:  Sea bottom")')
     case (20)
        write(text,'("Level:  Isothermal level ")')
        units = "K"
@@ -281,7 +281,7 @@ contains
        write(text,'("Level:  Isobaric surface ")')
        units = "Pa"
     case (101)
-       write(text,'("Level:  Mean sea level")') 
+       write(text,'("Level:  Mean sea level")')
     case (102)
        write(text,'("Level:  Height MSL ")')
        units = "m"

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_grib_common.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_grib_common.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_grib_common
@@ -184,10 +184,10 @@ module module_grib_common
      type (GT_3_30_Struct) :: GT_3_30
   end type Section3Struct
 
-!  type PDT_4_0_Struct 
+!  type PDT_4_0_Struct
 !  end type PDT_4_0_Struct
 
-  type PDT_4_8_Struct 
+  type PDT_4_8_Struct
      integer :: end_year
      integer :: end_month
      integer :: end_day
@@ -318,7 +318,7 @@ contains
   integer function unpack_signed_integer(buffer, nbytes, iskip) RESULT (signed_integer)
     implicit none
     !
-    ! Purpose:  
+    ! Purpose:
     !      From a string of bytes in a buffer array, unpack a stream of bytes into an 
     !      integer variable, with the a priori knowledge that this stream of bytes
     !      represents a signed integer, the sign indicated by the first bit in the stream. 
@@ -369,7 +369,7 @@ contains
   integer function unpack_unsigned_integer(buffer, nbytes, iskip) RESULT (unsigned_integer)
     implicit none
     !
-    ! Purpose:  
+    ! Purpose:
     !      From a string of bytes in a buffer array, unpack a stream of bytes into an 
     !      integer variable, with the a priori knowledge that this stream of bytes
     !      represents an _unsigned_ integer.  The <iskip> indicator is then incremented 

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_input_data_structure.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_input_data_structure.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_input_data_structure

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_llxy.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_llxy.F
@@ -2,27 +2,27 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 MODULE module_llxy
 
 ! Module that defines constants, data structures, and
 ! subroutines used to convert grid indices to lat/lon
-! and vice versa.   
+! and vice versa.
 !
 ! SUPPORTED PROJECTIONS
 ! ---------------------
@@ -39,9 +39,9 @@ MODULE module_llxy
 ! obtained from NCEP's w3 library.  The original NCEP routines were less
 ! flexible (e.g., polar-stereo routines only supported truelat of 60N/60S)
 ! than what we needed, so modifications based on equations in Hoke, Hayes, and
-! Renninger (AFGWC/TN/79-003) were added to improve the flexibility.  
+! Renninger (AFGWC/TN/79-003) were added to improve the flexibility.
 ! Additionally, coding was improved to F90 standards and the routines were
-! combined into this module.  
+! combined into this module.
 !
 ! ASSUMPTIONS
 ! -----------
@@ -183,12 +183,12 @@ MODULE module_llxy
 
    ! Define some private constants
    INTEGER, PRIVATE, PARAMETER :: HIGH = 8
- 
+
    TYPE proj_info
- 
+
       INTEGER          :: code     ! Integer code for projection TYPE
       INTEGER          :: nlat     ! For Gaussian -- number of latitude points 
-                                   !  north of the equator 
+                                   !  north of the equator
       INTEGER          :: nlon     !
                                    !
       INTEGER          :: ixdim    ! For Rotated Lat/Lon -- number of mass points
@@ -227,24 +227,24 @@ MODULE module_llxy
       REAL             :: rho0     ! For Albers equal area
       REAL             :: nc       ! For Albers equal area
       REAL             :: bigc     ! For Albers equal area
-      LOGICAL          :: init     ! Flag to indicate if this struct is 
+      LOGICAL          :: init     ! Flag to indicate if this struct is
                                    !  ready for use
       LOGICAL          :: wrap     ! For Gaussian -- flag to indicate wrapping 
                                    !  around globe?
       REAL, POINTER, DIMENSION(:) :: gauss_lat  ! Latitude array for Gaussian grid
- 
+
    END TYPE proj_info
 
  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  CONTAINS
  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- 
+
    SUBROUTINE map_init(proj)
       ! Initializes the map projection structure to missing values
-  
+
       IMPLICIT NONE
       TYPE(proj_info), INTENT(INOUT)  :: proj
-  
+
       proj%lat1     = -999.9
       proj%lon1     = -999.9
       proj%lat0     = -999.9
@@ -277,7 +277,7 @@ MODULE module_llxy
       proj%nc       = 0.
       proj%bigc     = 0.
       nullify(proj%gauss_lat)
-   
+
    END SUBROUTINE map_init
 
 
@@ -285,17 +285,17 @@ MODULE module_llxy
                       loninc, stdlon, truelat1, truelat2, nlat, nlon, ixdim, jydim, &
                       stagger, phi, lambda, r_earth)
       ! Given a partially filled proj_info structure, this routine computes
-      ! polei, polej, rsw, and cone (if LC projection) to complete the 
+      ! polei, polej, rsw, and cone (if LC projection) to complete the
       ! structure.  This allows us to eliminate redundant calculations when
       ! calling the coordinate conversion routines multiple times for the
       ! same map.
       ! This will generally be the first routine called when a user wants
       ! to be able to use the coordinate conversion routines, and it
-      ! will call the appropriate subroutines based on the 
+      ! will call the appropriate subroutines based on the
       ! proj%code which indicates which projection type this is.
-  
+
       IMPLICIT NONE
-      
+
       ! Declare arguments
       INTEGER, INTENT(IN)               :: proj_code
       INTEGER, INTENT(IN), OPTIONAL     :: nlat
@@ -324,7 +324,7 @@ MODULE module_llxy
       REAL :: dummy_lon1
       REAL :: dummy_lon0
       REAL :: dummy_stdlon
-  
+
       ! First, verify that mandatory parameters are present for the specified proj_code
       IF ( proj_code == PROJ_LC ) THEN
          IF ( .NOT.PRESENT(truelat1) .OR. &
@@ -445,7 +445,7 @@ MODULE module_llxy
          PRINT '(A,I2)', 'Unknown projection code: ', proj_code
          STOP 'MAP_INIT'
       END IF
-  
+
       ! Check for validity of mandatory variables in proj
       IF ( PRESENT(lat1) ) THEN
          IF ( ABS(lat1) .GT. 90. ) THEN
@@ -454,11 +454,11 @@ MODULE module_llxy
             STOP 'MAP_INIT'
          ENDIF
       ENDIF
-  
+
       IF ( PRESENT(lon1) ) THEN
          dummy_lon1 = lon1
          IF ( ABS(dummy_lon1) .GT. 180.) THEN
-            iter = 0 
+            iter = 0
             DO WHILE (ABS(dummy_lon1) > 180. .AND. iter < 10)
                IF (dummy_lon1 < -180.) dummy_lon1 = dummy_lon1 + 360.
                IF (dummy_lon1 > 180.) dummy_lon1 = dummy_lon1 - 360.
@@ -471,11 +471,11 @@ MODULE module_llxy
             ENDIF
          ENDIF
       ENDIF
-  
+
       IF ( PRESENT(lon0) ) THEN
          dummy_lon0 = lon0
          IF ( ABS(dummy_lon0) .GT. 180.) THEN
-            iter = 0 
+            iter = 0
             DO WHILE (ABS(dummy_lon0) > 180. .AND. iter < 10)
                IF (dummy_lon0 < -180.) dummy_lon0 = dummy_lon0 + 360.
                IF (dummy_lon0 > 180.) dummy_lon0 = dummy_lon0 - 360.
@@ -488,18 +488,18 @@ MODULE module_llxy
             ENDIF
          ENDIF
       ENDIF
-  
+
       IF ( PRESENT(dx) ) THEN
          IF ((dx .LE. 0.).AND.(proj_code .NE. PROJ_LATLON)) THEN
             PRINT '(A)', 'Require grid spacing (dx) in meters be positive'
             STOP 'MAP_INIT'
          ENDIF
       ENDIF
-  
+
       IF ( PRESENT(stdlon) ) THEN
          dummy_stdlon = stdlon
          IF ((ABS(dummy_stdlon) > 180.).AND.(proj_code /= PROJ_MERC)) THEN
-            iter = 0 
+            iter = 0
             DO WHILE (ABS(dummy_stdlon) > 180. .AND. iter < 10)
                IF (dummy_stdlon < -180.) dummy_stdlon = dummy_stdlon + 360.
                IF (dummy_stdlon > 180.) dummy_stdlon = dummy_stdlon - 360.
@@ -507,20 +507,20 @@ MODULE module_llxy
             END DO
             IF (abs(dummy_stdlon) > 180.) THEN
                PRINT '(A)', 'Need orientation longitude (stdlon) as: '
-               PRINT '(A)', '   -180E <= stdlon <= 180W' 
+               PRINT '(A)', '   -180E <= stdlon <= 180W'
                STOP 'MAP_INIT'
             ENDIF
          ENDIF
       ENDIF
-  
+
       IF ( PRESENT(truelat1) ) THEN
          IF (ABS(truelat1).GT.90.) THEN
             PRINT '(A)', 'Set true latitude 1 for all projections'
             STOP 'MAP_INIT'
          ENDIF
       ENDIF
-     
-      CALL map_init(proj) 
+
+      CALL map_init(proj)
       proj%code  = proj_code
       IF ( PRESENT(lat1) )     proj%lat1     = lat1
       IF ( PRESENT(lon1) )     proj%lon1     = dummy_lon1
@@ -542,14 +542,14 @@ MODULE module_llxy
       IF ( PRESENT(phi) )      proj%phi      = phi
       IF ( PRESENT(lambda) )   proj%lambda   = lambda
       IF ( PRESENT(r_earth) )  proj%re_m     = r_earth
-  
-      IF ( PRESENT(dx) ) THEN 
+
+      IF ( PRESENT(dx) ) THEN
          IF ( (proj_code == PROJ_LC) .OR. (proj_code == PROJ_PS) .OR. &
               (proj_code == PROJ_PS_WGS84) .OR. (proj_code == PROJ_ALBERS_NAD83) .OR. &
               (proj_code == PROJ_MERC) ) THEN
             proj%dx = dx
             IF (truelat1 .LT. 0.) THEN
-               proj%hemi = -1.0 
+               proj%hemi = -1.0
             ELSE
                proj%hemi = 1.0
             ENDIF
@@ -558,7 +558,7 @@ MODULE module_llxy
       ENDIF
 
       pick_proj: SELECT CASE(proj%code)
-  
+
          CASE(PROJ_PS)
             CALL set_ps(proj)
 
@@ -567,29 +567,29 @@ MODULE module_llxy
 
          CASE(PROJ_ALBERS_NAD83)
             CALL set_albers_nad83(proj)
-   
+
          CASE(PROJ_LC)
             IF (ABS(proj%truelat2) .GT. 90.) THEN
                proj%truelat2=proj%truelat1
             ENDIF
             CALL set_lc(proj)
-      
+
          CASE (PROJ_MERC)
             CALL set_merc(proj)
-      
+
          CASE (PROJ_LATLON)
-   
+
          CASE (PROJ_GAUSS)
             CALL set_gauss(proj)
-      
+
          CASE (PROJ_CYL)
             CALL set_cyl(proj)
-      
+
          CASE (PROJ_CASSINI)
             CALL set_cassini(proj)
-      
+
          CASE (PROJ_ROTLL)
-     
+
       END SELECT pick_proj
       proj%init = .TRUE.
 
@@ -600,43 +600,43 @@ MODULE module_llxy
 
    SUBROUTINE latlon_to_ij(proj, lat, lon, i, j)
       ! Converts input lat/lon values to the cartesian (i,j) value
-      ! for the given projection. 
-  
+      ! for the given projection.
+
       IMPLICIT NONE
       TYPE(proj_info), INTENT(IN)          :: proj
       REAL, INTENT(IN)                     :: lat
       REAL, INTENT(IN)                     :: lon
       REAL, INTENT(OUT)                    :: i
       REAL, INTENT(OUT)                    :: j
-  
+
       IF (.NOT.proj%init) THEN
          PRINT '(A)', 'You have not called map_set for this projection'
          STOP 'LATLON_TO_IJ'
       ENDIF
-  
+
       SELECT CASE(proj%code)
-   
+
          CASE(PROJ_LATLON)
             CALL llij_latlon(lat,lon,proj,i,j)
-   
+
          CASE(PROJ_MERC)
             CALL llij_merc(lat,lon,proj,i,j)
-   
+
          CASE(PROJ_PS)
             CALL llij_ps(lat,lon,proj,i,j)
 
          CASE(PROJ_PS_WGS84)
             CALL llij_ps_wgs84(lat,lon,proj,i,j)
-         
+
          CASE(PROJ_ALBERS_NAD83)
             CALL llij_albers_nad83(lat,lon,proj,i,j)
-         
+
          CASE(PROJ_LC)
             CALL llij_lc(lat,lon,proj,i,j)
-   
+
          CASE(PROJ_GAUSS)
             CALL llij_gauss(lat,lon,proj,i,j)
-   
+
          CASE(PROJ_CYL)
             CALL llij_cyl(lat,lon,proj,i,j)
 
@@ -645,11 +645,11 @@ MODULE module_llxy
 
          CASE(PROJ_ROTLL)
             CALL llij_rotlatlon(lat,lon,proj,i,j)
-   
+
          CASE DEFAULT
             PRINT '(A,I2)', 'Unrecognized map projection code: ', proj%code
             STOP 'LATLON_TO_IJ'
-    
+
       END SELECT
 
       RETURN
@@ -660,51 +660,51 @@ MODULE module_llxy
    SUBROUTINE ij_to_latlon(proj, i, j, lat, lon)
       ! Computes geographical latitude and longitude for a given (i,j) point
       ! in a grid with a projection of proj
-  
+
       IMPLICIT NONE
       TYPE(proj_info),INTENT(IN)          :: proj
       REAL, INTENT(IN)                    :: i
       REAL, INTENT(IN)                    :: j
       REAL, INTENT(OUT)                   :: lat
       REAL, INTENT(OUT)                   :: lon
-  
+
       IF (.NOT.proj%init) THEN
          PRINT '(A)', 'You have not called map_set for this projection'
          STOP 'IJ_TO_LATLON'
       ENDIF
       SELECT CASE (proj%code)
-  
+
          CASE (PROJ_LATLON)
             CALL ijll_latlon(i, j, proj, lat, lon)
-   
+
          CASE (PROJ_MERC)
             CALL ijll_merc(i, j, proj, lat, lon)
-   
+
          CASE (PROJ_PS)
             CALL ijll_ps(i, j, proj, lat, lon)
 
          CASE (PROJ_PS_WGS84)
             CALL ijll_ps_wgs84(i, j, proj, lat, lon)
-   
+
          CASE (PROJ_ALBERS_NAD83)
             CALL ijll_albers_nad83(i, j, proj, lat, lon)
-   
+
          CASE (PROJ_LC)
             CALL ijll_lc(i, j, proj, lat, lon)
-   
+
          CASE (PROJ_CYL)
             CALL ijll_cyl(i, j, proj, lat, lon)
-   
+
          CASE (PROJ_CASSINI)
             CALL ijll_cassini(i, j, proj, lat, lon)
-   
+
          CASE (PROJ_ROTLL)
             CALL ijll_rotlatlon(i, j, proj, lat, lon)
-   
+
          CASE DEFAULT
             PRINT '(A,I2)', 'Unrecognized map projection code: ', proj%code
             STOP 'IJ_TO_LATLON'
-  
+
       END SELECT
       RETURN
    END SUBROUTINE ij_to_latlon
@@ -716,26 +716,26 @@ MODULE module_llxy
       ! southwest corner and computes the i/j location of the pole for use
       ! in llij_ps and ijll_ps.
       IMPLICIT NONE
-   
+
       ! Declare args
       TYPE(proj_info), INTENT(INOUT)    :: proj
-  
+
       ! Local vars
       REAL                              :: ala1
       REAL                              :: alo1
       REAL                              :: reflon
       REAL                              :: scale_top
-  
+
       ! Executable code
       reflon = proj%stdlon + 90.
-  
+
       ! Compute numerator term of map scale factor
       scale_top = 1. + proj%hemi * SIN(proj%truelat1 * rad_per_deg)
-  
+
       ! Compute radius to lower-left (SW) corner
       ala1 = proj%lat1 * rad_per_deg
       proj%rsw = proj%rebydx*COS(ala1)*scale_top/(1.+proj%hemi*SIN(ala1))
-  
+
       ! Find the pole point
       alo1 = (proj%lon1 - reflon) * rad_per_deg
       proj%polei = proj%knowni - proj%rsw * COS(alo1)
@@ -748,89 +748,89 @@ MODULE module_llxy
 
    SUBROUTINE llij_ps(lat,lon,proj,i,j)
       ! Given latitude (-90 to 90), longitude (-180 to 180), and the
-      ! standard polar-stereographic projection information via the 
+      ! standard polar-stereographic projection information via the
       ! public proj structure, this routine returns the i/j indices which
       ! if within the domain range from 1->nx and 1->ny, respectively.
-  
+
       IMPLICIT NONE
-  
+
       ! Delcare input arguments
       REAL, INTENT(IN)               :: lat
       REAL, INTENT(IN)               :: lon
       TYPE(proj_info),INTENT(IN)     :: proj
-  
-      ! Declare output arguments     
+
+      ! Declare output arguments
       REAL, INTENT(OUT)              :: i !(x-index)
       REAL, INTENT(OUT)              :: j !(y-index)
-  
+
       ! Declare local variables
-      
+
       REAL                           :: reflon
       REAL                           :: scale_top
       REAL                           :: ala
       REAL                           :: alo
       REAL                           :: rm
-  
+
       ! BEGIN CODE
-    
+
       reflon = proj%stdlon + 90.
-     
+
       ! Compute numerator term of map scale factor
-  
+
       scale_top = 1. + proj%hemi * SIN(proj%truelat1 * rad_per_deg)
-  
+
       ! Find radius to desired point
       ala = lat * rad_per_deg
       rm = proj%rebydx * COS(ala) * scale_top/(1. + proj%hemi *SIN(ala))
       alo = (lon - reflon) * rad_per_deg
       i = proj%polei + rm * COS(alo)
       j = proj%polej + proj%hemi * rm * SIN(alo)
-   
+
       RETURN
 
    END SUBROUTINE llij_ps
 
 
    SUBROUTINE ijll_ps(i, j, proj, lat, lon)
- 
-      ! This is the inverse subroutine of llij_ps.  It returns the 
+
+      ! This is the inverse subroutine of llij_ps.  It returns the
       ! latitude and longitude of an i/j point given the projection info 
-      ! structure.  
-  
+      ! structure.
+
       IMPLICIT NONE
-  
+
       ! Declare input arguments
       REAL, INTENT(IN)                    :: i    ! Column
       REAL, INTENT(IN)                    :: j    ! Row
       TYPE (proj_info), INTENT(IN)        :: proj
-      
+
       ! Declare output arguments
       REAL, INTENT(OUT)                   :: lat     ! -90 -> 90 north
       REAL, INTENT(OUT)                   :: lon     ! -180 -> 180 East
-  
+
       ! Local variables
       REAL                                :: reflon
       REAL                                :: scale_top
       REAL                                :: xx,yy
       REAL                                :: gi2, r2
       REAL                                :: arccos
-  
+
       ! Begin Code
-  
+
       ! Compute the reference longitude by rotating 90 degrees to the east
       ! to find the longitude line parallel to the positive x-axis.
       reflon = proj%stdlon + 90.
-     
+
       ! Compute numerator term of map scale factor
       scale_top = 1. + proj%hemi * SIN(proj%truelat1 * rad_per_deg)
-  
+
       ! Compute radius to point of interest
       xx = i - proj%polei
       yy = (j - proj%polej) * proj%hemi
       r2 = xx**2 + yy**2
-  
+
       ! Now the magic code
-      IF (r2 .EQ. 0.) THEN 
+      IF (r2 .EQ. 0.) THEN
          lat = proj%hemi * 90.
          lon = reflon
       ELSE
@@ -843,13 +843,13 @@ MODULE module_llxy
             lon = reflon - deg_per_rad * arccos
          ENDIF
       ENDIF
-    
+
       ! Convert to a -180 -> 180 East convention
       IF (lon .GT. 180.) lon = lon - 360.
       IF (lon .LT. -180.) lon = lon + 360.
 
       RETURN
-   
+
    END SUBROUTINE ijll_ps
 
 
@@ -860,10 +860,10 @@ MODULE module_llxy
       ! pole for use in llij_ps and ijll_ps.
 
       IMPLICIT NONE
-   
+
       ! Arguments
       TYPE(proj_info), INTENT(INOUT)    :: proj
-  
+
       ! Local variables
       real :: h, mc, tc, t, rho
 
@@ -887,19 +887,19 @@ MODULE module_llxy
 
    SUBROUTINE llij_ps_wgs84(lat,lon,proj,i,j)
       ! Given latitude (-90 to 90), longitude (-180 to 180), and the
-      ! standard polar-stereographic projection information via the 
+      ! standard polar-stereographic projection information via the
       ! public proj structure, this routine returns the i/j indices which
       ! if within the domain range from 1->nx and 1->ny, respectively.
-  
+
       IMPLICIT NONE
-  
+
       ! Arguments
       REAL, INTENT(IN)               :: lat
       REAL, INTENT(IN)               :: lon
       REAL, INTENT(OUT)              :: i !(x-index)
       REAL, INTENT(OUT)              :: j !(y-index)
       TYPE(proj_info),INTENT(IN)     :: proj
-  
+
       ! Local variables
       real :: h, mc, tc, t, rho
 
@@ -920,20 +920,20 @@ MODULE module_llxy
       ! Get i/j relative to reference i/j
       i = proj%knowni + (i - proj%polei)
       j = proj%knownj + (j - proj%polej)
-  
+
       RETURN
 
    END SUBROUTINE llij_ps_wgs84
 
 
    SUBROUTINE ijll_ps_wgs84(i, j, proj, lat, lon)
- 
-      ! This is the inverse subroutine of llij_ps.  It returns the 
+
+      ! This is the inverse subroutine of llij_ps.  It returns the
       ! latitude and longitude of an i/j point given the projection info 
-      ! structure.  
-  
+      ! structure.
+
       implicit none
-  
+
       ! Arguments
       REAL, INTENT(IN)                    :: i    ! Column
       REAL, INTENT(IN)                    :: j    ! Row
@@ -954,7 +954,7 @@ MODULE module_llxy
                 (((1.0+E_WGS84*sin(h*proj%truelat1*rad_per_deg))/(1.0-E_WGS84*sin(h*proj%truelat1*rad_per_deg)))**E_WGS84 ))
 
       rho = sqrt((x*proj%dx)**2.0 + (y*proj%dx)**2.0)
-      t = rho * tc / (A_WGS84 * mc) 
+      t = rho * tc / (A_WGS84 * mc)
 
       lon = h*proj%stdlon + h*atan2(h*x,h*(-y))
 
@@ -971,7 +971,7 @@ MODULE module_llxy
       lon = lon*deg_per_rad
 
       RETURN
-   
+
    END SUBROUTINE ijll_ps_wgs84
 
 
@@ -982,10 +982,10 @@ MODULE module_llxy
       ! pole for use in llij_albers_nad83 and ijll_albers_nad83.
 
       IMPLICIT NONE
-   
+
       ! Arguments
       TYPE(proj_info), INTENT(INOUT)    :: proj
-  
+
       ! Local variables
       real :: h, m1, m2, q1, q2, theta, q, sinphi
 
@@ -1018,7 +1018,7 @@ MODULE module_llxy
       proj%rho0 = h * (A_NAD83 / proj%dx) * sqrt(proj%bigc - proj%nc * q) / proj%nc 
       theta = proj%nc*(proj%lon1 - proj%stdlon)*rad_per_deg
 
-      proj%polei = proj%rho0 * sin(h*theta) 
+      proj%polei = proj%rho0 * sin(h*theta)
       proj%polej = proj%rho0 - proj%rho0 * cos(h*theta)
 
       RETURN
@@ -1028,19 +1028,19 @@ MODULE module_llxy
 
    SUBROUTINE llij_albers_nad83(lat,lon,proj,i,j)
       ! Given latitude (-90 to 90), longitude (-180 to 180), and the
-      ! standard projection information via the 
+      ! standard projection information via the
       ! public proj structure, this routine returns the i/j indices which
       ! if within the domain range from 1->nx and 1->ny, respectively.
-  
+
       IMPLICIT NONE
-  
+
       ! Arguments
       REAL, INTENT(IN)               :: lat
       REAL, INTENT(IN)               :: lon
       REAL, INTENT(OUT)              :: i !(x-index)
       REAL, INTENT(OUT)              :: j !(y-index)
       TYPE(proj_info),INTENT(IN)     :: proj
-  
+
       ! Local variables
       real :: h, q, rho, theta, sinphi
 
@@ -1068,13 +1068,13 @@ MODULE module_llxy
 
 
    SUBROUTINE ijll_albers_nad83(i, j, proj, lat, lon)
- 
+
       ! This is the inverse subroutine of llij_albers_nad83.  It returns the 
       ! latitude and longitude of an i/j point given the projection info 
-      ! structure.  
-  
+      ! structure.
+
       implicit none
-  
+
       ! Arguments
       REAL, INTENT(IN)                    :: i    ! Column
       REAL, INTENT(IN)                    :: j    ! Row
@@ -1107,70 +1107,70 @@ MODULE module_llxy
       lon = proj%stdlon + theta*deg_per_rad/proj%nc
 
       RETURN
-   
+
    END SUBROUTINE ijll_albers_nad83
 
 
    SUBROUTINE set_lc(proj)
       ! Initialize the remaining items in the proj structure for a
       ! lambert conformal grid.
-  
+
       IMPLICIT NONE
-      
+
       TYPE(proj_info), INTENT(INOUT)     :: proj
-  
+
       REAL                               :: arg
       REAL                               :: deltalon1
       REAL                               :: tl1r
       REAL                               :: ctl1r
-  
+
       ! Compute cone factor
       CALL lc_cone(proj%truelat1, proj%truelat2, proj%cone)
-  
+
       ! Compute longitude differences and ensure we stay out of the
       ! forbidden "cut zone"
       deltalon1 = proj%lon1 - proj%stdlon
       IF (deltalon1 .GT. +180.) deltalon1 = deltalon1 - 360.
       IF (deltalon1 .LT. -180.) deltalon1 = deltalon1 + 360.
-  
+
       ! Convert truelat1 to radian and compute COS for later use
       tl1r = proj%truelat1 * rad_per_deg
       ctl1r = COS(tl1r)
-  
+
       ! Compute the radius to our known lower-left (SW) corner
       proj%rsw = proj%rebydx * ctl1r/proj%cone * &
              (TAN((90.*proj%hemi-proj%lat1)*rad_per_deg/2.) / &
               TAN((90.*proj%hemi-proj%truelat1)*rad_per_deg/2.))**proj%cone
-  
+
       ! Find pole point
       arg = proj%cone*(deltalon1*rad_per_deg)
       proj%polei = proj%hemi*proj%knowni - proj%hemi * proj%rsw * SIN(arg)
-      proj%polej = proj%hemi*proj%knownj + proj%rsw * COS(arg)  
-  
+      proj%polej = proj%hemi*proj%knownj + proj%rsw * COS(arg)
+
       RETURN
 
-   END SUBROUTINE set_lc                             
+   END SUBROUTINE set_lc
 
 
    SUBROUTINE lc_cone(truelat1, truelat2, cone)
- 
+
    ! Subroutine to compute the cone factor of a Lambert Conformal projection
- 
+
       IMPLICIT NONE
-      
+
       ! Input Args
       REAL, INTENT(IN)             :: truelat1  ! (-90 -> 90 degrees N)
       REAL, INTENT(IN)             :: truelat2  !   "   "  "   "     "
-  
+
       ! Output Args
       REAL, INTENT(OUT)            :: cone
-  
+
       ! Locals
-  
+
       ! BEGIN CODE
-  
+
       ! First, see if this is a secant or tangent projection.  For tangent
-      ! projections, truelat1 = truelat2 and the cone is tangent to the 
+      ! projections, truelat1 = truelat2 and the cone is tangent to the
       ! Earth's surface at this latitude.  For secant projections, the cone
       ! intersects the Earth's surface at each of the distinctly different
       ! latitudes
@@ -1180,7 +1180,7 @@ MODULE module_llxy
          cone = cone /(ALOG10(TAN((45.0 - ABS(truelat1)/2.0) * rad_per_deg)) - &
                 ALOG10(TAN((45.0 - ABS(truelat2)/2.0) * rad_per_deg)))        
       ELSE
-         cone = SIN(ABS(truelat1)*rad_per_deg )  
+         cone = SIN(ABS(truelat1)*rad_per_deg )
       ENDIF
 
       RETURN
@@ -1189,25 +1189,25 @@ MODULE module_llxy
 
 
    SUBROUTINE ijll_lc( i, j, proj, lat, lon)
- 
-   ! Subroutine to convert from the (i,j) cartesian coordinate to the 
+
+   ! Subroutine to convert from the (i,j) cartesian coordinate to the
    ! geographical latitude and longitude for a Lambert Conformal projection.
- 
+
    ! History:
    ! 25 Jul 01: Corrected by B. Shaw, NOAA/FSL
-   ! 
+   !
       IMPLICIT NONE
-  
+
       ! Input Args
       REAL, INTENT(IN)              :: i        ! Cartesian X coordinate
       REAL, INTENT(IN)              :: j        ! Cartesian Y coordinate
       TYPE(proj_info),INTENT(IN)    :: proj     ! Projection info structure
-  
-      ! Output Args                 
+
+      ! Output Args
       REAL, INTENT(OUT)             :: lat      ! Latitude (-90->90 deg N)
       REAL, INTENT(OUT)             :: lon      ! Longitude (-180->180 E)
-  
-      ! Locals 
+
+      ! Locals
       REAL                          :: inew
       REAL                          :: jnew
       REAL                          :: r
@@ -1215,106 +1215,106 @@ MODULE module_llxy
       REAL                          :: r2
       REAL                          :: xx
       REAL                          :: yy
-  
+
       ! BEGIN CODE
-  
+
       chi1 = (90. - proj%hemi*proj%truelat1)*rad_per_deg
       chi2 = (90. - proj%hemi*proj%truelat2)*rad_per_deg
-  
+
       ! See if we are in the southern hemispere and flip the indices
-      ! if we are. 
+      ! if we are.
       inew = proj%hemi * i
       jnew = proj%hemi * j
-  
+
       ! Compute radius**2 to i/j location
       xx = inew - proj%polei
       yy = proj%polej - jnew
       r2 = (xx*xx + yy*yy)
       r = SQRT(r2)/proj%rebydx
-     
+
       ! Convert to lat/lon
       IF (r2 .EQ. 0.) THEN
          lat = proj%hemi * 90.
          lon = proj%stdlon
       ELSE
-         
+
          ! Longitude
          lon = proj%stdlon + deg_per_rad * ATAN2(proj%hemi*xx,yy)/proj%cone
          lon = MOD(lon+360., 360.)
-   
+
          ! Latitude.  Latitude determined by solving an equation adapted 
          ! from:
          !  Maling, D.H., 1973: Coordinate Systems and Map Projections
-         ! Equations #20 in Appendix I.  
-           
+         ! Equations #20 in Appendix I.
+
          IF (chi1 .EQ. chi2) THEN
             chi = 2.0*ATAN( ( r/TAN(chi1) )**(1./proj%cone) * TAN(chi1*0.5) )
          ELSE
             chi = 2.0*ATAN( (r*proj%cone/SIN(chi1))**(1./proj%cone) * TAN(chi1*0.5)) 
          ENDIF
          lat = (90.0-chi*deg_per_rad)*proj%hemi
-  
+
       ENDIF
-  
+
       IF (lon .GT. +180.) lon = lon - 360.
       IF (lon .LT. -180.) lon = lon + 360.
- 
+
       RETURN
 
    END SUBROUTINE ijll_lc
 
 
    SUBROUTINE llij_lc( lat, lon, proj, i, j)
- 
+
    ! Subroutine to compute the geographical latitude and longitude values
    ! to the cartesian x/y on a Lambert Conformal projection.
-     
+
       IMPLICIT NONE
-  
+
       ! Input Args
       REAL, INTENT(IN)              :: lat      ! Latitude (-90->90 deg N)
       REAL, INTENT(IN)              :: lon      ! Longitude (-180->180 E)
       TYPE(proj_info),INTENT(IN)      :: proj     ! Projection info structure
-  
-      ! Output Args                 
+
+      ! Output Args
       REAL, INTENT(OUT)             :: i        ! Cartesian X coordinate
       REAL, INTENT(OUT)             :: j        ! Cartesian Y coordinate
-  
-      ! Locals 
+
+      ! Locals
       REAL                          :: arg
       REAL                          :: deltalon
       REAL                          :: tl1r
       REAL                          :: rm
       REAL                          :: ctl1r
-      
-  
+
+
       ! BEGIN CODE
-      
+
       ! Compute deltalon between known longitude and standard lon and ensure
       ! it is not in the cut zone
       deltalon = lon - proj%stdlon
       IF (deltalon .GT. +180.) deltalon = deltalon - 360.
       IF (deltalon .LT. -180.) deltalon = deltalon + 360.
-      
+
       ! Convert truelat1 to radian and compute COS for later use
       tl1r = proj%truelat1 * rad_per_deg
-      ctl1r = COS(tl1r)     
-     
+      ctl1r = COS(tl1r)
+
       ! Radius to desired point
       rm = proj%rebydx * ctl1r/proj%cone * &
            (TAN((90.*proj%hemi-lat)*rad_per_deg/2.) / &
             TAN((90.*proj%hemi-proj%truelat1)*rad_per_deg/2.))**proj%cone
-  
+
       arg = proj%cone*(deltalon*rad_per_deg)
       i = proj%polei + proj%hemi * rm * SIN(arg)
       j = proj%polej - rm * COS(arg)
-  
+
       ! Finally, if we are in the southern hemisphere, flip the i/j
       ! values to a coordinate system where (1,1) is the SW corner
       ! (what we assume) which is different than the original NCEP
-      ! algorithms which used the NE corner as the origin in the 
+      ! algorithms which used the NE corner as the origin in the
       ! southern hemisphere (left-hand vs. right-hand coordinate?)
-      i = proj%hemi * i  
+      i = proj%hemi * i
       j = proj%hemi * j
 
       RETURN
@@ -1322,22 +1322,22 @@ MODULE module_llxy
 
 
    SUBROUTINE set_merc(proj)
-   
+
       ! Sets up the remaining basic elements for the mercator projection
-  
+
       IMPLICIT NONE
       TYPE(proj_info), INTENT(INOUT)       :: proj
       REAL                                 :: clain
-  
-  
+
+
       !  Preliminary variables
-  
+
       clain = COS(rad_per_deg*proj%truelat1)
       proj%dlon = proj%dx / (proj%re_m * clain)
-  
-      ! Compute distance from equator to origin, and store in the 
+
+      ! Compute distance from equator to origin, and store in the
       ! proj%rsw tag.
-  
+
       proj%rsw = 0.
       IF (proj%lat1 .NE. 0.) THEN
          proj%rsw = (ALOG(TAN(0.5*((proj%lat1+90.)*rad_per_deg))))/proj%dlon
@@ -1349,9 +1349,9 @@ MODULE module_llxy
 
 
    SUBROUTINE llij_merc(lat, lon, proj, i, j)
- 
+
       ! Compute i/j coordinate from lat lon for mercator projection
-    
+
       IMPLICIT NONE
       REAL, INTENT(IN)              :: lat
       REAL, INTENT(IN)              :: lon
@@ -1359,31 +1359,31 @@ MODULE module_llxy
       REAL,INTENT(OUT)              :: i
       REAL,INTENT(OUT)              :: j
       REAL                          :: deltalon
-  
+
       deltalon = lon - proj%lon1
       IF (deltalon .LT. -180.) deltalon = deltalon + 360.
       IF (deltalon .GT. 180.) deltalon = deltalon - 360.
       i = proj%knowni + (deltalon/(proj%dlon*deg_per_rad))
       j = proj%knownj + (ALOG(TAN(0.5*((lat + 90.) * rad_per_deg)))) / &
              proj%dlon - proj%rsw
-  
+
       RETURN
 
    END SUBROUTINE llij_merc
 
 
    SUBROUTINE ijll_merc(i, j, proj, lat, lon)
- 
+
       ! Compute the lat/lon from i/j for mercator projection
-  
+
       IMPLICIT NONE
       REAL,INTENT(IN)               :: i
-      REAL,INTENT(IN)               :: j    
+      REAL,INTENT(IN)               :: j
       TYPE(proj_info),INTENT(IN)    :: proj
       REAL, INTENT(OUT)             :: lat
-      REAL, INTENT(OUT)             :: lon 
-  
-  
+      REAL, INTENT(OUT)             :: lon
+
+
       lat = 2.0*ATAN(EXP(proj%dlon*(proj%rsw + j-proj%knownj)))*deg_per_rad - 90.
       lon = (i-proj%knowni)*proj%dlon*deg_per_rad + proj%lon1
       IF (lon.GT.180.) lon = lon - 360.
@@ -1394,7 +1394,7 @@ MODULE module_llxy
 
 
    SUBROUTINE llij_latlon(lat, lon, proj, i, j)
-  
+
       ! Compute the i/j location of a lat/lon on a LATLON grid.
       IMPLICIT NONE
       REAL, INTENT(IN)             :: lat
@@ -1402,29 +1402,29 @@ MODULE module_llxy
       TYPE(proj_info), INTENT(IN)  :: proj
       REAL, INTENT(OUT)            :: i
       REAL, INTENT(OUT)            :: j
-  
+
       REAL                         :: deltalat
       REAL                         :: deltalon
-  
+
       ! Compute deltalat and deltalon as the difference between the input 
       ! lat/lon and the origin lat/lon
       deltalat = lat - proj%lat1
-      deltalon = lon - proj%lon1      
-      
+      deltalon = lon - proj%lon1
+
       ! Compute i/j
       i = deltalon/proj%loninc
       j = deltalat/proj%latinc
 
       i = i + proj%knowni
       j = j + proj%knownj
-  
+
       RETURN
 
    END SUBROUTINE llij_latlon
 
 
    SUBROUTINE ijll_latlon(i, j, proj, lat, lon)
-  
+
       ! Compute the lat/lon location of an i/j on a LATLON grid.
       IMPLICIT NONE
       REAL, INTENT(IN)             :: i
@@ -1432,21 +1432,21 @@ MODULE module_llxy
       TYPE(proj_info), INTENT(IN)  :: proj
       REAL, INTENT(OUT)            :: lat
       REAL, INTENT(OUT)            :: lon
-  
+
       REAL                         :: i_work, j_work
       REAL                         :: deltalat
       REAL                         :: deltalon
-  
+
       i_work = i - proj%knowni
       j_work = j - proj%knownj
 
-      ! Compute deltalat and deltalon 
+      ! Compute deltalat and deltalon
       deltalat = j_work*proj%latinc
       deltalon = i_work*proj%loninc
-  
+
       lat = proj%lat1 + deltalat
       lon = proj%lon1 + deltalon
-  
+
       RETURN
 
    END SUBROUTINE ijll_latlon
@@ -1467,7 +1467,7 @@ MODULE module_llxy
    SUBROUTINE llij_cyl(lat, lon, proj, i, j)
 
       implicit none
-    
+
       ! Arguments
       real, intent(in) :: lat, lon
       real, intent(out) :: i, j
@@ -1500,9 +1500,9 @@ MODULE module_llxy
 
 
    SUBROUTINE ijll_cyl(i, j, proj, lat, lon)
-   
+
       implicit none
-    
+
       ! Arguments
       real, intent(in) :: i, j
       real, intent(out) :: lat, lon
@@ -1513,7 +1513,7 @@ MODULE module_llxy
       real :: deltalon
       real :: i_work, j_work
 
-      i_work = i - proj%knowni 
+      i_work = i - proj%knowni
       j_work = j - proj%knownj
 
       if (i_work < 0.)              i_work = i_work + 360./proj%loninc
@@ -1566,7 +1566,7 @@ MODULE module_llxy
    SUBROUTINE llij_cassini(lat, lon, proj, i, j)
 
       implicit none
-    
+
       ! Arguments
       real, intent(in) :: lat, lon
       real, intent(out) :: i, j
@@ -1590,9 +1590,9 @@ MODULE module_llxy
 
 
    SUBROUTINE ijll_cassini(i, j, proj, lat, lon)
-   
+
       implicit none
-    
+
       ! Arguments
       real, intent(in) :: i, j
       real, intent(out) :: lat, lon
@@ -1617,7 +1617,7 @@ MODULE module_llxy
 
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    ! Purpose: Converts between computational and geographic lat/lon for Cassini
-   !          
+   !
    ! Notes: This routine was provided by Bill Skamarock, 2007-03-27
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    SUBROUTINE rotate_coords(ilat,ilon,olat,olon,lat_np,lon_np,lon_0,direction)
@@ -1674,15 +1674,15 @@ MODULE module_llxy
 
 
    SUBROUTINE llij_rotlatlon(lat, lon, proj, i_real, j_real)
-   
+
       IMPLICIT NONE
-    
+
       ! Arguments
       REAL, INTENT(IN) :: lat, lon
       REAL             :: i, j
       REAL, INTENT(OUT) :: i_real, j_real
       TYPE (proj_info), INTENT(IN) :: proj
-      
+
       ! Local variables
       INTEGER :: ii,imt,jj,jmt,k,krows,ncol,nrow,iri
       REAL(KIND=HIGH) :: dphd,dlmd !Grid increments, degrees
@@ -1694,14 +1694,14 @@ MODULE module_llxy
 
       glatd = lat
       glond = -lon
-  
+
       dphd = proj%phi/REAL((proj%jydim-1)/2)
       dlmd = proj%lambda/REAL(proj%ixdim-1)
 
       pi = ACOS(-1.0)
       d2r = pi/180.
       r2d = 1./d2r
-  
+
       imt = 2*proj%ixdim-1
       jmt = proj%jydim/2+1
 
@@ -1711,7 +1711,7 @@ MODULE module_llxy
       dlm = dlmd*d2r
       tph0 = proj%lat1*d2r
       tlm0 = -proj%lon1*d2r
-  
+
       x = COS(tph0)*COS(glat)*COS(glon-tlm0)+SIN(tph0)*SIN(glat)
       y = -COS(glat)*SIN(glon-tlm0)
       z = COS(tph0)*SIN(glat)-SIN(tph0)*COS(glat)*COS(glon-tlm0)
@@ -1736,7 +1736,7 @@ MODULE module_llxy
       tlat = tlat*d2r
       tlon = tlon*d2r
 
-  
+
       IF (proj%stagger == HH) THEN
 
          IF (mod(nrow,2) .eq. 0) then
@@ -1746,7 +1746,7 @@ MODULE module_llxy
          ENDIF
          j_real=row
 
-  
+
          IF ((abs(MOD(nrow,2)) == 1 .AND. abs(MOD(ncol,2)) == 1) .OR. &
              (MOD(nrow,2) == 0 .AND. MOD(ncol,2) == 0)) THEN
 
@@ -1764,7 +1764,7 @@ MODULE module_llxy
                nrow = nrow+1
                ncol = ncol+1
             END IF
-   
+
          ELSE
             tlat1 = (nrow+1-jmt)*dph
             tlat2 = tlat1-dph
@@ -1781,16 +1781,16 @@ MODULE module_llxy
                ncol = ncol+1
             END IF
          END IF
-  
+
       ELSE IF (proj%stagger == VV) THEN
 
          IF (mod(nrow,2) .eq. 0) then
             i_real = col / 2.0 + 0.5
          ELSE
-            i_real = col / 2.0 
+            i_real = col / 2.0
          ENDIF
          j_real=row
-  
+
          IF ((MOD(nrow,2) == 0 .AND. abs(MOD(ncol,2)) == 1) .OR. &
              (abs(MOD(nrow,2)) == 1 .AND. MOD(ncol,2) == 0)) THEN
             tlat1 = (nrow-jmt)*dph
@@ -1801,12 +1801,12 @@ MODULE module_llxy
             dlm2 = tlon-tlon2
             d1 = ACOS(COS(tlat)*COS(tlat1)*COS(dlm1)+SIN(tlat)*SIN(tlat1))
             d2 = ACOS(COS(tlat)*COS(tlat2)*COS(dlm2)+SIN(tlat)*SIN(tlat2))
-    
+
             IF (d1 > d2) THEN
                nrow = nrow+1
                ncol = ncol+1
             END IF
-   
+
          ELSE
             tlat1 = (nrow+1-jmt)*dph
             tlat2 = tlat1-dph
@@ -1816,7 +1816,7 @@ MODULE module_llxy
             dlm2 = tlon-tlon2
             d1 = ACOS(COS(tlat)*COS(tlat1)*COS(dlm1)+SIN(tlat)*SIN(tlat1))
             d2 = ACOS(COS(tlat)*COS(tlat2)*COS(dlm2)+SIN(tlat)*SIN(tlat2))
-    
+
             IF (d1 < d2) THEN
                nrow = nrow+1
             ELSE
@@ -1824,7 +1824,7 @@ MODULE module_llxy
             END IF
          END IF
       END IF
-  
+
 
 !!! Added next line as a Kludge - not yet understood why needed
       if (ncol .le. 0) ncol=ncol-1
@@ -1845,14 +1845,14 @@ MODULE module_llxy
 
 
    SUBROUTINE ijll_rotlatlon(i, j, proj, lat,lon)
-   
+
       IMPLICIT NONE
-    
+
       ! Arguments
       REAL, INTENT(IN) :: i, j
       REAL, INTENT(OUT) :: lat, lon
       TYPE (proj_info), INTENT(IN) :: proj
-      
+
       ! Local variables
       INTEGER :: ih,jh
       INTEGER :: midcol,midrow,ncol,iadd1,iadd2,imt,jh2,knrow,krem,kv,nrow
@@ -1864,16 +1864,16 @@ MODULE module_llxy
 
       i_work = i
       j_work = j
-  
+
       if ( (j - INT(j)) .gt. 0.999) then
          j_work = j + 0.0002
       endif
 
       jh = INT(j_work)
-  
+
       dphd = proj%phi/REAL((proj%jydim-1)/2)
       dlmd = proj%lambda/REAL(proj%ixdim-1)
-    
+
       pi = ACOS(-1.0)
       d2r = pi/180.
       r2d = 1./d2r
@@ -1894,19 +1894,19 @@ MODULE module_llxy
              tlond = tlond + DLMD
           end if
        END IF
-    
+
       tlatr = tlatd*d2r
       tlonr = tlond*d2r
       arg1 = SIN(tlatr)*COS(tph0)+COS(tlatr)*SIN(tph0)*COS(tlonr)
       glatr = ASIN(arg1)
-     
+
       glatd = glatr*r2d
-     
+
       arg2 = COS(tlatr)*COS(tlonr)/(COS(glatr)*COS(tph0))-TAN(glatr)*TAN(tph0)
       IF (ABS(arg2) > 1.) arg2 = ABS(arg2)/arg2
       fctr = 1.
       IF (tlond > 0.) fctr = -1.
-     
+
       glond = tlm0*r2d+fctr*ACOS(arg2)*r2d
 
       lat = glatd
@@ -1914,41 +1914,41 @@ MODULE module_llxy
 
       IF (lon .GT. +180.) lon = lon - 360.
       IF (lon .LT. -180.) lon = lon + 360.
-   
+
    END SUBROUTINE ijll_rotlatlon
 
 
    SUBROUTINE set_gauss(proj)
-    
+
       IMPLICIT NONE
- 
+
       ! Argument
       type (proj_info), intent(inout) :: proj
- 
+
       !  Initialize the array that will hold the Gaussian latitudes.
- 
+
       IF ( ASSOCIATED( proj%gauss_lat ) ) THEN
          DEALLOCATE ( proj%gauss_lat )
       END IF
- 
+
       !  Get the needed space for our array.
- 
+
       ALLOCATE ( proj%gauss_lat(proj%nlat*2) )
- 
+
       !  Compute the Gaussian latitudes.
- 
+
       CALL gausll( proj%nlat*2 , proj%gauss_lat )
- 
+
       !  Now, these could be upside down from what we want, so let's check.
       !  We take advantage of the equatorial symmetry to remove any sort of
       !  array re-ordering.
- 
+
       IF ( ABS(proj%gauss_lat(1) - proj%lat1) .GT. 0.01 ) THEN
          proj%gauss_lat = -1. * proj%gauss_lat
       END IF
- 
+
       !  Just a sanity check.
- 
+
       IF ( ABS(proj%gauss_lat(1) - proj%lat1) .GT. 0.01 ) THEN
          PRINT '(A)','Oops, something is not right with the Gaussian latitude computation.'
          PRINT '(A,F8.3,A)','The input data gave the starting latitude as ',proj%lat1,'.'
@@ -1956,124 +1956,124 @@ MODULE module_llxy
          PRINT '(A,F8.3,A)','The difference is larger than 0.01 degrees, which is not expected.'
          STOP 'Gaussian_latitude_computation'
       END IF
- 
+
    END SUBROUTINE set_gauss
 
 
    SUBROUTINE gausll ( nlat , lat_sp )
- 
+
       IMPLICIT NONE
-   
+
       INTEGER                            :: nlat , i
       REAL (KIND=HIGH) , PARAMETER       :: pi = 3.141592653589793
       REAL (KIND=HIGH) , DIMENSION(nlat) :: cosc , gwt , sinc , colat , wos2 , lat
       REAL             , DIMENSION(nlat) :: lat_sp
-   
+
       CALL lggaus(nlat, cosc, gwt, sinc, colat, wos2)
-   
+
       DO i = 1, nlat
          lat(i) = ACOS(sinc(i)) * 180._HIGH / pi
          IF (i.gt.nlat/2) lat(i) = -lat(i)
       END DO
-   
+
       lat_sp = REAL(lat)
- 
+
    END SUBROUTINE gausll
 
 
    SUBROUTINE lggaus( nlat, cosc, gwt, sinc, colat, wos2 )
- 
+
       IMPLICIT NONE
- 
+
       !  LGGAUS finds the Gaussian latitudes by finding the roots of the
       !  ordinary Legendre polynomial of degree NLAT using Newton's
       !  iteration method.
-      
+
       !  On entry:
             integer NLAT ! the number of latitudes (degree of the polynomial)
-      
+
       !  On exit: for each Gaussian latitude
       !     COSC   - cos(colatitude) or sin(latitude)
       !     GWT    - the Gaussian weights
       !     SINC   - sin(colatitude) or cos(latitude)
       !     COLAT  - the colatitudes in radians
       !     WOS2   - Gaussian weight over sin**2(colatitude)
- 
+
       REAL (KIND=HIGH) , DIMENSION(nlat) :: cosc , gwt , sinc , colat  , wos2 
       REAL (KIND=HIGH) , PARAMETER       :: pi = 3.141592653589793
- 
+
       !  Convergence criterion for iteration of cos latitude
- 
+
       REAL , PARAMETER :: xlim  = 1.0E-14
- 
+
       INTEGER :: nzero, i, j
       REAL (KIND=HIGH) :: fi, fi1, a, b, g, gm, gp, gt, delta, c, d
- 
+
       !  The number of zeros between pole and equator
- 
+
       nzero = nlat/2
- 
+
       !  Set first guess for cos(colat)
- 
+
       DO i=1,nzero
          cosc(i) = SIN( (i-0.5)*pi/nlat + pi*0.5 )
       END DO
- 
+
       !  Constants for determining the derivative of the polynomial
       fi  = nlat
       fi1 = fi+1.0
       a   = fi*fi1 / SQRT(4.0*fi1*fi1-1.0)
       b   = fi1*fi / SQRT(4.0*fi*fi-1.0)
- 
+
       !  Loop over latitudes, iterating the search for each root
- 
+
       DO i=1,nzero
          j=0
- 
+
          !  Determine the value of the ordinary Legendre polynomial for
          !  the current guess root
- 
+
          DO
             CALL lgord( g, cosc(i), nlat )
-   
+
             !  Determine the derivative of the polynomial at this point
-   
+
             CALL lgord( gm, cosc(i), nlat-1 )
             CALL lgord( gp, cosc(i), nlat+1 )
             gt = (cosc(i)*cosc(i)-1.0) / (a*gp-b*gm)
-   
+
             !  Update the estimate of the root
-   
+
             delta   = g*gt
             cosc(i) = cosc(i) - delta
-   
+
             !  If convergence criterion has not been met, keep trying
-   
+
             j = j+1
             IF( ABS(delta).GT.xlim ) CYCLE
-   
+
             !  Determine the Gaussian weights
-   
+
             c      = 2.0 *( 1.0-cosc(i)*cosc(i) )
             CALL lgord( d, cosc(i), nlat-1 )
             d      = d*d*fi*fi
             gwt(i) = c *( fi-0.5 ) / d
             EXIT
- 
+
          END DO
- 
+
       END DO
- 
+
       !  Determine the colatitudes and sin(colat) and weights over sin**2
- 
+
       DO i=1,nzero
          colat(i)= ACOS(cosc(i))
          sinc(i) = SIN(colat(i))
          wos2(i) = gwt(i) /( sinc(i)*sinc(i) )
       END DO
- 
+
       !  If NLAT is odd, set values at the equator
- 
+
       IF( MOD(nlat,2) .NE. 0 ) THEN
          i       = nzero+1
          cosc(i) = 0.0
@@ -2085,9 +2085,9 @@ MODULE module_llxy
          sinc(i) = 1.0
          wos2(i) = gwt(i)
       END IF
- 
+
       !  Determine the southern hemisphere values by symmetry
- 
+
       DO i=nlat-nzero+1,nlat
          cosc(i) =-cosc(nlat+1-i)
          gwt(i)  = gwt(nlat+1-i)
@@ -2095,37 +2095,37 @@ MODULE module_llxy
          sinc(i) = sinc(nlat+1-i)
          wos2(i) = wos2(nlat+1-i)
       END DO
- 
+
    END SUBROUTINE lggaus
 
 
    SUBROUTINE lgord( f, cosc, n )
- 
+
       IMPLICIT NONE
- 
+
       !  LGORD calculates the value of an ordinary Legendre polynomial at a
       !  specific latitude.
-      
+
       !  On entry:
       !     cosc - COS(colatitude)
       !     n      - the degree of the polynomial
-      
+
       !  On exit:
       !     f      - the value of the Legendre polynomial of degree N at
       !              latitude ASIN(cosc)
- 
+
       REAL (KIND=HIGH) :: s1, c4, a, b, fk, f, cosc, colat, c1, fn, ang
       INTEGER :: n, k
- 
+
       !  Determine the colatitude
- 
+
       colat = ACOS(cosc)
- 
+
       c1 = SQRT(2.0_HIGH)
       DO k=1,n
          c1 = c1 * SQRT( 1.0 - 1.0/(4*k*k) )
       END DO
- 
+
       fn = n
       ang= fn * colat
       s1 = 0.0
@@ -2140,35 +2140,35 @@ MODULE module_llxy
          fk = k
          ang= colat * (fn-fk-2.0)
          c4 = ( a * (fn-b+1.0) / ( b * (fn+fn-a) ) ) * c4
-      END DO 
- 
+      END DO
+
       f = s1 * c1
- 
+
    END SUBROUTINE lgord
 
 
-   SUBROUTINE llij_gauss (lat, lon, proj, i, j) 
- 
+   SUBROUTINE llij_gauss (lat, lon, proj, i, j)
+
       IMPLICIT NONE
- 
+
       REAL    , INTENT(IN)  :: lat, lon
       REAL    , INTENT(OUT) :: i, j
       TYPE (proj_info), INTENT(IN) :: proj
- 
+
       INTEGER :: n , n_low
       LOGICAL :: found = .FALSE.
       REAL    :: diff_1 , diff_nlat
- 
+
       !  The easy one first, get the x location.  The calling routine has already made
       !  sure that the necessary assumptions concerning the sign of the deltalon and the
       !  relative east/west'ness of the longitude and the starting longitude are consistent
       !  to allow this easy computation.
- 
+
       i = ( lon - proj%lon1 ) / proj%loninc + 1.
- 
+
       !  Since this is a global data set, we need to be concerned about wrapping the
       !  fields around the globe.
- 
+
 !      IF      ( ( proj%loninc .GT. 0 ) .AND. &
 !                ( FLOOR((lon-proj%lon1)/proj%loninc) + 1 .GE. proj%ixdim ) .AND. &
 !                ( lon + proj%loninc .GE. proj%lon1 + 360 ) ) THEN
@@ -2184,27 +2184,27 @@ MODULE module_llxy
 ! !        proj%wrap = .TRUE.
 !         i = proj%ixdim
 !      END IF
- 
+
       !  Yet another quicky test, can we find bounding values?  If not, then we may be
       !  dealing with putting data to a polar projection, so just give them them maximal
       !  value for the location.  This is an OK assumption for the interpolation across the
       !  top of the pole, given how close the longitude lines are.
- 
+
       IF ( ABS(lat) .GT. ABS(proj%gauss_lat(1)) ) THEN
- 
+
          diff_1    = lat - proj%gauss_lat(1)
          diff_nlat = lat - proj%gauss_lat(proj%nlat*2)
- 
+
          IF ( ABS(diff_1) .LT. ABS(diff_nlat) ) THEN
             j = 1
          ELSE
             j = proj%nlat*2
          END IF
- 
+
       !  If the latitude is between the two bounding values, we have to search and interpolate.
- 
+
       ELSE
- 
+
          DO n = 1 , proj%nlat*2 -1
             IF ( ( proj%gauss_lat(n) - lat ) * ( proj%gauss_lat(n+1) - lat ) .LE. 0 ) THEN
                found = .TRUE.
@@ -2212,20 +2212,20 @@ MODULE module_llxy
                EXIT
             END IF
          END DO
- 
+
          !  Everything still OK?
-  
+
          IF ( .NOT. found ) THEN
             PRINT '(A)','Troubles in river city.  No bounding values of latitude found in the Gaussian routines.'
             STOP 'Gee_no_bounding_lats_Gaussian'
          END IF
- 
+
          j = ( ( proj%gauss_lat(n_low) - lat                     ) * ( n_low + 1 ) + &
                ( lat                   - proj%gauss_lat(n_low+1) ) * ( n_low     ) ) / &
                ( proj%gauss_lat(n_low) - proj%gauss_lat(n_low+1) )
- 
+
       END IF
 
-   END SUBROUTINE llij_gauss 
-  
+   END SUBROUTINE llij_gauss
+
 END MODULE module_llxy

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_mapinfo.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_mapinfo.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_mapinfo

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_wrfinputfile.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/module_wrfinputfile.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_wrfinputfile
@@ -46,8 +46,8 @@ module module_wrfinputfile
 contains
 
   subroutine read_wrfinput_file(flnm, wrfinput, ierr)
-    ! 
-    ! Reads the wrfinput file identified by <flnm>, and fills out 
+    !
+    ! Reads the wrfinput file identified by <flnm>, and fills out
     ! the <wrfinput> structure with the appropriate values.
     !
     implicit none
@@ -108,7 +108,7 @@ contains
     allocate(wrfinput%ter(wrfinput%idim, wrfinput%jdim))
     call get_2d("HGT", ncid, wrfinput%ter, wrfinput%idim, wrfinput%jdim)
 
-    ! Get Land Use categories 
+    ! Get Land Use categories
     allocate(wrfinput%use(wrfinput%idim, wrfinput%jdim))
     call get_2d("IVGTYP", ncid, wrfinput%use, wrfinput%idim, wrfinput%jdim)
 
@@ -240,7 +240,7 @@ contains
 
   subroutine get_2d(name, ncid, array, idim, jdim)
     !
-    ! From the NetCDF unit <ncid>, read the variable named <name> with  
+    ! From the NetCDF unit <ncid>, read the variable named <name> with
     ! dimensions <idim> and <jdim>, filling the pre-dimensioned array <array>
     !
     implicit none

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/swap4f.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/swap4f.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 subroutine swap4f(in,nn)
@@ -39,7 +39,7 @@ subroutine swap4f(in,nn)
      ia = in(i+(nbytes-1):i:-1)
      in(i:i+(nbytes-1)) = ia
   enddo
-	
+
 #endif
 end
 !KWM -------------------------------------------------------------------------
@@ -102,8 +102,8 @@ end
 !KWM	data l/32/,u/127/
 !KWM	do 10 i=1,in
 !KWM	n(i)=m(i)
-!KWM	if(n(i).lt.  l) n(i)=l  
-!KWM	if(n(i).gt.  u) n(i)=u   
+!KWM	if(n(i).lt.  l) n(i)=l
+!KWM	if(n(i).gt.  u) n(i)=u
 !KWM   10	continue
 !KWM	return
 !KWM#endif

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/trig_degrees.F
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/trig_degrees.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !

--- a/src/Land_models/Noah/IO_code/module_hrldas_netcdf_io.F
+++ b/src/Land_models/Noah/IO_code/module_hrldas_netcdf_io.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_hrldas_netcdf_io
@@ -77,10 +77,10 @@ contains
 
     ! Check that output directory OUTDIR exists and is writable, by
     ! trying to open a test file in that directory.  Include a random
-    ! number in the test file name, to greatly reduce the chance of 
-    ! collision with existing file names.  This assumes that the 
-    ! intrinsic random_seed routine, called without argument, will seed 
-    ! the random number generator based on something like system time 
+    ! number in the test file name, to greatly reduce the chance of
+    ! collision with existing file names.  This assumes that the
+    ! intrinsic random_seed routine, called without argument, will seed
+    ! the random number generator based on something like system time
     ! or hardware noise.
 
     integer,          intent(in) :: rank
@@ -227,7 +227,7 @@ contains
     integer :: i
     integer :: rank
 
-#ifdef _PARALLEL_  
+#ifdef _PARALLEL_
     call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
 #else
@@ -289,7 +289,7 @@ contains
 
     ierr = nf90_get_att(ncid, NF90_GLOBAL, "MMINLU", llanduse)
     call error_handler(ierr, failure="READ_HRLDAS_HDRINFO:  Problems finding global attribute 'MMINLU'")
-    
+
     ! IBM XLF seems to need something like this:
     do i = 1, 256
        if (ichar(llanduse(i:i)) == 0) llanduse(i:i) = " "
@@ -350,7 +350,7 @@ contains
     real, dimension(xstart:xend,ystart:yend) :: xdum
     integer :: rank
 
-#ifdef _PARALLEL_  
+#ifdef _PARALLEL_
     call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
 #else
@@ -487,7 +487,7 @@ contains
     ! FATAL_IF_ERROR:  an input code value:
     !      .TRUE. if an error in reading the data should stop the program.
     !      Otherwise the, IERR error flag is set, but the program continues.
-    logical, intent(in) :: fatal_if_error 
+    logical, intent(in) :: fatal_if_error
     integer, intent(out) :: ierr
 
     units = " "
@@ -543,7 +543,7 @@ contains
     ! FATAL_IF_ERROR:  an input code value:
     !      .TRUE. if an error in reading the data should stop the program.
     !      Otherwise the, IERR error flag is set, but the program continues.
-    logical, intent(in) :: fatal_if_error 
+    logical, intent(in) :: fatal_if_error
     integer, intent(out) :: ierr
     real, intent(out) :: layer_bottom
     real, intent(out) :: layer_top
@@ -601,7 +601,7 @@ contains
     integer,                                           intent(in)  :: nsoil
     real,    dimension(nsoil),                         intent(in)  :: sldpth
     character(len=*),                                  intent(in)  :: target_date
-    
+
     integer,                                           intent(out) :: ldasin_version
     real,    dimension(xstart:xend,ystart:yend,nsoil), intent(out) :: smc
     real,    dimension(xstart:xend,ystart:yend,nsoil), intent(out) :: stc
@@ -760,7 +760,7 @@ contains
     integer :: ierr
     integer :: rank
 
-#ifdef _PARALLEL_    
+#ifdef _PARALLEL_
     call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
 #else
@@ -786,7 +786,7 @@ contains
 
        if (dst_centerpoint(k) < src_centerpoint(1)) then
           ! If the center of the destination layer is closer to the surface than
-          ! the center of the topmost source layer, then simply set the 
+          ! the center of the topmost source layer, then simply set the
           ! value of the destination layer equal to the topmost source layer:
           if (rank == 0) then
              print'("Shallow destination layer:  Taking destination layer at ",F7.4, " from source layer at ", F7.4)', &
@@ -798,7 +798,7 @@ contains
 
        if (dst_centerpoint(k) > src_centerpoint(nvar)) then
           ! If the center of the destination layer is deeper than
-          ! the center of the deepest source layer, then simply set the 
+          ! the center of the deepest source layer, then simply set the
           ! value of the destination layer equal to the deepest source layer:
           if (rank == 0) then
              print'("Deep destination layer:  Taking destination layer at ",F7.4, " from source layer at ", F7.4)', &
@@ -860,7 +860,7 @@ contains
        var(:,:,k) = (src(:,:,ktop)*fraction) + (src(:,:,kbottom)*(1.0-fraction))
 
     enddo KLOOP
-     
+
   end subroutine init_interp
 
 !---------------------------------------------------------------------------------------------------------
@@ -988,7 +988,7 @@ contains
 
           ! Copy nextread to lastread
           lastread = nextread
-       
+
           ! Clear nextread
           call nullify_inputstruct(nextread)
        endif
@@ -1523,7 +1523,7 @@ contains
 
     output_count_remember = output_count_remember + 1
     if (output_count_remember == split_output_count) then
-       output_count_remember = 0 
+       output_count_remember = 0
        ierr = nf90_close(ncid_remember)
        call error_handler(ierr, failure="Problem nf90_close for output file")
     else
@@ -1547,7 +1547,7 @@ contains
     if (define_mode_remember) then
        call make_var_att_2d ( ncid_remember , dimid_ix_remember , dimid_jx_remember , dimid_times_remember , &
             NF90_FLOAT , trim(name) , trim(description) , trim(units) )
-    else 
+    else
        ixpar = size(array,1)
        jxpar = size(array,2)
        call put_var_2d (ncid_remember , output_count_remember+1 , vegtyp_remember , iswater_remember , &
@@ -1587,7 +1587,7 @@ contains
     if (define_mode_remember) then
        call make_var_att_3d ( ncid_remember , dimid_ix_remember , dimid_jx_remember , dimid_times_remember , &
             NF90_FLOAT , dimid_layers_remember, trim(name) , trim(description) , trim(units) )
-    else 
+    else
 
        ixpar = size(array,1)
        jxpar = size(array,2)
@@ -1783,7 +1783,7 @@ contains
     restart_filename_remember = " "
     iswater_remember   = -999999
     xstartpar_remember = -999999
-    
+
   end subroutine finalize_restart_file
 
 !---------------------------------------------------------------------------------------------------------
@@ -1959,7 +1959,7 @@ contains
     else
        local_description = "-"
     endif
-    
+
 #ifdef _PARALLEL_
     ierr = nf90_open_par(trim(output_flnm), NF90_WRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
@@ -2033,7 +2033,7 @@ contains
     else
        local_description = "-"
     endif
-    
+
 #ifdef _PARALLEL_
     ierr = nf90_open_par(trim(output_flnm), NF90_WRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
@@ -2110,7 +2110,7 @@ contains
     else
        local_description = "-"
     endif
-    
+
 #ifdef _PARALLEL_
     ierr = nf90_open_par(trim(output_flnm), NF90_WRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
@@ -2273,7 +2273,7 @@ contains
        endif
 
 #ifdef _HRLDAS_URBAN_
-       
+
        ierr = nf90_get_att(ncid, NF90_GLOBAL, "UCMCALL", read_ucmcall)
        call error_handler(ierr, "Problem getting UCMCALL as attribute of restart file")
        if (read_ucmcall /= ucmcall) then
@@ -2311,7 +2311,7 @@ contains
        ! Get the time stamp from the restart file.
        ierr = nf90_inq_varid(ncid, "Times", varid)
        call error_handler(ierr, "Problem finding variable in restart file: 'Times'")
-       
+
        ierr = nf90_get_var(ncid, varid, olddate)
        call error_handler(ierr, "Problem finding variable in restart file: 'Times'")
 
@@ -2382,7 +2382,7 @@ contains
 
     ierr = nf90_close(ncid)
     call error_handler(ierr, "Problem closing restart file")
-    
+
   end subroutine get_from_restart_2d_float
 
 !-----------------------------------------------------------------------------------------
@@ -2437,7 +2437,7 @@ contains
 
     ierr = nf90_close(ncid)
     call error_handler(ierr, "Problem closing restart file")
-    
+
   end subroutine get_from_restart_2d_integer
 
 !-----------------------------------------------------------------------------------------
@@ -2492,7 +2492,7 @@ contains
 
     ierr = nf90_close(ncid)
     call error_handler(ierr, "Problem closing restart file")
-    
+
   end subroutine get_from_restart_3d
 
 !-----------------------------------------------------------------------------------------

--- a/src/Land_models/Noah/Noah/module_sf_noahlsm.F
+++ b/src/Land_models/Noah/Noah/module_sf_noahlsm.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 MODULE module_sf_noahlsm
@@ -305,7 +305,7 @@ CONTAINS
 !   SOILM      TOTAL SOIL COLUMN MOISTURE CONTENT (FROZEN+UNFROZEN) (M)
 !   Q1         Effective mixing ratio at surface (kg kg-1), used for
 !              diagnosing the mixing ratio at 2 meter for coupled model
-!   SMAV       Soil Moisture Availability for each layer, as a fraction 
+!   SMAV       Soil Moisture Availability for each layer, as a fraction
 !              between SMCWLT and SMCMAX.
 !  Documentation for SNOTIME1 and SNOABL2 ?????
 !  What categories of arguments do these variables fall into ????
@@ -355,7 +355,7 @@ CONTAINS
       real, intent(in)                       :: qlowbdry
       integer, intent(in)                    :: gwsoilcpl
       !BF end
-      
+
       REAL, INTENT(IN)   :: SHDMIN,SHDMAX,DT,DQSDT2,LWDN,PRCP,PRCPRAIN,     &
                             Q2,Q2SAT,SFCPRS,SFCSPD,SFCTMP, SNOALB,          &
                             SOLDN,SOLNET,TBOT,TH2,ZLVL,                            &
@@ -896,7 +896,7 @@ CONTAINS
       ET(K) = ET(K) * LVH2O
       ENDDO
       ETT = ETT * LVH2O
-      
+
       ETPND1=ETPND1 * LVH2O
 
       ESNOW = ESNOW * LSUBS
@@ -1498,7 +1498,7 @@ CONTAINS
 ! ----------------------------------------------------------------------
 
   SUBROUTINE FAC2MIT(SMCMAX,FLIMIT)
-    IMPLICIT NONE		
+    IMPLICIT NONE
     REAL, INTENT(IN)  :: SMCMAX
     REAL, INTENT(OUT) :: FLIMIT
 
@@ -2882,7 +2882,7 @@ CONTAINS
                     DWSAT,DKSAT,SMCMAX,BEXP,RUNOFF1,                    &
                     RUNOFF2,DT,SMCWLT,SLOPE,KDT,FRZFACT,SICE,AI,BI,CI,  &
                     SFHEAD1RT,INFXS1RT, &
-		    gwsoilcpl, qlowbdry) 
+		    gwsoilcpl, qlowbdry)
          CALL SSTEP (SH2OFG,SH2O,DUMMY,RHSTT,RHSCT,DT,NSOIL,SMCMAX,     &
                         CMCMAX,RUNOFF3,ZSOIL,SMC,SICE,AI,BI,CI,INFXS1RT)
          DO K = 1,NSOIL
@@ -3609,10 +3609,10 @@ CONTAINS
       BURIAL = 7.0*Z0BRD - SNOWH
       IF(BURIAL.LE.0.0007) THEN
         Z0EFF = Z0S
-      ELSE      
+      ELSE
         Z0EFF = BURIAL/7.0
       ENDIF
-      
+
       Z0 = (1.- SNCOVR)* Z0BRD + SNCOVR * Z0EFF
 
 ! ----------------------------------------------------------------------
@@ -3933,17 +3933,17 @@ select case(gwsoilcpl)
 case(2)
         if(K .eq. nsoil) then
          NUMER = (WDF2 * DSMDZ2) - qLowBdry - (WDF * DSMDZ) - WCND + ET (K)  
-  else 
+  else
         ! withdrawal has positive sign (e.g. ET), replenishment has negative sign (e.g. qlowbdry)
          NUMER = (WDF2 * DSMDZ2) + SLOPX * WCND2- (WDF * DSMDZ)         &
                  - WCND+ ET (K)
   end if
 
-case default  
- 
+case default
+
          NUMER = (WDF2 * DSMDZ2) + SLOPX * WCND2- (WDF * DSMDZ)         &
                  - WCND+ ET (K)
- 
+
 
 end select
 ! ----------------------------------------------------------------------
@@ -3962,13 +3962,13 @@ end select
 !BF gwsoil coupling
 select case (gwsoilcpl)
  case(2)
-            RUNOFF2 = -qLowBdry  
+            RUNOFF2 = -qLowBdry
 
  case default
 	    RUNOFF2 = SLOPX * WCND2
 
 end select
-	    
+
          END IF
          IF (K .ne. NSOIL) THEN
             WDF = WDF2

--- a/src/Land_models/Noah/Noah/module_sf_urban.F
+++ b/src/Land_models/Noah/Noah/module_sf_urban.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 MODULE module_sf_urban
@@ -87,7 +87,7 @@ MODULE module_sf_urban
    REAL, DIMENSION(1:24)           :: ahdiuprf        ! ah diurnal profile, tloc: 1-24
    REAL, DIMENSION(1:24)           :: hsequip_tbl
 
-   INTEGER                         :: allocate_status 
+   INTEGER                         :: allocate_status
 
 !   INTEGER                         :: num_roof_layers
 !   INTEGER                         :: num_wall_layers
@@ -124,7 +124,7 @@ MODULE module_sf_urban
 ! Input Data from WRF [MKS unit]:
 !
 !     UTYPE  [-]     : Urban type. 1=Commercial/Industrial; 2=High-intensity residential; 
-!                    : 3=low-intensity residential 
+!                    : 3=low-intensity residential
 !     TA     [K]     : Potential temperature at 1st wrf level (absolute temp)
 !     QA     [kg/kg] : Mixing ratio at 1st atmospheric level
 !     UA     [m/s]   : Wind speed at 1st atmospheric level
@@ -134,15 +134,15 @@ MODULE module_sf_urban
 !                      single solar downward can be used instead.
 !                      SSG = SSGD + SSGQ
 !     LSOLAR [-]     : Indicating the input type of solar downward radiation
-!                      True: both direct and diffusive solar radiation 
+!                      True: both direct and diffusive solar radiation
 !                      are available
 !                      False: only total downward ridiation is available.
 !     SSGD   [W/m/m] : Direct solar radiation at a flat surface
 !                      if SSGD is not available, one can assume a ratio SRATIO
-!                      (e.g., 0.7), so that SSGD = SRATIO*SSG 
+!                      (e.g., 0.7), so that SSGD = SRATIO*SSG
 !     SSGQ   [W/m/m] : Diffuse solar radiation at a flat surface
 !                      If SSGQ is not available, SSGQ = SSG - SSGD
-!     LLG    [W/m/m] : Long wave downward radiation at a flat surface 
+!     LLG    [W/m/m] : Long wave downward radiation at a flat surface
 !     RAIN   [mm/h]  : Precipitation
 !     RHOO   [kg/m/m/m] : Air density
 !     ZA     [m]     : First atmospheric level
@@ -162,10 +162,10 @@ MODULE module_sf_urban
 !     SH  [W/m/m/]       : Sensible heat flux, = FLXTH*RHOO*CPP
 !     LH  [W/m/m]        : Latent heat flux, = FLXHUM*RHOO*ELL
 !     LH_INEMATIC [kg/m/m/sec]: Moisture Kinematic flux, = FLXHUM*RHOO
-!     SW  [W/m/m]        : Upward shortwave radiation flux, 
+!     SW  [W/m/m]        : Upward shortwave radiation flux,
 !                          = SSG-SNET*697.7*60. (697.7*60.=100.*100.*4.186)
 !     ALB [-]            : Time-varying albedo
-!     LW  [W/m/m]        : Upward longwave radiation flux, 
+!     LW  [W/m/m]        : Upward longwave radiation flux,
 !                          = LNET*697.7*60.-LLG
 !     G   [W/m/m]        : Heat Flux into the Ground
 !     RN  [W/m/m]        : Net radiation
@@ -269,7 +269,7 @@ MODULE module_sf_urban
 !     Kusaka et al. (2001) Bound.-Layer Meteor., vol.101, p329-358
 !
 ! History:
-!     2006/06          modified by H. Kusaka (Univ. Tsukuba), M. Tewari 
+!     2006/06          modified by H. Kusaka (Univ. Tsukuba), M. Tewari
 !     2005/10/26,      modified by Fei Chen, Mukul Tewari
 !     2003/07/21 WRF , modified  by H. Kusaka of CRIEPI (NCAR/MMM)
 !     2001/08/26 PhD , modified  by H. Kusaka of CRIEPI (Univ.Tsukuba)
@@ -320,7 +320,7 @@ MODULE module_sf_urban
    LOGICAL, INTENT(IN) :: LSOLAR  ! logical    [true=both, false=SSG only]
 
 !  The following variables are also model configuration variables, but are 
-!  defined in the URBAN.TBL and in the contains statement in the top of 
+!  defined in the URBAN.TBL and in the contains statement in the top of
 !  the module_urban_init, so we should not declare them here.
 
   INTEGER, INTENT(IN) :: num_roof_layers
@@ -366,7 +366,7 @@ MODULE module_sf_urban
    REAL, INTENT(INOUT) :: CHC_URB
 
 !-------------------------------------------------------------------------------
-! O: output variables from Urban to LSM 
+! O: output variables from Urban to LSM
 !-------------------------------------------------------------------------------
 
    REAL, INTENT(OUT) :: TS     ! surface potential temperature    [K]
@@ -381,7 +381,7 @@ MODULE module_sf_urban
    REAL, INTENT(OUT) :: RN     ! net radition                     [W/m/m]
    REAL, INTENT(OUT) :: PSIM   ! similality stability shear function for momentum
    REAL, INTENT(OUT) :: PSIH   ! similality stability shear function for heat
-   REAL, INTENT(OUT) :: GZ1OZ0   
+   REAL, INTENT(OUT) :: GZ1OZ0
    REAL, INTENT(OUT) :: U10    ! u at 10m                         [m/s]
    REAL, INTENT(OUT) :: V10    ! u at 10m                         [m/s]
    REAL, INTENT(OUT) :: TH2    ! potential temperature at 2 m     [K]
@@ -421,15 +421,15 @@ MODULE module_sf_urban
 
    REAL :: ZR, Z0C, Z0HC, ZDC, SVF, R, RW, HGT, AH
    REAL :: SIGMA_ZED
-   REAL :: CAPR, CAPB, CAPG, AKSR, AKSB, AKSG, ALBR, ALBB, ALBG 
+   REAL :: CAPR, CAPB, CAPG, AKSR, AKSB, AKSG, ALBR, ALBB, ALBG
    REAL :: EPSR, EPSB, EPSG, Z0R,  Z0B,  Z0G,  Z0HB, Z0HG
    REAL :: TRLEND,TBLEND,TGLEND
    REAL :: T1VR, T1VC,TH2V
    REAL :: RLMO_URB
    REAL :: AKANDA_URBAN
-   
+
    REAL :: TH2X                                                !m
-   
+
    INTEGER :: BOUNDR, BOUNDB, BOUNDG
    INTEGER :: CH_SCHEME, TS_SCHEME
 
@@ -486,7 +486,7 @@ MODULE module_sf_urban
    REAL :: FAI        ! Latitude [rad]
    REAL :: CNT,SNT
    REAL :: PS         ! Surface Pressure [hPa]
-   REAL :: TAV        ! Vertial Temperature [K] 
+   REAL :: TAV        ! Vertial Temperature [K]
 
    REAL :: XXX, X, Z0, Z0H, CD, CH
    REAL :: XXX2, PSIM2, PSIH2, XXX10, PSIM10, PSIH10
@@ -494,7 +494,7 @@ MODULE module_sf_urban
 
    REAL :: TRP, TBP, TGP, TCP, QCP, TST, QST
 
-   INTEGER :: iteration, K 
+   INTEGER :: iteration, K
    INTEGER :: tloc
 
 #ifdef _HRLDAS_URBAN_
@@ -520,9 +520,9 @@ MODULE module_sf_urban
                    ALBG,EPSR,EPSB,EPSG,Z0R,Z0B,Z0G,Z0HB,Z0HG,     &
                    BETR,BETB,BETG,TRLEND,TBLEND,TGLEND,           &
 !for BEP
-                   NUMDIR, STREET_DIRECTION, STREET_WIDTH,        & 
-                   BUILDING_WIDTH, NUMHGT, HEIGHT_BIN,            & 
-                   HPERCENT_BIN,                                  & 
+                   NUMDIR, STREET_DIRECTION, STREET_WIDTH,        &
+                   BUILDING_WIDTH, NUMHGT, HEIGHT_BIN,            &
+                   HPERCENT_BIN,                                  &
 !end BEP
                    BOUNDR,BOUNDB,BOUNDG,CH_SCHEME,TS_SCHEME,      &
                    AKANDA_URBAN)
@@ -581,7 +581,7 @@ MODULE module_sf_urban
      BB = 0.4 * ZR / ( XLB * alog( ( ZR - ZDC ) / Z0C ) )
      UC=UR*EXP(-BB*(1.-ZC/ZR))
    ELSE
-     ! PRINT *, 'Warning ZR + 2m  is larger than the 1st WRF level' 
+     ! PRINT *, 'Warning ZR + 2m  is larger than the 1st WRF level'
      ZC=ZA/2.
      UC=UA/2.
    END IF
@@ -680,32 +680,32 @@ MODULE module_sf_urban
 
    ! Alternative option for MOST using SFCDIF routine from Noah
    ! Virtual temperatures needed by SFCDIF
-   T1VR = TRP* (1.0+ 0.61 * QA) 
+   T1VR = TRP* (1.0+ 0.61 * QA)
    TH2V = (TA + ( 0.0098 * ZA)) * (1.0+ 0.61 * QA)
-  
+
    ! note that CHR_URB contains UA (=CHR_MOS*UA)
    RLMO_URB=0.0
    CALL SFCDIF_URB (ZA,Z0R,T1VR,TH2V,UA,AKANDA_URBAN,CMR_URB,CHR_URB,RLMO_URB,CDR)
    ALPHAR =  RHO*CP*CHR_URB
    CHR=ALPHAR/RHO/CP/UA
 
-   IF(RAIN > 1.) BETR=0.7  
+   IF(RAIN > 1.) BETR=0.7
 
-   IF (TS_SCHEME == 1) THEN 
+   IF (TS_SCHEME == 1) THEN
 
 !-------------------------------------------------------------------------------
 ! TR  Solving Non-Linear Equation by Newton-Rapson
-! TRL Solving Heat Equation by Tri Diagonal Matrix Algorithm  
+! TRL Solving Heat Equation by Tri Diagonal Matrix Algorithm
 !-------------------------------------------------------------------------------
-!      TSC=TRP-273.15                          
+!      TSC=TRP-273.15
 !      ES=EXP(19.482-4303.4/(TSC+243.5))        ! WMO
 !      ES=6.11*10.**(TETENA*TSC/(TETENB+TSC))   ! Tetens
 !      DESDT=( 6.1078*(2500.-2.4*TSC)/ &        ! Tetens
-!            (0.46151*(TSC+273.15)**2.) )*10.**(7.5*TSC/(237.3+TSC)) 
+!            (0.46151*(TSC+273.15)**2.) )*10.**(7.5*TSC/(237.3+TSC))
 !      ES=6.11*EXP((2.5*10.**6./461.51)*(TRP-273.15)/(273.15*TRP) ) ! Clausius-Clapeyron 
 !      DESDT=(2.5*10.**6./461.51)*ES/(TRP**2.)                      ! Clausius-Clapeyron
-!      QS0R=0.622*ES/(PS-0.378*ES) 
-!      DQS0RDTR = DESDT*0.622*PS/((PS-0.378*ES)**2.) 
+!      QS0R=0.622*ES/(PS-0.378*ES)
+!      DQS0RDTR = DESDT*0.622*PS/((PS-0.378*ES)**2.)
 !      DQS0RDTR = 17.269*(273.15-35.86)/((TRP-35.86)**2.)*QS0R
 
 !    TRP=350.
@@ -714,8 +714,8 @@ MODULE module_sf_urban
 
        ES=6.11*EXP( (2.5*10.**6./461.51)*(TRP-273.15)/(273.15*TRP) )
        DESDT=(2.5*10.**6./461.51)*ES/(TRP**2.)
-       QS0R=0.622*ES/(PS-0.378*ES) 
-       DQS0RDTR = DESDT*0.622*PS/((PS-0.378*ES)**2.) 
+       QS0R=0.622*ES/(PS-0.378*ES)
+       DQS0RDTR = DESDT*0.622*PS/((PS-0.378*ES)**2.)
 
        RR=EPSR*(RX-SIG*(TRP**4.)/60.)
        HR=RHO*CP*CHR*UA*(TRP-TA)*100.
@@ -729,7 +729,7 @@ MODULE module_sf_urban
        DELERDTR = RHO*EL*CHR*UA*BETR*DQS0RDTR*100.
        DG0RDTR =  2.*AKSR/DZR(1)
 
-       DFDT = DRRDTR - DHRDTR - DELERDTR - DG0RDTR 
+       DFDT = DRRDTR - DHRDTR - DELERDTR - DG0RDTR
        DTR = F/DFDT
 
        TR = TRP - DTR
@@ -746,7 +746,7 @@ MODULE module_sf_urban
    ELSE
 
      ES=6.11*EXP( (2.5*10.**6./461.51)*(TRP-273.15)/(273.15*TRP) )
-     QS0R=0.622*ES/(PS-0.378*ES)        
+     QS0R=0.622*ES/(PS-0.378*ES)
 
      RR=EPSR*(RX-SIG*(TRP**4.)/60.)
      HR=RHO*CP*CHR*UA*(TRP-TA)*100.
@@ -763,7 +763,7 @@ MODULE module_sf_urban
    FLXHUMR=ELER/RHO/EL/100.
 
 !-------------------------------------------------------------------------------
-!  Wall and Road 
+!  Wall and Road
 !-------------------------------------------------------------------------------
 
 !-------------------------------------------------------------------------------
@@ -777,12 +777,12 @@ MODULE module_sf_urban
    ! CALL mos(XXXC,ALPHAC,CDC,BHC,RIBC,Z,Z0C,UA,TA,TCP,RHO)
    ! Virtual temperatures needed by SFCDIF routine from Noah
 
-   T1VC = TCP* (1.0+ 0.61 * QA) 
+   T1VC = TCP* (1.0+ 0.61 * QA)
    RLMO_URB=0.0
    CALL SFCDIF_URB(ZA,Z0C,T1VC,TH2V,UA,AKANDA_URBAN,CMC_URB,CHC_URB,RLMO_URB,CDC)
    ALPHAC =  RHO*CP*CHC_URB
 
-   IF (CH_SCHEME == 1) THEN 
+   IF (CH_SCHEME == 1) THEN
 
      Z=ZDC
      BHB=LOG(Z0B/Z0HB)/0.4
@@ -813,7 +813,7 @@ MODULE module_sf_urban
 
 !-------------------------------------------------------------------------------
 !  TB, TG  Solving Non-Linear Simultaneous Equation by Newton-Rapson
-!  TBL,TGL Solving Heat Equation by Tri Diagonal Matrix Algorithm  
+!  TBL,TGL Solving Heat Equation by Tri Diagonal Matrix Algorithm
 !-------------------------------------------------------------------------------
 
 !    TBP=350.
@@ -836,15 +836,15 @@ MODULE module_sf_urban
      DO ITERATION=1,20
 #endif
 
-       ES=6.11*EXP( (2.5*10.**6./461.51)*(TBP-273.15)/(273.15*TBP) ) 
+       ES=6.11*EXP( (2.5*10.**6./461.51)*(TBP-273.15)/(273.15*TBP) )
        DESDT=(2.5*10.**6./461.51)*ES/(TBP**2.)
-       QS0B=0.622*ES/(PS-0.378*ES) 
+       QS0B=0.622*ES/(PS-0.378*ES)
        DQS0BDTB=DESDT*0.622*PS/((PS-0.378*ES)**2.)
 
-       ES=6.11*EXP( (2.5*10.**6./461.51)*(TGP-273.15)/(273.15*TGP) ) 
+       ES=6.11*EXP( (2.5*10.**6./461.51)*(TGP-273.15)/(273.15*TGP) )
        DESDT=(2.5*10.**6./461.51)*ES/(TGP**2.)
-       QS0G=0.622*ES/(PS-0.378*ES)        
-       DQS0GDTG=DESDT*0.22*PS/((PS-0.378*ES)**2.) 
+       QS0G=0.622*ES/(PS-0.378*ES)
+       DQS0GDTG=DESDT*0.22*PS/((PS-0.378*ES)**2.)
 
        RG1=EPSG*( RX*VFGS          &
        +EPSB*VFGW*SIG*TBP**4./60.  &
@@ -915,12 +915,12 @@ MODULE module_sf_urban
        DG0GDTB=0.
 
        F = SB + RB - HB - ELEB - G0B
-       FX = DRBDTB - DHBDTB - DELEBDTB - DG0BDTB 
+       FX = DRBDTB - DHBDTB - DELEBDTB - DG0BDTB
        FY = DRBDTG - DHBDTG - DELEBDTG - DG0BDTG
 
        GF = SG + RG - HG - ELEG - G0G
        GX = DRGDTB - DHGDTB - DELEGDTB - DG0GDTB
-       GY = DRGDTG - DHGDTG - DELEGDTG - DG0GDTG 
+       GY = DRGDTG - DHGDTG - DELEGDTG - DG0GDTG
 
 #ifdef _HRLDAS_URBAN_
        DTB = converge_coefficient * (GF*FY-F*GY)/(FX*GY-GX*FY)
@@ -997,14 +997,14 @@ MODULE module_sf_urban
    ELSE
 
 !-------------------------------------------------------------------------------
-!  TB, TG  by Force-Restore Method 
+!  TB, TG  by Force-Restore Method
 !-------------------------------------------------------------------------------
 
        ES=6.11*EXP((2.5*10.**6./461.51)*(TBP-273.15)/(273.15*TBP) )
-       QS0B=0.622*ES/(PS-0.378*ES)       
+       QS0B=0.622*ES/(PS-0.378*ES)
 
        ES=6.11*EXP((2.5*10.**6./461.51)*(TGP-273.15)/(273.15*TGP) )
-       QS0G=0.622*ES/(PS-0.378*ES)        
+       QS0G=0.622*ES/(PS-0.378*ES)
 
        RG1=EPSG*( RX*VFGS             &
        +EPSB*VFGW*SIG*TBP**4./60.     &
@@ -1086,7 +1086,7 @@ MODULE module_sf_urban
    LW    = LLG - (LNET*697.7*60.) ! Upward longwave radiation   [W/m/m]
    SW    = SSG - (SNET*697.7*60.) ! Upward shortwave radiation  [W/m/m]
    ALB   = 0.
-   IF( ABS(SSG) > 0.0001) ALB = SW/SSG ! Effective albedo [-] 
+   IF( ABS(SSG) > 0.0001) ALB = SW/SSG ! Effective albedo [-]
    G = -FLXG*697.7*60.            ! [W/m/m]
    RN = (SNET+LNET)*697.7*60.     ! Net radiation [W/m/m]
 
@@ -1098,7 +1098,7 @@ MODULE module_sf_urban
 !  diagnostic GRID AVERAGED  PSIM  PSIH  TS QS --> WRF
 !------------------------------------------------------
 
-   Z0 = Z0C 
+   Z0 = Z0C
    Z0H = Z0HC
    Z = ZA - ZDC
 
@@ -1175,7 +1175,7 @@ MODULE module_sf_urban
 !   TH2 = TS + (TA-TS)*(PSIT2/PSIT)   ! potential temp at 2 m [K]
 !  TH2 = TS + (TA-TS)*(PSIT2/PSIT)   ! Fei: this seems to be temp (not potential) at 2 m [K]
 !Fei: consistant with M-O theory
-   TH2 = TS + (TA-TS) *(CHS/CHS2) 
+   TH2 = TS + (TA-TS) *(CHS/CHS2)
 
    Q2 = QS + (QA-QS)*(PSIT2/PSIT)    ! humidity at 2 m       [-]
 
@@ -1205,7 +1205,7 @@ MODULE module_sf_urban
    INTEGER             :: NEWT
    INTEGER, PARAMETER  :: NEWT_END=10
 
-   IF(RIB <= -15.) RIB=-15. 
+   IF(RIB <= -15.) RIB=-15.
 
    IF(RIB < 0.) THEN
 
@@ -1269,7 +1269,7 @@ MODULE module_sf_urban
    CD=US*US/UA**2.            ! CD
    ALPHA=RHO*CP*0.4*US/PSIH   ! RHO*CP*CH*U
 
-   RETURN 
+   RETURN
    END SUBROUTINE mos
 !===============================================================================
 !
@@ -1291,14 +1291,14 @@ MODULE module_sf_urban
    IF(RIB <= -15.) RIB=-15.
 
    IF(RIB >= 0.0) THEN
-      IF(RIB >= 0.142857) THEN 
+      IF(RIB >= 0.142857) THEN
          XX=0.714
-      ELSE 
+      ELSE
          XX=RIB*LOG(Z/Z0)/(1.-7.*RIB)
-      END IF 
+      END IF
       CH=0.16/0.74/(LOG(Z/Z0)+7.*MIN(XX,0.714))**2.
       CD=0.16/(LOG(Z/Z0)+7.*MIN(XX,0.714))**2.
-   ELSE 
+   ELSE
       CMB=7.4*A2*9.4*SQRT(Z/Z0)
       CHB=5.3*A2*9.4*SQRT(Z/Z0)
       CH=A2/0.74*(1.-9.4*RIB/(1.+CHB*SQRT(-RIB)))
@@ -1307,7 +1307,7 @@ MODULE module_sf_urban
 
    ALPHA=RHO*CP*CH*UA
 
-   RETURN 
+   RETURN
    END SUBROUTINE louis79
 !===============================================================================
 !
@@ -1321,19 +1321,19 @@ MODULE module_sf_urban
    REAL, PARAMETER     :: CP=0.24
    REAL, INTENT(IN)    :: Z, Z0, UA, RHO
    REAL, INTENT(OUT)   :: ALPHA, CD
-   REAL, INTENT(INOUT) :: RIB 
-   REAL                :: A2, FM, FH, CH, CHH 
+   REAL, INTENT(INOUT) :: RIB
+   REAL                :: A2, FM, FH, CH, CHH
 
    A2=(0.4/ALOG(Z/Z0))**2.
 
    IF(RIB <= -15.) RIB=-15.
 
-   IF(RIB >= 0.0) THEN 
+   IF(RIB >= 0.0) THEN
       FM=1./((1.+(2.*5.*RIB)/SQRT(1.+5.*RIB)))
       FH=1./(1.+(3.*5.*RIB)*SQRT(1.+5.*RIB))
       CH=A2*FH
       CD=A2*FM
-   ELSE 
+   ELSE
       CHH=5.*3.*5.*A2*SQRT(Z/Z0)
       FM=1.-(2.*5.*RIB)/(1.+3.*5.*5.*A2*SQRT(Z/Z0+1.)*(-RIB))
       FH=1.-(3.*5.*RIB)/(1.+CHH*SQRT(-RIB))
@@ -1392,11 +1392,11 @@ MODULE module_sf_urban
       B(K) = CAP*DZ(K)/DELT + 2.*AKS/(DZ(K-1)+DZ(K)) + 2.*AKS/(DZ(K)+DZ(K+1)) 
       C(K) = -2.*AKS/(DZ(K)+DZ(K+1))
       D(K) = CAP*DZ(K)/DELT*TSL(K)
-   END DO 
+   END DO
 
    IF(BOUND == 1) THEN                  ! Flux=0
       A(KM) = -2.*AKS/(DZ(KM-1)+DZ(KM))
-      B(KM) = CAP*DZ(KM)/DELT + 2.*AKS/(DZ(KM-1)+DZ(KM))  
+      B(KM) = CAP*DZ(KM)/DELT + 2.*AKS/(DZ(KM-1)+DZ(KM))
       C(KM) = 0.0
       D(KM) = CAP*DZ(KM)/DELT*TSL(KM)
    ELSE                                 ! T=constant
@@ -1404,7 +1404,7 @@ MODULE module_sf_urban
       B(KM) = CAP*DZ(KM)/DELT + 2.*AKS/(DZ(KM-1)+DZ(KM)) + 2.*AKS/(DZ(KM)+DZEND) 
       C(KM) = 0.0
       D(KM) = CAP*DZ(KM)/DELT*TSL(KM) + 2.*AKS*TSLEND/(DZ(KM)+DZEND)
-   END IF 
+   END IF
 
    P(1) = -C(1)/B(1)
    Q(1) =  D(1)/B(1)
@@ -1412,19 +1412,19 @@ MODULE module_sf_urban
    DO K=2,KM
       P(K) = -C(K)/(A(K)*P(K-1)+B(K))
       Q(K) = (-A(K)*Q(K-1)+D(K))/(A(K)*P(K-1)+B(K))
-   END DO 
+   END DO
 
    X(KM) = Q(KM)
 
    DO K=KM-1,1,-1
       X(K) = P(K)*X(K+1)+Q(K)
-   END DO 
+   END DO
 
    DO K=1,KM
       TSL(K) = X(K)
-   END DO 
+   END DO
 
-   RETURN 
+   RETURN
    END SUBROUTINE multi_layer
 !===============================================================================
 !
@@ -1444,7 +1444,7 @@ MODULE module_sf_urban
                          BOUNDR,BOUNDB,BOUNDG,CH_SCHEME,TS_SCHEME,     & ! out
                          AKANDA_URBAN)                                   ! out
 
-   INTEGER, INTENT(IN)  :: UTYPE 
+   INTEGER, INTENT(IN)  :: UTYPE
 
    REAL, INTENT(OUT)    :: ZR,Z0C,Z0HC,ZDC,SVF,R,RW,HGT,AH,              &
                            CAPR,CAPB,CAPG,AKSR,AKSB,AKSG,ALBR,ALBB,ALBG, &
@@ -1460,7 +1460,7 @@ MODULE module_sf_urban
    INTEGER,                     INTENT(OUT) :: NUMHGT
    REAL,    DIMENSION(MAXHGTS), INTENT(OUT) :: HEIGHT_BIN
    REAL,    DIMENSION(MAXHGTS), INTENT(OUT) :: HPERCENT_BIN
-   
+
 !end BEP
 
    INTEGER, INTENT(OUT) :: BOUNDR,BOUNDB,BOUNDG,CH_SCHEME,TS_SCHEME
@@ -1552,7 +1552,7 @@ MODULE module_sf_urban
    INTEGER :: num_roof_layers
    INTEGER :: num_wall_layers
    INTEGER :: num_road_layers
-   INTEGER :: dummy 
+   INTEGER :: dummy
    REAL    :: DHGT, HGT, VFWS, VFGS
 
    REAL, allocatable, dimension(:) :: ROOF_WIDTH
@@ -1595,7 +1595,7 @@ MODULE module_sf_urban
    CALL wrf_error_fatal('ERROR OPEN URBPARM.TBL')
    ENDIF
 
-   READLOOP : do 
+   READLOOP : do
       read(11,'(A512)', iostat=iostatus) string
       if (iostatus /= 0) exit READLOOP
       if (string(1:1) == "#") cycle READLOOP
@@ -1603,7 +1603,7 @@ MODULE module_sf_urban
       indx = index(string,":")
       if (indx <= 0) cycle READLOOP
       name = trim(adjustl(string(1:indx-1)))
-      
+
       ! Here are the variables we expect to be defined in the URBPARM.TBL:
       if (name == "Number of urban categories") then
          read(string(indx+1:),*) icate
@@ -1614,11 +1614,11 @@ MODULE module_sf_urban
             if(allocate_status /= 0)CALL wrf_error_fatal('Error allocating SIGMA_ZED_TBL in urban_param_init')
             ALLOCATE( Z0C_TBL(ICATE), stat=allocate_status )
             if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating Z0C_TBL in urban_param_init')
-            ALLOCATE( Z0HC_TBL(ICATE), stat=allocate_status ) 
+            ALLOCATE( Z0HC_TBL(ICATE), stat=allocate_status )
             if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating Z0HC_TBL in urban_param_init')
             ALLOCATE( ZDC_TBL(ICATE), stat=allocate_status )
             if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating ZDC_TBL in urban_param_init')
-            ALLOCATE( SVF_TBL(ICATE), stat=allocate_status ) 
+            ALLOCATE( SVF_TBL(ICATE), stat=allocate_status )
             if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating SVF_TBL in urban_param_init')
             ALLOCATE( R_TBL(ICATE), stat=allocate_status )
             if(allocate_status /= 0) CALL wrf_error_fatal('Error allocating R_TBL in urban_param_init')
@@ -1849,13 +1849,13 @@ MODULE module_sf_urban
             numhgt_tbl(k) = numhgt_tbl(k) + 1
             height_bin_tbl(numhgt_tbl(k), k) = dummy_hgt
             hpercent_bin_tbl(numhgt_tbl(k),k) = dummy_pct
-            
+
          enddo HEIGHTLOOP
          pctsum = sum ( hpercent_bin_tbl(:,k) , mask=(hpercent_bin_tbl(:,k)>-1.E25 ) )
          if ( pctsum /= 100.) then
             write (*,'(//,"Building height percentages for category ", I2, " must sum to 100.0")') k
             write (*,'("Currently, they sum to ", F6.2,/)') pctsum
-            CALL wrf_error_fatal('pctsum is not equal to 100.') 
+            CALL wrf_error_fatal('pctsum is not equal to 100.')
          endif
       else if ( name == "Z0R") then
          read(string(indx+1:),*) Z0R_tbl(1:icate)
@@ -1885,7 +1885,7 @@ MODULE module_sf_urban
          read(string(indx+1:),*) hsequip_tbl(1:24)
       else if (name == "HSEQUIP_SCALE_FACTOR") then
          read(string(indx+1:),*) hsesf_tbl(1:icate)
-!end BEP         
+!end BEP
       else
          CALL wrf_error_fatal('URBPARM.TBL: Unrecognized NAME = "'//trim(name)//'" in Subr URBAN_PARAM_INIT')
       endif
@@ -1912,7 +1912,7 @@ MODULE module_sf_urban
       BETG_TBL(LC) = 0.0
 
       ! The following urban canyon geometry parameters are following Macdonald's (1998) formulations
-      
+
       ! Lambda_P :: Plan areal fraction, which corresponds to R for a 2-d canyon.
       ! Lambda_F :: Frontal area index, which corresponds to HGT for a 2-d canyon
       ! Cd       :: Drag coefficient ( 1.2 from Grimmond and Oke, 1998 )
@@ -1922,7 +1922,7 @@ MODULE module_sf_urban
       Lambda_P = R_TBL(LC)
       Lambda_F = HGT_TBL(LC)
       Cd         = 1.2
-      alpha_macd = 4.43 
+      alpha_macd = 4.43
       beta_macd  = 1.0
 
 
@@ -2013,7 +2013,7 @@ MODULE module_sf_urban
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN)                    :: TDEEP0_URB
    INTEGER, DIMENSION( ims:ime, jms:jme ), INTENT(IN)                 :: IVGTYP
    LOGICAL , INTENT(IN) :: restart
- 
+
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TR_URB2D
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TB_URB2D
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TG_URB2D
@@ -2098,7 +2098,7 @@ MODULE module_sf_urban
       LH_URB2D(I,J)=0.
       G_URB2D(I,J)=0.
       RN_URB2D(I,J)=0.
-      
+
 !m
       FRC_URB2D(I,J)=0.
       UTYPE_URB2D(I,J)=0
@@ -2111,17 +2111,17 @@ MODULE module_sf_urban
             IF( IVGTYP(I,J) == 31) THEN
                UTYPE_URB2D(I,J) = 3  ! low-intensity residential
                UTYPE_URB = UTYPE_URB2D(I,J)  ! low-intensity residential
-               FRC_URB2D(I,J) = FRC_URB_TBL(UTYPE_URB) 
+               FRC_URB2D(I,J) = FRC_URB_TBL(UTYPE_URB)
             ENDIF
             IF( IVGTYP(I,J) == 32) THEN
                UTYPE_URB2D(I,J) = 2  ! high-intensity
                UTYPE_URB = UTYPE_URB2D(I,J)  ! high-intensity
-               FRC_URB2D(I,J) = FRC_URB_TBL(UTYPE_URB) 
+               FRC_URB2D(I,J) = FRC_URB_TBL(UTYPE_URB)
             ENDIF
             IF( IVGTYP(I,J) == 33) THEN
                UTYPE_URB2D(I,J) = 1  !  Commercial/Industrial/Transportation
                UTYPE_URB = UTYPE_URB2D(I,J)  !  Commercial/Industrial/Transportation
-               FRC_URB2D(I,J) = FRC_URB_TBL(UTYPE_URB) 
+               FRC_URB2D(I,J) = FRC_URB_TBL(UTYPE_URB)
             ENDIF
 
 
@@ -2192,7 +2192,7 @@ MODULE module_sf_urban
         TGL_URB3D(I,K,J)=TLAYER0_URB(I,K,J)+0.
 #endif
       END DO
-      
+
 ! multi-layer urban
 !      IF( sf_urban_physics .EQ. 2)THEN
        IF((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.eq.3)) THEN
@@ -2229,9 +2229,9 @@ MODULE module_sf_urban
         SFR_URB3D(I,K,J)=0.
         SFG_URB3D(I,K,J)=0.
       ENDDO
-       
-       ENDIF 
-              
+
+       ENDIF
+
       if (SF_URBAN_PHYSICS.EQ.3) then
          LF_AC_URB3D(I,J)=0.
          SF_AC_URB3D(I,J)=0.
@@ -2325,7 +2325,7 @@ MODULE module_sf_urban
        TS=0.5*(TS1+TS2)
 
        ES=6.11*EXP( (2.5*10.**6./461.51)*(TS-273.15)/(273.15*TS) )
-       QS0=0.622*ES/(PS-0.378*ES) 
+       QS0=0.622*ES/(PS-0.378*ES)
        R=EPS*(RX-SIG*(TS**4.)/60.)
        H=RHO*CP*CH*UA*(TS-TA)*100.
        ELE=RHO*EL*CH*UA*BET*(QS0-QA)*100.
@@ -2445,7 +2445,7 @@ SUBROUTINE SFCDIF_URB (ZLM,Z0,THZ0,THLM,SFCSPD,AKANDA,AKMS,AKHS,RLMO,CD)
 ! KCL/TL Try Kanda approach instead (Kanda et al. 2007, JAMC)
 !      ZT = EXP (ZILFC * SQRT (USTAR * Z0))* Z0
       ZT = EXP (2.0-AKANDA*(SQVISC**2 * USTAR * Z0)**0.25)* Z0
-      
+
       ZSLU = ZLM + ZU
 
       ZSLT = ZLM + ZT
@@ -2465,7 +2465,7 @@ SUBROUTINE SFCDIF_URB (ZLM,Z0,THZ0,THLM,SFCSPD,AKANDA,AKMS,AKHS,RLMO,CD)
 
          ZETAT = ZT * RLMO
          IF (ILECH .eq. 0) THEN
-            IF (RLMO .lt. 0.0)THEN 
+            IF (RLMO .lt. 0.0)THEN
                XLU4 = 1. -16.* ZETALU
                XLT4 = 1. -16.* ZETALT
                XU4 = 1. -16.* ZETAU

--- a/src/Land_models/Noah/Utility_programs/gcip_sw_to_grib/srb_daily_to_grib.F
+++ b/src/Land_models/Noah/Utility_programs/gcip_sw_to_grib/srb_daily_to_grib.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !*****************************************************************************!
@@ -149,7 +149,7 @@ contains
     implicit none
 
 ! Input:
-    character(len=*), intent(in) :: flnm 
+    character(len=*), intent(in) :: flnm
 
 ! Output:
     integer, intent(out) :: gribunit
@@ -205,7 +205,7 @@ contains
 
 ! Local variables
     integer :: ierr ! Error flag returned from call to CCLOSE.
-    
+
     call cclose(gribunit, 0, ierr)
     if (ierr /= 0) then
        write(*,'(/,"***** ERROR *****")')
@@ -315,7 +315,7 @@ contains
     integer :: itmp
 
     ! Final packing of all sections, before the write.
-    ! These should stay in this order:  
+    ! These should stay in this order:
     !      gribsec1_pack, gribsec2_pack, gribsec4_pack, gribsec0_pack
     ! because the other packing needs to be done before we know the final
     ! size of the grib record to go into GRIB section 0.
@@ -407,7 +407,7 @@ contains
           i = i + 1
        endif
     enddo
-    
+
     if (DO_BYTE_SWAP) then
        if (mod(output_size,4) == 0) then
           call swap4f(output_buffer, output_size)
@@ -436,7 +436,7 @@ contains
   subroutine gribsec1_clear
     implicit none
     newsec1 = 0
-    
+
     sec1_ptv = -999999
     sec1_cid = -999999
     sec1_pid = -999999
@@ -548,7 +548,7 @@ contains
 
 ! Local variables:
     integer :: iskip
-    integer :: totsize 
+    integer :: totsize
 
     totsize = 8 + sec1_size + sec2_size + sec3_size + sec4_size + 4
     iskip = 0
@@ -783,7 +783,7 @@ contains
        enddo
 
     else if (sec2_scm == 1) then
-       
+
        do i = ist, ien, inc
           do j = jst, jen, jnc
              if (lbm(i,j)) then
@@ -1053,7 +1053,7 @@ contains
        write(*, '("sec2_gty = ", I12)') sec2_gty
        stop "Unrecognized grid type in GRIBSEC2_PACK"
     end select
-    
+
   end subroutine gribsec2_pack
 
 
@@ -1076,7 +1076,7 @@ contains
     integer :: iskip, numunused, bmod, i, j, ist, ien, inc, jst, jen, jnc
 
     if (sec4_nbt == 0) then
-       ! We have a constant field.  Zero bits needed (sec4_nbt==0) 
+       ! We have a constant field.  Zero bits needed (sec4_nbt==0)
        ! to pack each datum.
        sec4_size = 12
        allocate(newsec4((sec4_size+3)/4))
@@ -1096,7 +1096,7 @@ contains
           stop
        endif
        call sbenc(newsec4, sec4_rfa, 0, iskip, 7)
-          
+
        call sbenc(newsec4, sec4_rfb, 0, iskip, 24)        ! Bytes 8-10
        call sbenc(newsec4, 0, 0, iskip, 8)                ! Byte 11
        call sbenc(newsec4, 0, 0, iskip, 8)                ! Byte 12
@@ -1169,7 +1169,7 @@ contains
           sec4_size = sec4_size + 1
           numunused = numunused + 8
        endif
-       
+
        if (mod(((size(gribiarr)*sec4_nbt)+numunused),16) /= 8) then
           print*, 'numused = ', size(gribiarr)*sec4_nbt
           print*, 'sec4_size = ', sec4_size
@@ -1200,7 +1200,7 @@ contains
 
     call sbenc(newsec4, sec4_rfb, 0, iskip, 24) ! Bytes 8-10
     call sbenc(newsec4, sec4_nbt, 0, iskip, 8)
-    
+
     if ((sec2_inc == 1) .or. (sec2_inc < -999998)) then
        ist = 1
        ien = size(gribiarr,1)
@@ -1254,7 +1254,7 @@ contains
        enddo
 
     else if (sec2_scm == 1) then
-       
+
        do i = ist, ien, inc
           do j = jst, jen, jnc
              if (lbm(i,j)) then
@@ -1282,7 +1282,7 @@ contains
        enddo
 
     else if (sec2_scm == 1) then
-       
+
        do i = ist, ien, inc
           do j = jst, jen, jnc
              call sbenc(newsec4, iarr(i,j), -999999, iskip, sec4_nbt)
@@ -1501,7 +1501,7 @@ contains
        endif
     endif
 
-! Find the maximum difference between the original data and the 
+! Find the maximum difference between the original data and the
 ! unpacking of the packed data.
     testdiff = maxval(abs(((rval+dble(iarr)*eval)*dval)-xarr))
     ! print*, '     Maximum abs(value), difference = ', xmax, testdiff
@@ -1563,7 +1563,7 @@ contains
           Dsave = D
           tsave = (m-xm)
        endif
-       
+
     enddo
 
     if (found) then
@@ -1729,7 +1729,7 @@ PROGRAM  sw_to_grib
   hdate(6:7)  = Fname(indxs+3:indxs+4) ! mm
   hdate(9:10) = Fname(indxs+5:indxs+6) ! dd
   if ( hdate(1:4) > "2050" ) hdate(1:2) = "19"
-  
+
   print*, 'Hdate = ', Hdate
 
   if (hdate(1:7) < "2001-07") then
@@ -1814,7 +1814,7 @@ PROGRAM  sw_to_grib
      if (allocated(newsec2)) deallocate(newsec2)
      if (allocated(newsec3)) deallocate(newsec3)
      if (allocated(newsec4)) deallocate(newsec4)
-     
+
   enddo
 
 END PROGRAM Sw_to_grib
@@ -1853,4 +1853,3 @@ subroutine getdata(Fname, Fluxi, Nlon, Nlat, Nhours)
 !KWM  endif
 
 end subroutine getdata
-

--- a/src/Land_models/Noah/Utility_programs/gcip_sw_to_grib/srb_monthly_to_grib.F
+++ b/src/Land_models/Noah/Utility_programs/gcip_sw_to_grib/srb_monthly_to_grib.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !*****************************************************************************!
@@ -149,7 +149,7 @@ contains
     implicit none
 
 ! Input:
-    character(len=*), intent(in) :: flnm 
+    character(len=*), intent(in) :: flnm
 
 ! Output:
     integer, intent(out) :: gribunit
@@ -205,7 +205,7 @@ contains
 
 ! Local variables
     integer :: ierr ! Error flag returned from call to CCLOSE.
-    
+
     call cclose(gribunit, 0, ierr)
     if (ierr /= 0) then
        write(*,'(/,"***** ERROR *****")')
@@ -315,7 +315,7 @@ contains
     integer :: itmp
 
     ! Final packing of all sections, before the write.
-    ! These should stay in this order:  
+    ! These should stay in this order:
     !      gribsec1_pack, gribsec2_pack, gribsec4_pack, gribsec0_pack
     ! because the other packing needs to be done before we know the final
     ! size of the grib record to go into GRIB section 0.
@@ -407,7 +407,7 @@ contains
           i = i + 1
        endif
     enddo
-    
+
     if (DO_BYTE_SWAP) then
        if (mod(output_size,4) == 0) then
           call swap4f(output_buffer, output_size)
@@ -436,7 +436,7 @@ contains
   subroutine gribsec1_clear
     implicit none
     newsec1 = 0
-    
+
     sec1_ptv = -999999
     sec1_cid = -999999
     sec1_pid = -999999
@@ -548,7 +548,7 @@ contains
 
 ! Local variables:
     integer :: iskip
-    integer :: totsize 
+    integer :: totsize
 
     totsize = 8 + sec1_size + sec2_size + sec3_size + sec4_size + 4
     iskip = 0
@@ -783,7 +783,7 @@ contains
        enddo
 
     else if (sec2_scm == 1) then
-       
+
        do i = ist, ien, inc
           do j = jst, jen, jnc
              if (lbm(i,j)) then
@@ -1053,7 +1053,7 @@ contains
        write(*, '("sec2_gty = ", I12)') sec2_gty
        stop "Unrecognized grid type in GRIBSEC2_PACK"
     end select
-    
+
   end subroutine gribsec2_pack
 
 
@@ -1076,7 +1076,7 @@ contains
     integer :: iskip, numunused, bmod, i, j, ist, ien, inc, jst, jen, jnc
 
     if (sec4_nbt == 0) then
-       ! We have a constant field.  Zero bits needed (sec4_nbt==0) 
+       ! We have a constant field.  Zero bits needed (sec4_nbt==0)
        ! to pack each datum.
        sec4_size = 12
        allocate(newsec4((sec4_size+3)/4))
@@ -1096,7 +1096,7 @@ contains
           stop
        endif
        call sbenc(newsec4, sec4_rfa, 0, iskip, 7)
-          
+
        call sbenc(newsec4, sec4_rfb, 0, iskip, 24)        ! Bytes 8-10
        call sbenc(newsec4, 0, 0, iskip, 8)                ! Byte 11
        call sbenc(newsec4, 0, 0, iskip, 8)                ! Byte 12
@@ -1169,7 +1169,7 @@ contains
           sec4_size = sec4_size + 1
           numunused = numunused + 8
        endif
-       
+
        if (mod(((size(gribiarr)*sec4_nbt)+numunused),16) /= 8) then
           print*, 'numused = ', size(gribiarr)*sec4_nbt
           print*, 'sec4_size = ', sec4_size
@@ -1200,7 +1200,7 @@ contains
 
     call sbenc(newsec4, sec4_rfb, 0, iskip, 24) ! Bytes 8-10
     call sbenc(newsec4, sec4_nbt, 0, iskip, 8)
-    
+
     if ((sec2_inc == 1) .or. (sec2_inc < -999998)) then
        ist = 1
        ien = size(gribiarr,1)
@@ -1254,7 +1254,7 @@ contains
        enddo
 
     else if (sec2_scm == 1) then
-       
+
        do i = ist, ien, inc
           do j = jst, jen, jnc
              if (lbm(i,j)) then
@@ -1282,7 +1282,7 @@ contains
        enddo
 
     else if (sec2_scm == 1) then
-       
+
        do i = ist, ien, inc
           do j = jst, jen, jnc
              call sbenc(newsec4, iarr(i,j), -999999, iskip, sec4_nbt)
@@ -1501,7 +1501,7 @@ contains
        endif
     endif
 
-! Find the maximum difference between the original data and the 
+! Find the maximum difference between the original data and the
 ! unpacking of the packed data.
     testdiff = maxval(abs(((rval+dble(iarr)*eval)*dval)-xarr))
     ! print*, '     Maximum abs(value), difference = ', xmax, testdiff
@@ -1563,7 +1563,7 @@ contains
           Dsave = D
           tsave = (m-xm)
        endif
-       
+
     enddo
 
     if (found) then
@@ -1724,7 +1724,7 @@ PROGRAM  sw_to_grib
   hdate = "2000-00-00_00:00:00.0000"
   hdate(3:4)  = Fname(indxs+1:indxs+2) ! yy
   hdate(6:7)  = Fname(indxs+3:indxs+4) ! mm
-  
+
   print*, 'hdate = ', hdate
   print*, 'nmdays = ', nmdays(hdate)
   DAYLOOP : do icount = 1, nmdays(hdate)
@@ -1737,7 +1737,7 @@ PROGRAM  sw_to_grib
      hdate(6:7)  = Fname(indxs+3:indxs+4) ! mm
      write(hdate(9:10), '(I2.2)') icount
      if ( hdate(1:4) > "2050" ) hdate(1:2) = "19"
-  
+
      print*, 'Hdate = ', Hdate
 
      if (hdate(1:7) < "2001-07") then
@@ -1826,7 +1826,7 @@ PROGRAM  sw_to_grib
 
         call write_grib(gribunit)
         call close_newgrib(gribunit)
-     
+
      enddo
   enddo DAYLOOP
 
@@ -1887,4 +1887,3 @@ subroutine getdata(Fname, Fluxi, Nlon, Nlat, Nhours, icount)
 !KWM  endif
 
 end subroutine getdata
-

--- a/src/Land_models/Noah/Utility_programs/hrldas_extract_point.F
+++ b/src/Land_models/Noah/Utility_programs/hrldas_extract_point.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 
@@ -117,7 +117,7 @@ contains
     call lltoxy_generic(lat, lon, x, y, &
          mapinfo%projection, mapinfo%dxm*1.E-3, mapinfo%lat1, mapinfo%lon1, 1.0, 1.0, &
          mapinfo%xlonc, mapinfo%truelat1, mapinfo%truelat2)
-    
+
   end subroutine lltoxy_hrldas
 
 !------------------------------------------------------------------------------
@@ -134,7 +134,7 @@ contains
     call xytoll_generic(x, y, lat, lon, &
          mapinfo%projection, mapinfo%dxm*1.E-3, mapinfo%lat1, mapinfo%lon1, 1.0, 1.0, &
          mapinfo%xlonc, mapinfo%truelat1, mapinfo%truelat2)
-    
+
   end subroutine xytoll_hrldas
 
 !------------------------------------------------------------------------------
@@ -204,7 +204,7 @@ program hrldas_extract_point
   type(hrldas_mapinfo_type) :: mapinfo
 
   character(len=10) :: nowdate, startdate, enddate
-  
+
 
   arguments_help = '(" [-lat <latitude>] [-lon <longitude>] ",/,&
        &"              [-x <x-coordinate>] [-y <y-coordinate>]",/,&
@@ -233,7 +233,7 @@ program hrldas_extract_point
         write(*,'(/,"  ***** X/y specified.  Do not specify lat/lon *****")')
         call print_help
      endif
-  else 
+  else
      write(*,'(/,"  ***** Point not specified.                         *****")')
      write(*,'(  "  ***** Specify desired point in lat/lon or in x/y.  *****")')
      call print_help
@@ -276,7 +276,7 @@ program hrldas_extract_point
              x, y, lat, lon
 
      endif
-  
+
      ival = int(x)
      jval = int(y)
 
@@ -305,7 +305,7 @@ program hrldas_extract_point
      call geth_newdate(nowdate, nowdate, 1)
 
   enddo TIMELOOP
-  
+
 end program hrldas_extract_point
 
 !------------------------------------------------------------------------------
@@ -486,7 +486,7 @@ subroutine loop_through_variable_list(ncid, ival, jval, nowdate, outunit)
         ierr = nf90_get_var(ncid, varid, idata, start(1:ndims))
         call handle_error(ierr, "Trying to get variable "//trim(varname))
         write(outunit, '(I18)', advance="no") idata
-        
+
      else if (xtype == NF90_CHAR) then
         ierr = nf90_get_var(ncid, varid, hdata, start, array_count)
         call handle_error(ierr, "Trying to get variable "//trim(varname))
@@ -508,4 +508,3 @@ subroutine loop_through_variable_list(ncid, ival, jval, nowdate, outunit)
   write(outunit,*)
 
 end subroutine loop_through_variable_list
-

--- a/src/Land_models/Noah/Utility_programs/lccone.F
+++ b/src/Land_models/Noah/Utility_programs/lccone.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 subroutine lccone (fsplat,ssplat,sign,confac)

--- a/src/Land_models/Noah/Utility_programs/llxy_generic.F
+++ b/src/Land_models/Noah/Utility_programs/llxy_generic.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_llxy_generic
@@ -282,7 +282,7 @@ contains
        tt2 = tan((pi2 - rflt  )*0.5)    ! Tangent Term 2.
        ct1 = -cos(flat1) * re/confac   ! cosine Term 1.
 
-       ! Calculate the (projected) distance from the pole to 
+       ! Calculate the (projected) distance from the pole to
        ! the reference lat/lon.
        drp = ct1 * (tt2/tt1)**confac
        ! Now from the pole to the reference y along the center lon.
@@ -321,7 +321,7 @@ contains
        dii = drp * sin(rcln-rfln)
        di = dii + ((x-refx)*dskm)
        ! Calculate the Big Messy quantity as would be done for LC
-       ! projections.  This quantity is different in value, same 
+       ! projections.  This quantity is different in value, same
        ! in purpose of BM above
        bm = (1.0/re) * sqrt(di*di + dj*dj) / (1.0 + cos(pi2-flat1))
        !  Calculate the desired latitude in radians

--- a/src/Land_models/Noah/Utility_programs/modify_wrfinput.F
+++ b/src/Land_models/Noah/Utility_programs/modify_wrfinput.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_modify_wrfinput
@@ -198,7 +198,7 @@ subroutine copy_replace(source_ncid, source_name, dest_ncid, dest_name)
   integer, dimension(NF90_MAX_VAR_DIMS) :: vcount
   integer, dimension(NF90_MAX_VAR_DIMS) :: source_dimids
   integer, dimension(NF90_MAX_VAR_DIMS) :: dest_dimids
-  
+
   integer :: j, destdim
 
 
@@ -272,7 +272,7 @@ subroutine copy_replace(source_ncid, source_name, dest_ncid, dest_name)
 
      iret = nf90_get_var(dest_ncid, dest_varid, dest_gone, start=vstart, count=vcount)
      call error_handler(iret, failure="Problem getting variable")
-     
+
      where (xdum < -1.E25) xdum = dest_gone
 
      iret = nf90_put_var(dest_ncid, dest_varid, xdum, start=vstart, count=vcount)
@@ -288,7 +288,7 @@ subroutine copy_replace(source_ncid, source_name, dest_ncid, dest_name)
   endif
 
 end subroutine copy_replace
-  
+
 subroutine copy_new(source_ncid, source_name, dest_ncid, dest_name)
   !
   ! Copy the variable named <source_name> from dataset <source_ncid> to
@@ -349,7 +349,7 @@ subroutine copy_new(source_ncid, source_name, dest_ncid, dest_name)
 
      iret = nf90_get_var(source_ncid, source_varid, xdum, start=vstart, count=vcount)
      call error_handler(iret, failure="Problem getting variable")
-     
+
      ! Put our destination dataset into define mode.
      iret = nf90_redef(dest_ncid)
      call error_handler(iret, failure="Problem putting dataset in define mode (redef)")
@@ -399,7 +399,7 @@ subroutine copy_new(source_ncid, source_name, dest_ncid, dest_name)
   endif
 
 end subroutine copy_new
-  
+
 subroutine copy_dataset(wrf_ncid, copy_ncid)
   use module_modify_wrfinput
   implicit none
@@ -474,7 +474,7 @@ subroutine copy_dataset(wrf_ncid, copy_ncid)
   iret = nf90_enddef(copy_ncid)
   call error_handler(iret, failure="Problem getting us out of define mode")
 
-  ! Copy all the data 
+  ! Copy all the data
 
   do i = 1, nvars
 
@@ -534,4 +534,3 @@ subroutine copy_dataset(wrf_ncid, copy_ncid)
   call error_handler(iret, failure="Problem closing copy_ncid.")
 
 end subroutine copy_dataset
-

--- a/src/Land_models/Noah/Utility_programs/vectorize/vectorize_geo_em.F
+++ b/src/Land_models/Noah/Utility_programs/vectorize/vectorize_geo_em.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 program vectorize_geo_em
@@ -55,7 +55,7 @@ program vectorize_geo_em
   character(len=256) :: dumstr
 
   namelist/vectorize_namelist/ keep_lu_list, full_geo_em, vector_directory
-  
+
   ! Default values
   keep_lu_list = -99999
   landuse_count = 0
@@ -105,7 +105,7 @@ program vectorize_geo_em
 
   iret = nf90_get_var(ncid_in, varid_in(1), lu_index)
   call error_handler(iret, "Problem getting variable 'LU_INDEX'")
-  
+
 !!!!!
 ! XLAT
 !!!!!
@@ -115,7 +115,7 @@ program vectorize_geo_em
 
   iret = nf90_get_var(ncid_in, varid_in(2), xlat_in)
   call error_handler(iret, "Problem getting variable 'XLAT_M'")
-  
+
 !!!!!
 ! XLONG
 !!!!!
@@ -125,7 +125,7 @@ program vectorize_geo_em
 
   iret = nf90_get_var(ncid_in, varid_in(3), xlon_in)
   call error_handler(iret, "Problem getting variable 'XLONG_M'")
-  
+
 !!!!!
 ! GREENFRAC
 !!!!!
@@ -147,7 +147,7 @@ program vectorize_geo_em
   allocate ( xlat_out  ( west_east_new , south_north_new , 1 ) )
   allocate ( xlon_out  ( west_east_new , south_north_new , 1 ) )
   allocate ( green_out ( west_east_new , south_north_new , 12, 1 ) )
-  
+
   iloc = 0
   do ilat = 1,south_north_old
      do ilon = 1,west_east_old
@@ -191,7 +191,7 @@ program vectorize_geo_em
 
   iret = nf90_inquire(ncid_in,ndims, nvars, natts)
   call error_handler(iret, "Problem getting number attributes")
-  
+
   do iloc = 1, natts
 
     iret = nf90_inq_attname(ncid_in,NF90_GLOBAL, iloc, attname)
@@ -317,10 +317,10 @@ program vectorize_geo_em
 
   iret = nf90_close(ncid_out)
   call error_handler(iret, "Problem closing output file")
-  
+
   iret = nf90_close(ncid_in)
   call error_handler(iret, "Problem closing input file")
-    
+
 end program
 
 !-----------------------------------------------------------------------------

--- a/src/Land_models/Noah/Utility_programs/vectorize/vectorize_ldasin.F
+++ b/src/Land_models/Noah/Utility_programs/vectorize/vectorize_ldasin.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 program vectorize_ldasin
@@ -110,7 +110,7 @@ program vectorize_ldasin
   character(len=256) :: dumstr
 
   namelist/vectorize_namelist/ keep_lu_list, full_geo_em, vector_directory
-  
+
   ! Default values
   keep_lu_list = -99999
   landuse_count = 0
@@ -223,7 +223,7 @@ program vectorize_ldasin
   call read_var_2d(ncid_in, "LWDOWN",   varid_in(8), lwdown_in(:,:,1),   west_east_old, south_north_old)
 
   ! Optional variables:
-  
+
   call read_var_2d_optional(ncid_in, "WEASD",    FOUND_WEASD,    varid_in(9),  weasd_in(:,:,1),    west_east_old, south_north_old)
   call read_var_2d_optional(ncid_in, "VEGFRA",   FOUND_VEGFRA,   varid_in(10), vegfra_in(:,:,1),   west_east_old, south_north_old)
   call read_var_2d_optional(ncid_in, "CANWAT",   FOUND_CANWAT,   varid_in(11), canwat_in(:,:,1),   west_east_old, south_north_old)
@@ -641,7 +641,7 @@ subroutine read_var_2d(ncid, name, varid, array, idim, jdim)
   integer,                    intent(in)  :: jdim
   integer,                    intent(out) :: varid
   real, dimension(idim,jdim), intent(out) :: array   ! Assumed-shape array
-  
+
   integer :: iret
 
   iret = nf90_inq_varid ( ncid, name, varid )
@@ -665,7 +665,7 @@ subroutine read_var_2d_optional(ncid, name, found, varid, array, idim, jdim)
   logical,                    intent(out) :: found
   integer,                    intent(out) :: varid
   real, dimension(idim,jdim), intent(out) :: array   ! Assumed-shape array
-  
+
   integer :: iret
 
   iret = nf90_inq_varid ( ncid, name, varid )
@@ -706,4 +706,3 @@ end subroutine define_var
 
 !-----------------------------------------------------------------------------
 !-----------------------------------------------------------------------------
-

--- a/src/Land_models/Noah/Utility_programs/vectorize/vectorize_wrfinput.f90
+++ b/src/Land_models/Noah/Utility_programs/vectorize/vectorize_wrfinput.f90
@@ -57,7 +57,7 @@ program vectorize_wrfinput
 
   iret = nf90_inquire(ncid_in,ndims, nvars, natts)
    if(iret/=0) print*, "Problem getting number attributes"
-  
+
   do iloc = 1, natts
     iret = nf90_inq_attname(ncid_in,NF90_GLOBAL, iloc, attname)
      if(iret/=0) print*, "Problem getting attribute name"
@@ -84,7 +84,7 @@ program vectorize_wrfinput
 
   iret = nf90_get_var(ncid_in, varid_in(1), ivgtyp_in)
    if(iret/=0) print*, "Problem getting variable"
-  
+
 !!!!!
 ! ISLTYP
 !!!!!
@@ -94,7 +94,7 @@ program vectorize_wrfinput
 
   iret = nf90_get_var(ncid_in, varid_in(2), isltyp_in)
    if(iret/=0) print*, "Problem getting variable"
-  
+
 !!!!!
 ! HGT
 !!!!!
@@ -104,7 +104,7 @@ program vectorize_wrfinput
 
   iret = nf90_get_var(ncid_in, varid_in(3), hgt_in)
    if(iret/=0) print*, "Problem getting variable"
-  
+
 !!!!!
 ! XLAT
 !!!!!
@@ -114,7 +114,7 @@ program vectorize_wrfinput
 
   iret = nf90_get_var(ncid_in, varid_in(4), xlat_in)
    if(iret/=0) print*, "Problem getting variable"
-  
+
 !!!!!
 ! XLONG
 !!!!!
@@ -124,7 +124,7 @@ program vectorize_wrfinput
 
   iret = nf90_get_var(ncid_in, varid_in(5), xlong_in)
    if(iret/=0) print*, "Problem getting variable"
-  
+
 !!!!!
 ! TMN
 !!!!!
@@ -134,7 +134,7 @@ program vectorize_wrfinput
 
   iret = nf90_get_var(ncid_in, varid_in(6), tmn_in)
    if(iret/=0) print*, "Problem getting variable"
-    
+
   iloc = 0
   do ilat = 1,2632
   do ilon = 1,1795
@@ -254,9 +254,9 @@ program vectorize_wrfinput
 
   iret = nf90_close(ncid_out)
    if(iret/=0) print*, "Problem closing output file"
-  
+
   iret = nf90_close(ncid_in)
    if(iret/=0) print*, "Problem closing input file"
-  
-    
+
+
 end program

--- a/src/Land_models/Noah/Utility_routines/kwm_string_utilities.F
+++ b/src/Land_models/Noah/Utility_routines/kwm_string_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_string_utilities
@@ -68,7 +68,7 @@ contains
           return_string(j:j) = string(i:i)
        endif
     enddo
-    
+
   end function unblank
 
 !KWM  character function upcase(h)
@@ -87,7 +87,7 @@ contains
     implicit none
     character(len=*), intent(in) :: h
     integer :: i
-    
+
     return_string = " "
 
     do i = 1, len_trim(h)

--- a/src/Land_models/Noah/Utility_routines/module_Noahlsm_utility.F
+++ b/src/Land_models/Noah/Utility_routines/module_Noahlsm_utility.F
@@ -2,31 +2,31 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
-MODULE module_Noahlsm_utility 
- 
+MODULE module_Noahlsm_utility
+
   REAL, PARAMETER      :: CP = 1004.5, RD = 287.04, SIGMA = 5.67E-8,    &
                           CPH2O = 4.218E+3,CPICE = 2.106E+3,            &
                           LSUBF = 3.335E+5
 
 CONTAINS
 
-  SUBROUTINE CALTMP(T1, SFCTMP, SFCPRS, ZLVL, Q2, TH2, T1V, TH2V, RHO ) 
+  SUBROUTINE CALTMP(T1, SFCTMP, SFCPRS, ZLVL, Q2, TH2, T1V, TH2V, RHO )
 
     IMPLICIT NONE
 
@@ -47,7 +47,7 @@ CONTAINS
     REAL                   :: T2V
 
     TH2 = SFCTMP + ( 0.0098 * ZLVL)
-    T1V= T1 * (1.0+ 0.61 * Q2) 
+    T1V= T1 * (1.0+ 0.61 * Q2)
     TH2V = TH2 * (1.0+ 0.61 * Q2)
     T2V = SFCTMP * ( 1.0 + 0.61 * Q2 )
     RHO = SFCPRS/(RD * T2V)
@@ -57,33 +57,33 @@ CONTAINS
   SUBROUTINE CALHUM(SFCTMP, SFCPRS, Q2SAT, DQSDT2)
 
     IMPLICIT NONE
-  
+
     ! Input:
     REAL, INTENT(IN)       :: SFCTMP
     REAL, INTENT(IN)       :: SFCPRS
-    
+
     ! Output:
     REAL, INTENT(OUT)      :: Q2SAT   ! Saturated specific humidity
-    REAL, INTENT(OUT)      :: DQSDT2 
-    
+    REAL, INTENT(OUT)      :: DQSDT2
+
     ! Local
     REAL, PARAMETER        :: A2=17.67,A3=273.15,A4=29.65, ELWV=2.501E6,        &
                               A23M4=A2*(A3-A4), E0=611.0, RV=461.0,             &
-                              EPSILON=0.622 
+                              EPSILON=0.622
     REAL                   :: ES
 
     ! ES:  e.g. Dutton chapter 8, eq 11
         ES = E0 * EXP ( ELWV/RV*(1./A3 - 1./SFCTMP) )
 
-    ! Q2SAT:  
+    ! Q2SAT:
         Q2SAT = EPSILON * ES / (SFCPRS-(1-EPSILON)*ES)
 
 ! DQSDT2 is calculated assuming Q2SAT is a specific humidity
-        !KWM DQSDT2=(Q2SAT/(1+Q2SAT))*A23M4/(SFCTMP-A4)**2 
-        DQSDT2=Q2SAT*A23M4/(SFCTMP-A4)**2 
+        !KWM DQSDT2=(Q2SAT/(1+Q2SAT))*A23M4/(SFCTMP-A4)**2
+        DQSDT2=Q2SAT*A23M4/(SFCTMP-A4)**2
 
         END SUBROUTINE CALHUM
- 
+
 
 END MODULE module_Noahlsm_utility
 

--- a/src/Land_models/Noah/Utility_routines/module_date_utilities.F
+++ b/src/Land_models/Noah/Utility_routines/module_date_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module Module_Date_utilities
@@ -459,7 +459,7 @@ contains
 
     implicit none
 
-    !  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'), 
+    !  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'),
     !  compute the time difference.
 
     !  on entry     -  newdate  -  the new hdate.
@@ -687,7 +687,7 @@ contains
     opass = .true.
 
     !  Check that the month of NDATE makes sense.
-    
+
     if ((monew.gt.12).or.(monew.lt.1)) then
        write(*,*) 'GETH_IDTS:  Month of NDATE = ', monew
        npass = .false.
@@ -853,7 +853,7 @@ contains
     integer, intent(in) :: year ! Four-digit year
 
     nfeb = 28 ! By default, February has 28 days ...
-    if (mod(year,4).eq.0) then  
+    if (mod(year,4).eq.0) then
        nfeb = 29  ! But every four years, it has 29 days ...
        if (mod(year,100).eq.0) then
           nfeb = 28  ! Except every 100 years, when it has 28 days ...

--- a/src/Land_models/Noah/Utility_routines/module_model_constants.F
+++ b/src/Land_models/Noah/Utility_routines/module_model_constants.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !WRF:MODEL_LAYER:CONSTANTS
@@ -65,7 +65,7 @@
    REAL    , PARAMETER :: cvovcp       = 1./cpovcv
    REAL    , PARAMETER :: rvovrd       = r_v/r_d
 
-   REAL    , PARAMETER :: reradius     = 1./6370.0e03 
+   REAL    , PARAMETER :: reradius     = 1./6370.0e03
 
    REAL    , PARAMETER :: asselin      = .025
 !   REAL    , PARAMETER :: asselin      = .0
@@ -148,7 +148,7 @@
        REAL , PARAMETER ::  wght=0.35
        REAL , PARAMETER ::  wpc=0.075
        REAL , PARAMETER ::  z0land=0.10
-#ifdef HWRF 
+#ifdef HWRF
        REAL , PARAMETER ::  z0max=0.01
 #else
        REAL , PARAMETER ::  z0max=0.008

--- a/src/Land_models/Noah/Utility_routines/module_sfcdif_wrf.F
+++ b/src/Land_models/Noah/Utility_routines/module_sfcdif_wrf.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 ! Note:  Initialize USTAR to 0.1 at start of HRLDAS driver.

--- a/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/fluxes_statistics.F
+++ b/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/fluxes_statistics.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 program fluxes_statistics
@@ -319,7 +319,7 @@ program fluxes_statistics
 
      call gsln(1)
      nowdate = startdate
-     
+
      ! QFX_Corrected
      do while ( nowdate(1:13) < enddate(1:13) )
         call geth_newdate(nowdate(1:13), nowdate(1:13), 1)
@@ -368,7 +368,7 @@ program fluxes_statistics
      call set ( xl , xr , xb , xt , 0.0 , 1.0 , 0.0 , 1.0 , 1 )
      call perim(0,0,0,0)
      call pchiqu(0.525, 0.95, "QFX:  Station "//textsta, 0.0075, 0.0, 0.0)
-     
+
      xl = frame_left   + (frame_right-frame_left  )*0.15
      xr = frame_left   + (frame_right-frame_left  )*0.95
      xb = frame_bottom + (frame_top  -frame_bottom)*0.10
@@ -411,7 +411,7 @@ program fluxes_statistics
            station_qfx_bias = station_qfx_bias + (hrldas_qfx(ista,itime) - qfx_old(ista, itime+1))
            station_qfx_rmse = station_qfx_rmse + (hrldas_qfx(ista,itime) - qfx_old(ista, itime+1))**2
            station_qfx_count = station_qfx_count + 1
-           
+
            xxarray(station_qfx_count) = float(itime)
            yyarray(station_qfx_count) = qfx_old(ista,itime+1)
            zzarray(station_qfx_count) = hrldas_qfx(ista,itime)
@@ -493,7 +493,7 @@ program fluxes_statistics
      call line_in_color(xarray_diurnal(0), 400.0, xarray_diurnal(24), 400.0, color_index("gray90"))
      call gasetc("XLF", "(I2.2)")
      call periml(24, 0, 6, 0)
-  
+
      call connect_the_dots(xarray_diurnal, (/station_qfxoavg,station_qfxoavg(0)/), 25, color="blue")
      call connect_the_dots(xarray_diurnal, (/station_qfxoavg_old,station_qfxoavg_old(0)/), 25, color="green")
      call connect_the_dots(xarray_diurnal, (/station_qfxmavg,station_qfxmavg(0)/), 25, color="red")
@@ -618,7 +618,7 @@ program fluxes_statistics
      call line_in_color(xarray_diurnal(0), 300.0, xarray_diurnal(24), 300.0, color_index("gray90"))
      call line_in_color(xarray_diurnal(0), 400.0, xarray_diurnal(24), 400.0, color_index("gray90"))
      call periml(24,0,6,0)
-  
+
      call connect_the_dots(xarray_diurnal, (/station_hfxoavg,station_hfxoavg(0)/), 25, color="blue")
      call connect_the_dots(xarray_diurnal, (/station_hfxmavg,station_hfxmavg(0)/), 25, color="red")
 
@@ -649,7 +649,7 @@ program fluxes_statistics
   hfxrmse = sqrt(hfxrmse/float(hfxcount))
 
   ! Plot our average diurnal cycle.
-  
+
   call gsplci(color_index("black"))
   call set (0., 1., 0., 1., 0., 1., 0., 1., 1)
   call pchiqu(0.5*(.15+.9), 0.93, "Observed QFX (solid), Corrected Observed QFX (dot), HRLDAS QFX (dash)", 0.013, 0., 0.)
@@ -658,7 +658,7 @@ program fluxes_statistics
   call gasetc("YLF", '(F5.0)')
   call periml(8, 3, 6, 0)
   call line_in_color(0., 0., 24., 0., color_index("gray90"))
-  
+
   call gsln(1)
   call connect_the_dots(xarray_diurnal, (/qfxoavg_old,qfxoavg_old(0)/), 25)
 
@@ -706,7 +706,7 @@ program fluxes_statistics
   call periml(8, 3, 6, 0)
 
   call line_in_color(0., 0., 24., 0., color_index("gray90"))
-  
+
   call gsln(1)
   call connect_the_dots(xarray_diurnal, (/hfxoavg,hfxoavg(0)/), 25)
 
@@ -728,7 +728,7 @@ program fluxes_statistics
 
   call periml(8, 3, 6, 0)
 
-  
+
   call gsln(1)
   call connect_the_dots(xarray_diurnal, (/hfxbias, hfxbias(0)/), 25)
 
@@ -852,7 +852,7 @@ subroutine read_ihop(fluxobs_directory, &
 
   ! Skip 4 header lines
   read(iunit,'(///)')
-  READLOOP : do 
+  READLOOP : do
 
 !
 ! Fore some reason, I'm having a hard time reading this file with
@@ -862,13 +862,13 @@ subroutine read_ihop(fluxobs_directory, &
 ! Anyway, the read into character string Hrd_LEc is done because some bad data
 ! values in the file are encoded as the string "NaN".  Arrgh!
 !
-        
+
 
      if (ista == 10) then
         read(iunit,*, iostat=ierr) idum, idum, idum, idum, idum, rdyyyy, &
              rdmm, rddd, rdhhmmss, idum, idum, rd_rsw, rd_rlw, rt_T, rd_P, rd_MR, &
              rd_SPD, rd_U, rd_V, rd_rainacc, rd_rainr, rd_Rnet, rd_Rpar, &
-             rd_Tsfc, rd_LE, Hrd_LEc, rd_H, rd_Gsfc 
+             rd_Tsfc, rd_LE, Hrd_LEc, rd_H, rd_Gsfc
      else
         read(iunit,*, iostat=ierr) idum, idum, idum, idum, idum, rdyyyy, &
               rdmm, rddd, rdhhmmss, idum, rd_rsw, rd_rlw, rt_T, rd_P, rd_MR, &
@@ -933,7 +933,7 @@ subroutine read_namelist(fluxobs_directory, ldasout_directory)
      stop
   endif
 
-  read(11, nml=fluxstats, iostat=ierr) 
+  read(11, nml=fluxstats, iostat=ierr)
   if (ierr /= 0) then
      write(*,'("***** ERROR EXIT *****",/)')
      write(*,'(3x, "Problem reading namelist file:", /, 6x, A,/)') "'"//"namelist.fluxstats"//"'"
@@ -944,7 +944,7 @@ subroutine read_namelist(fluxobs_directory, ldasout_directory)
   close(11)
 
   print*, 'fluxobs_directory = "'//trim(fluxobs_directory)//'"'
-  
+
 end subroutine read_namelist
 
 !--------------------------------------------------------------------------------
@@ -1017,7 +1017,7 @@ subroutine draw_scatter(abbr1, abbr2, obs, mdl, ndim, bias, rmse, correlation, l
   call gagetr("XMN", hold_xmn)
   call gagetr("YMN", hold_ymn)
 
-  
+
   iblue  = color_index("blue")
   ired   = color_index("red")
   iblack = color_index("black")
@@ -1050,7 +1050,7 @@ subroutine draw_scatter(abbr1, abbr2, obs, mdl, ndim, bias, rmse, correlation, l
 
   write(text,'("Corr:  ", F10.4)') correlation
   call pchiqu(0.17, 0.816, trim(text), text_scale2, 0.0, -1.0)
-  
+
   minrange = min(minval(mdl,mask=(mdl>-1.E25)), minval(obs,mask=(obs>-1.E25)))
   maxrange = max(maxval(mdl,mask=(mdl>-1.E25)), maxval(obs,mask=(obs>-1.E25)))
   call find_good_range(minrange, maxrange, expn, irange)
@@ -1112,7 +1112,7 @@ subroutine flux_stats(obs, mdl, ndim, bias, rmse, correlation, lsra, lsrb)
 
   integer :: n
   integer :: ndat
-  
+
   real (kind=8) :: sumx, sumy, sumxx, sumxy, sumyy, sxx, sxy, syy
 
   bias = 0.0

--- a/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/get_unused_unit.F
+++ b/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/get_unused_unit.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 integer function get_unused_unit() result(iunit)

--- a/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/kwm_date_utilities.F
+++ b/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/kwm_date_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_date_utilities
@@ -23,7 +23,7 @@ contains
   subroutine geth_newdate (ndate, odate, idt)
     implicit none
 
-!  From old date ('YYYY-MM-DD HH:MM:SS.ffff') and 
+!  From old date ('YYYY-MM-DD HH:MM:SS.ffff') and
 !  delta-time, compute the new date.
 
 !  on entry     -  odate  -  the old hdate.
@@ -379,7 +379,7 @@ contains
        else if (nlen.eq.13) then
           write(ndate,13) yrnew, monew, dynew, hrnew
 13        format(i4,'-',i2.2,'-',i2.2,'_',i2.2)
-          
+
        else if (nlen.eq.10) then
           write(ndate,10) yrnew, monew, dynew
 10        format(i4,'-',i2.2,'-',i2.2)
@@ -387,7 +387,7 @@ contains
        end if
 
        if (olen.ge.11) ndate(11:11) = sp
-       
+
     else
 
        if (nlen.gt.20) then
@@ -406,7 +406,7 @@ contains
        else if (nlen.eq.10) then
           write(ndate,210) yrnew, monew, dynew, hrnew
 210       format(i4,i2.2,i2.2,i2.2)
-          
+
        else if (nlen.eq.8) then
           write(ndate,8) yrnew, monew, dynew
 8         format(i4,i2.2,i2.2)
@@ -421,7 +421,7 @@ contains
   subroutine geth_idts (newdate, olddate, idt)
     implicit none
 
-!  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'), 
+!  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'),
 !  compute the time difference.
 
 !  on entry     -  newdate  -  the new hdate.
@@ -551,7 +551,7 @@ contains
              end if
           end if
        end if
-       
+
 !  Break down new hdate into parts
 
        read(ndate(6:7),  '(i2)') monew
@@ -586,7 +586,7 @@ contains
              end if
           end if
        end if
-       
+
 !  Break down new hdate into parts
 
        read(ndate(5:6),  '(i2)') monew
@@ -794,7 +794,7 @@ contains
     integer, intent(in) :: year ! Four-digit year
 
     nfeb = 28 ! By default, February has 28 days ...
-    if (mod(year,4).eq.0) then  
+    if (mod(year,4).eq.0) then
        nfeb = 29  ! But every four years, it has 29 days ...
        if (mod(year,100).eq.0) then
           nfeb = 28  ! Except every 100 years, when it has 28 days ...

--- a/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/kwm_grid_utilities.F
+++ b/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/kwm_grid_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_grid_utilities
@@ -385,12 +385,12 @@ contains
 
 ! Compute the kernel
 
-! I'd rather do it in one step, going directly to my vector v, 
+! I'd rather do it in one step, going directly to my vector v,
 ! but I don't see how to be able to do that cleanly and still
 ! correct for the error (how much the sum differs from 1.0).
 
 ! First I compute the two-dimensional kernel array.
-    cval = 1./(twopi*sigsq) 
+    cval = 1./(twopi*sigsq)
     do i = 1, fsz
        x = float(hsz-i)
        do j = 1, fsz
@@ -442,7 +442,7 @@ contains
     real, dimension(ix,jx), intent(in)  :: slab1
     real, dimension(ix,jx), intent(out) :: slab2
     integer :: ie,je,i,j
-   
+
     IE=IX-1
     JE=JX-1
     DO I=2,IE
@@ -462,7 +462,7 @@ contains
     SLAB2(1,JX)=SLAB1(1,JE)
     SLAB2(IX,JX)=SLAB1(IE,JE)
     SLAB2(IX,1)=SLAB1(IE,1)
-   
+
   end subroutine crs2dot
 
 !KWM  SUBROUTINE MQD (NOBS, XC, YC, DAT, IX, JX, A1)
@@ -484,14 +484,14 @@ contains
 !KWM!         YC (nobs) :: 2nd coordinate of the observations
 !KWM!         IX        :: 1st dimension of first-guess and analysis arrays
 !KWM!         JX        :: 2nd dimension of first-guess and analysis arrays
-!KWM!         A1(ix,jx) :: dimension(ix,jx):: first guess; 
+!KWM!         A1(ix,jx) :: dimension(ix,jx):: first guess;
 !KWM!
 !KWM! ON EXIT:
 !KWM!         A1(ix,jx) :: Objective analysis
 !KWM!
 !KWM!  PROGRAMMED BY JIM BRESCH NCAR/UW    12/14/94
 !KWM!  Adapted to use blas routines by Kevin W. Manning.
-!KWM!  Further adapted, improved efficiency.  
+!KWM!  Further adapted, improved efficiency.
 !KWM!  Dropped into kwm modules package, October 2001.
 !KWM
 !KWM! As far as coordinate values:

--- a/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/kwm_plot_utilities.F
+++ b/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/kwm_plot_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !
@@ -23,7 +23,7 @@
 !
 ! This is very much a work in progress.
 !
-! A lot of this has been adapted from Mark Stoelinga's RIP program, 
+! A lot of this has been adapted from Mark Stoelinga's RIP program,
 ! which is highly recommended.
 !
 module kwm_plot_utilities
@@ -33,7 +33,7 @@ module kwm_plot_utilities
 
 
   ! NCO:  number of already-defined and named colors
-  integer, private :: nco 
+  integer, private :: nco
 
   type named_color
      character(len=20) :: name
@@ -104,7 +104,7 @@ contains
 ! Opens workstation 1 as a CGM workstation.
 ! Opens workstation 2 as a WISS.
 ! Defines a couple of colors, and sets a couple of NCAR Graphics parameters
-! 
+!
 ! If you want the gmeta file to be called something other than "gmeta",
 ! give this subroutine the optional argument.
     implicit none
@@ -152,7 +152,7 @@ contains
 !****************************************************************************************
 
   subroutine gset_named_color(NAME)
-    ! Calls NCAR-Graphics subroutine GSCR to set the next color index 
+    ! Calls NCAR-Graphics subroutine GSCR to set the next color index
     ! to the rgb values indicated by the color named NAME.
 
     ! Side effects:  Associate RGB values with a color index NCO.
@@ -508,7 +508,7 @@ contains
 
 !KWM    print*, 'usq = ', usq(1:numcon)
 
-! Number of areas for filling is one plus the number of contours, 
+! Number of areas for filling is one plus the number of contours,
 ! i.e., the contours define the boundaries between areas.
     nconarea = numcon+1
 
@@ -542,7 +542,7 @@ contains
     nco = nco - 1
     icomax = nco
 !
-! USIT is now our list of color names and associated rgb values in 
+! USIT is now our list of color names and associated rgb values in
 ! our color sequence.  Color values in USIT correspond to USQ
 
 ! Note that we haven't actually called GSCR to assign RGB values to
@@ -867,7 +867,7 @@ contains
     elseif (val.ge.valcon(numcon)) then
        if (usit(nsq)%name /= "transparent" ) c = usit(nsq)
     else
-       ! Interpolate from USIT rgb values (associated with RSQ 
+       ! Interpolate from USIT rgb values (associated with RSQ
        ! floating-point values) to a new color c.
 
        do isq=1,nsq-1
@@ -1498,7 +1498,7 @@ contains
 !****************************************************************************************
 
   subroutine set_gscr_color_indices(is,ie,seqstr)
-    ! Set all the ncargks color indices between IS and IE to the 
+    ! Set all the ncargks color indices between IS and IE to the
     ! colors listed in the SEQSTR
 
     implicit none
@@ -1733,7 +1733,7 @@ contains
     iymax = ceiling ( (10.0**(real(-expn))) * ymax )
     irange = (iymax-iymin)
 
-    ! If we've got too many steps between iymin and iymax, 
+    ! If we've got too many steps between iymin and iymax,
     ! then shift to the next power-of-ten for our scaling.
     if (irange > 20) then
        iymin = floor  (real(iymin)*0.1)
@@ -1866,7 +1866,7 @@ contains
     ! At the end of the routine, the original color and line_width settings are
     ! restored.
     !
-    ! Values more negative than -1.E25 are considered bad data.  
+    ! Values more negative than -1.E25 are considered bad data.
     !    if (on_missing == "SKIP") then
     !        Skip over bad data, connecting all good data points in order.
     !    else if (on_missing == "BREAK") then

--- a/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/kwm_string_utilities.F
+++ b/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/kwm_string_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_string_utilities
@@ -68,7 +68,7 @@ contains
           return_string(j:j) = string(i:i)
        endif
     enddo
-    
+
   end function unblank
 
 !KWM  character function upcase(h)
@@ -87,7 +87,7 @@ contains
     implicit none
     character(len=*), intent(in) :: h
     integer :: i
-    
+
     return_string = ""
 
     do i = 1, len_trim(h)

--- a/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/lccone.F
+++ b/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/lccone.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 subroutine lccone (fsplat,ssplat,sign,confac)

--- a/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/llxy_generic.F
+++ b/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/llxy_generic.F
@@ -68,7 +68,7 @@ subroutine lltoxy_generic (xlat,xlon,x,y,&
   else
      londiff = (xlon-cenlon)*degrad
   endif
-     
+
 
   if (project(1:2) .eq. 'ME') then
 
@@ -84,8 +84,8 @@ subroutine lltoxy_generic (xlat,xlon,x,y,&
 !KWM     di = re*(rlon-rfln)
 !KWM     y = refy + dj/dskm
 !KWM     x = refx + di/dskm
-     
-     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms 
+
+     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms
      ! of thousandths of degrees!
      !  Calculate the distance from the horizontal axis to (J,I)
      dj = xlat-reflat
@@ -239,7 +239,7 @@ subroutine xytoll_generic (x,y,xlat,xlon,&
 
 ! If the projection is cylindrical equidistant ('CE') then ...
   else if (project(1:2) .eq. 'CE') then
-     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms 
+     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms
      ! of thousandths of degrees!
      di = (x-refx) * dskm
      !  Calculate the distance from the horizontal axis to (J,I)
@@ -261,7 +261,7 @@ subroutine xytoll_generic (x,y,xlat,xlon,&
      tt2 = tan((pi2 - rflt  )*0.5)    ! Tangent Term 2.
      ct1 = -cos(flat1) * re/confac   ! cosine Term 1.
 
-     ! Calculate the (projected) distance from the pole to 
+     ! Calculate the (projected) distance from the pole to
      ! the reference lat/lon.
      drp = ct1 * (tt2/tt1)**confac
      ! Now from the pole to the reference y along the center lon.
@@ -300,7 +300,7 @@ subroutine xytoll_generic (x,y,xlat,xlon,&
      dii = drp * sin(rcln-rfln)
      di = dii + ((x-refx)*dskm)
      ! Calculate the Big Messy quantity as would be done for LC
-     ! projections.  This quantity is different in value, same 
+     ! projections.  This quantity is different in value, same
      ! in purpose of BM above
      bm = (1.0/re) * sqrt(di*di + dj*dj) / (1.0 + cos(pi2-flat1))
      !  Calculate the desired latitude in radians

--- a/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/module_hd.F
+++ b/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/module_hd.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_hd
@@ -83,7 +83,7 @@ contains
     start(2) = time_index
     nfcount(1) = DateStrLen
     nfcount(2) = 1
-    
+
     iret = nf90_get_var(ncid, varid, time_return, start, nfcount)
     if (iret /= 0) then
        write(*,'("netcdf_get_time:  NF90_GET_VAR:  ",A)') nf90_strerror(iret)

--- a/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/get_unused_unit.F
+++ b/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/get_unused_unit.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 integer function get_unused_unit() result(iunit)

--- a/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/kwm_date_utilities.F
+++ b/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/kwm_date_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_date_utilities
@@ -23,7 +23,7 @@ contains
   subroutine geth_newdate (ndate, odate, idt)
     implicit none
 
-!  From old date ('YYYY-MM-DD HH:MM:SS.ffff') and 
+!  From old date ('YYYY-MM-DD HH:MM:SS.ffff') and
 !  delta-time, compute the new date.
 
 !  on entry     -  odate  -  the old hdate.
@@ -379,7 +379,7 @@ contains
        else if (nlen.eq.13) then
           write(ndate,13) yrnew, monew, dynew, hrnew
 13        format(i4,'-',i2.2,'-',i2.2,'_',i2.2)
-          
+
        else if (nlen.eq.10) then
           write(ndate,10) yrnew, monew, dynew
 10        format(i4,'-',i2.2,'-',i2.2)
@@ -387,7 +387,7 @@ contains
        end if
 
        if (olen.ge.11) ndate(11:11) = sp
-       
+
     else
 
        if (nlen.gt.20) then
@@ -406,7 +406,7 @@ contains
        else if (nlen.eq.10) then
           write(ndate,210) yrnew, monew, dynew, hrnew
 210       format(i4,i2.2,i2.2,i2.2)
-          
+
        else if (nlen.eq.8) then
           write(ndate,8) yrnew, monew, dynew
 8         format(i4,i2.2,i2.2)
@@ -421,7 +421,7 @@ contains
   subroutine geth_idts (newdate, olddate, idt)
     implicit none
 
-!  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'), 
+!  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'),
 !  compute the time difference.
 
 !  on entry     -  newdate  -  the new hdate.
@@ -551,7 +551,7 @@ contains
              end if
           end if
        end if
-       
+
 !  Break down new hdate into parts
 
        read(ndate(6:7),  '(i2)') monew
@@ -586,7 +586,7 @@ contains
              end if
           end if
        end if
-       
+
 !  Break down new hdate into parts
 
        read(ndate(5:6),  '(i2)') monew
@@ -794,7 +794,7 @@ contains
     integer, intent(in) :: year ! Four-digit year
 
     nfeb = 28 ! By default, February has 28 days ...
-    if (mod(year,4).eq.0) then  
+    if (mod(year,4).eq.0) then
        nfeb = 29  ! But every four years, it has 29 days ...
        if (mod(year,100).eq.0) then
           nfeb = 28  ! Except every 100 years, when it has 28 days ...

--- a/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/kwm_plot_utilities.F
+++ b/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/kwm_plot_utilities.F
@@ -3,7 +3,7 @@
 !
 ! This is very much a work in progress.
 !
-! A lot of this has been adapted from Mark Stoelinga's RIP program, 
+! A lot of this has been adapted from Mark Stoelinga's RIP program,
 ! which is highly recommended.
 !
 module kwm_plot_utilities
@@ -13,7 +13,7 @@ module kwm_plot_utilities
 
 
   ! NCO:  number of already-defined and named colors
-  integer :: nco 
+  integer :: nco
 
   type named_color
      character(len=20) :: name
@@ -85,7 +85,7 @@ contains
 ! Opens workstation 1 as a CGM workstation.
 ! Opens workstation 2 as a WISS.
 ! Defines a couple of colors, and sets a couple of NCAR Graphics parameters
-! 
+!
 ! If you want the gmeta file to be called something other than "gmeta",
 ! give this subroutine the optional argument.
     implicit none
@@ -133,7 +133,7 @@ contains
 !****************************************************************************************
 
   subroutine gset_named_color(NAME)
-    ! Calls NCAR-Graphics subroutine GSCR to set the next color index 
+    ! Calls NCAR-Graphics subroutine GSCR to set the next color index
     ! to the rgb values indicated by the color named NAME.
 
     ! Side effects:  Associate RGB values with a color index NCO.
@@ -487,7 +487,7 @@ contains
 
 !KWM    print*, 'usq = ', usq(1:numcon)
 
-! Number of areas for filling is one plus the number of contours, 
+! Number of areas for filling is one plus the number of contours,
 ! i.e., the contours define the boundaries between areas.
     nconarea = numcon+1
 
@@ -521,7 +521,7 @@ contains
     nco = nco - 1
     icomax = nco
 !
-! USIT is now our list of color names and associated rgb values in 
+! USIT is now our list of color names and associated rgb values in
 ! our color sequence.  Color values in USIT correspond to USQ
 
 ! Note that we haven't actually called GSCR to assign RGB values to
@@ -846,7 +846,7 @@ contains
     elseif (val.ge.valcon(numcon)) then
        if (usit(nsq)%name /= "transparent" ) c = usit(nsq)
     else
-       ! Interpolate from USIT rgb values (associated with RSQ 
+       ! Interpolate from USIT rgb values (associated with RSQ
        ! floating-point values) to a new color c.
 
        do isq=1,nsq-1
@@ -1477,7 +1477,7 @@ contains
 !****************************************************************************************
 
   subroutine set_gscr_color_indices(is,ie,seqstr)
-    ! Set all the ncargks color indices between IS and IE to the 
+    ! Set all the ncargks color indices between IS and IE to the
     ! colors listed in the SEQSTR
 
     implicit none
@@ -1711,8 +1711,8 @@ contains
     iymin = floor   ( (10.0**(real(-expn))) * ymin )
     iymax = ceiling ( (10.0**(real(-expn))) * ymax )
     irange = (iymax-iymin)
-  
-    ! If we've got too many steps between iymin and iymax, 
+
+    ! If we've got too many steps between iymin and iymax,
     ! then shift to the next power-of-ten for our scaling.
     if (irange > 20) then
        iymin = floor  (real(iymin)*0.1)
@@ -1761,7 +1761,7 @@ contains
     if (present(line_width)) then
        call gslwsc(line_width_save)
     endif
-    
+
   end subroutine line_in_color_integer
 
   subroutine line_in_color_string(x1, y1, x2, y2, color, line_width)
@@ -1797,7 +1797,7 @@ contains
     if (present(line_width)) then
        call gslwsc(line_width_save)
     endif
-    
+
   end subroutine line_in_color_string
 
 !****************************************************************************************
@@ -1809,7 +1809,7 @@ contains
     ! At the end of the routine, the original color and line_width settings are
     ! restored.
     !
-    ! Values more negative than -1.E25 are considered bad data.  
+    ! Values more negative than -1.E25 are considered bad data.
     !    if (on_missing == "SKIP") then
     !        Skip over bad data, connecting all good data points in order.
     !    else if (on_missing == "BREAK") then

--- a/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/kwm_string_utilities.F
+++ b/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/kwm_string_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_string_utilities
@@ -68,7 +68,7 @@ contains
           return_string(j:j) = string(i:i)
        endif
     enddo
-    
+
   end function unblank
 
 !KWM  character function upcase(h)
@@ -87,7 +87,7 @@ contains
     implicit none
     character(len=*), intent(in) :: h
     integer :: i
-    
+
     return_string = ""
 
     do i = 1, len_trim(h)

--- a/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/lccone.F
+++ b/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/lccone.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 subroutine lccone (fsplat,ssplat,sign,confac)

--- a/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/llxy_generic.F
+++ b/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/llxy_generic.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 subroutine lltoxy_generic (xlat,xlon,x,y,&
@@ -88,7 +88,7 @@ subroutine lltoxy_generic (xlat,xlon,x,y,&
   else
      londiff = (xlon-cenlon)*degrad
   endif
-     
+
 
   if (project(1:2) .eq. 'ME') then
 
@@ -104,8 +104,8 @@ subroutine lltoxy_generic (xlat,xlon,x,y,&
 !KWM     di = re*(rlon-rfln)
 !KWM     y = refy + dj/dskm
 !KWM     x = refx + di/dskm
-     
-     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms 
+
+     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms
      ! of thousandths of degrees!
      !  Calculate the distance from the horizontal axis to (J,I)
      dj = xlat-reflat
@@ -259,7 +259,7 @@ subroutine xytoll_generic (x,y,xlat,xlon,&
 
 ! If the projection is cylindrical equidistant ('CE') then ...
   else if (project(1:2) .eq. 'CE') then
-     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms 
+     ! NOTE:  Cylindrical Equidistant grid increment expressed in terms
      ! of thousandths of degrees!
      di = (x-refx) * dskm
      !  Calculate the distance from the horizontal axis to (J,I)
@@ -281,7 +281,7 @@ subroutine xytoll_generic (x,y,xlat,xlon,&
      tt2 = tan((pi2 - rflt  )*0.5)    ! Tangent Term 2.
      ct1 = -cos(flat1) * re/confac   ! cosine Term 1.
 
-     ! Calculate the (projected) distance from the pole to 
+     ! Calculate the (projected) distance from the pole to
      ! the reference lat/lon.
      drp = ct1 * (tt2/tt1)**confac
      ! Now from the pole to the reference y along the center lon.
@@ -320,7 +320,7 @@ subroutine xytoll_generic (x,y,xlat,xlon,&
      dii = drp * sin(rcln-rfln)
      di = dii + ((x-refx)*dskm)
      ! Calculate the Big Messy quantity as would be done for LC
-     ! projections.  This quantity is different in value, same 
+     ! projections.  This quantity is different in value, same
      ! in purpose of BM above
      bm = (1.0/re) * sqrt(di*di + dj*dj) / (1.0 + cos(pi2-flat1))
      !  Calculate the desired latitude in radians

--- a/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/module_hd.F
+++ b/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/module_hd.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_hd
@@ -83,7 +83,7 @@ contains
     start(2) = time_index
     nfcount(1) = DateStrLen
     nfcount(2) = 1
-    
+
     iret = nf90_get_var(ncid, varid, time_return, start, nfcount)
     if (iret /= 0) then
        write(*,'("netcdf_get_time:  NF90_GET_VAR:  ",A)') nf90_strerror(iret)

--- a/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/rdmet.F
+++ b/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/rdmet.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 subroutine rdmet(okmeso_met, nstation, station, idate, pcp, Tair_out, TS05_out, TS10_out, TS30_out)
@@ -166,7 +166,7 @@ subroutine rdmet(okmeso_met, nstation, station, idate, pcp, Tair_out, TS05_out, 
            if (PRES > 0) PRES = PRES * 1.E2
 
            ! Convert RELH to Qv:
-           
+
            call RHtoQV( RELH, Tair, PRES, Qv )
 
            ! Convert WSPD and WDIR to U and V
@@ -175,7 +175,7 @@ subroutine rdmet(okmeso_met, nstation, station, idate, pcp, Tair_out, TS05_out, 
 
            ! Don't allow negative Short-Wave radiation.
 
-           SRAD = max(SRAD,0.0) 
+           SRAD = max(SRAD,0.0)
 
            pcp(i) = rain
 
@@ -183,7 +183,7 @@ subroutine rdmet(okmeso_met, nstation, station, idate, pcp, Tair_out, TS05_out, 
            TS05_out(i) = TS05
            TS10_out(i) = TS10
            TS30_out(i) = TS30
-           
+
            exit StnLoop
         endif
 
@@ -244,5 +244,5 @@ subroutine SDtoUV(WSPD, WDIR, U, V)
      u = -999
      v = -999
   endif
-  
+
 end subroutine SDtoUV

--- a/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/rdsom.F
+++ b/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/rdsom.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_ver
@@ -95,7 +95,7 @@ program ver
 
      ! Get corresponding HRLDAS results from HRLDAS files
      call rdhrldas(station, stnlat, stnlon, nstation, nowdate, sm(1:4,1:nstation,indx))
-     
+
   enddo DATELOOP
 
   ! Make some plots
@@ -150,7 +150,7 @@ subroutine pltsm(stn, wc, sm, nlev, ndim, startdate, stnlat, stnlon, stnx, stny)
      else if (n == 2) then
         call set(.1, .9, .15, .4, 1., float(ndim), 0., 0.5, 1)
      endif
-        
+
      call periml(0,0,5,1)
 
      call gsplci(color_index("blue"))
@@ -219,7 +219,7 @@ subroutine rdgeomeso(station, nstation, stnlat, stnlon, maxstn, iverbose)
   enddo RDLOOP
   close(iunit)
 end subroutine rdgeomeso
-  
+
 
 subroutine rdsom(stn, idate, wc)
   implicit none
@@ -246,9 +246,9 @@ subroutine rdsom(stn, idate, wc)
   write(flnm, &
        '("/wig/kmanning/HRLDAS_WRFDRIVER/VERIFICATION/OKMeso_SoilMoisture_SOM/",A8,".som")') &
    idate(1:8)
-  
+
   open(iunit, file=trim(flnm), status='old', form='formatted', action='read')
-  
+
   RDLOOP : do
      read(iunit, '(A256)', iostat=ierr) string
      if (ierr /= 0) exit RDLOOP
@@ -411,7 +411,7 @@ subroutine rdhrldas(stn, stnlat, stnlon, nstation, idate, sm)
   write(flnm, &
    '("/scholar2/kmanning/VERY_TEMPORARY_HRLDAS/Run_3.2/",A10,".LDASOUT_DOMAIN1")') idate(1:10)
 
-  
+
   iret = nf_open(flnm, NF_WRITE, ncid)
   if (iret /= 0) then
      write(*,'("Problem opening flnm: ''", A, "''")') &
@@ -473,5 +473,3 @@ subroutine rdhrldas(stn, stnlat, stnlon, nstation, idate, sm)
   enddo
 
 end subroutine rdhrldas
-
-

--- a/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/rdsom_mem.F
+++ b/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/rdsom_mem.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_ver
@@ -752,7 +752,7 @@ subroutine pltsm(stn, wc, sm, st, nlev, ndim, startdate, stnlat, stnlon, stnx, s
   character(len=256) :: text
   character(len=10)  :: enddate
   logical :: pd
-  
+
   real :: wcmean, smmean
   integer :: wccount, smcount
 
@@ -821,7 +821,7 @@ subroutine pltsm(stn, wc, sm, st, nlev, ndim, startdate, stnlat, stnlon, stnx, s
      else if (n == 2) then
         call set(.1, .9, .15, .4, 0., float(ndim-1)/24., 0., 0.5, 1)
      endif
-        
+
      call periml((ndim-1)/24,0,5,1)
 
      if (flag(n,1) == 1) then
@@ -862,11 +862,11 @@ subroutine pltsm(stn, wc, sm, st, nlev, ndim, startdate, stnlat, stnlon, stnx, s
            else
               call gsplci(color_index("gray90"))
            endif
-           
+
         endif
      enddo
      call plotif(0., 0., 2)
-     
+
      call gsplci(color_index("red"))
      smmean = 0.
      smcount = 0
@@ -940,7 +940,7 @@ subroutine pltsm(stn, wc, sm, st, nlev, ndim, startdate, stnlat, stnlon, stnx, s
   call set(0., 1., 0., 1., 0., 1., 0., 1., 1)
   call pchiqu(0.56, 0.85, "Soil T: ", 0.012, 0., -1.)
   call pchiqu(0.56, 0.82, "Soil T: ", 0.012, 0., -1.)
-  
+
 
 
 
@@ -951,7 +951,7 @@ subroutine pltsm(stn, wc, sm, st, nlev, ndim, startdate, stnlat, stnlon, stnx, s
      else if (n == 2) then
         call set(.1, .9, .15, .4, 0., float(ndim-1)/24., 275., 305., 1)
      endif
-        
+
      call periml((ndim-1)/24,0,5,1)
 
   call gflas3(2)
@@ -1083,7 +1083,7 @@ subroutine rdgeomeso(okmeso_soil_dir, station, nstation, stnlat, stnlon, maxstn,
   enddo RDLOOP
   close(iunit)
 end subroutine rdgeomeso
-  
+
 
 subroutine rdsom(okmeso_soil_dir, stn, idate, wc)
   implicit none
@@ -1105,9 +1105,9 @@ subroutine rdsom(okmeso_soil_dir, stn, idate, wc)
 
 
   write(flnm, '(A,"/",A8,".som")') okmeso_soil_dir, idate(1:8)
-  
+
   open(iunit, file=trim(flnm), status='old', form='formatted', action='read')
-  
+
   RDLOOP : do
      read(iunit, '(A256)', iostat=ierr) string
      if (ierr /= 0) exit RDLOOP
@@ -1178,7 +1178,7 @@ subroutine rdhrldas(ldasout_dir, stn, stnlat, stnlon, nstation, idate, sm, st)
   endif
 
   call netcdf_open(trim(tmpflnm), nfstruct)
-  
+
   ! Read a soil-moisture field
 
   call netcdf_get_field_3d(nfstruct, "SOIL_M", 1, smptr)
@@ -1241,7 +1241,7 @@ subroutine qc_sm(wc, flag, indx)
 
   ! Find the first unflagged value.
   jm = 1
-  do while (flag(jm) == 1) 
+  do while (flag(jm) == 1)
      jm = jm + 1
      if (jm > indx) exit
   enddo
@@ -1253,10 +1253,10 @@ subroutine qc_sm(wc, flag, indx)
 
      ! Find the next unflagged value.
      jp = jm + 1
-     if (jp > indx) exit TIMELOOP 
-     do while (flag(jp) == 1) 
+     if (jp > indx) exit TIMELOOP
+     do while (flag(jp) == 1)
         jp = jp + 1
-        if (jp > indx) exit TIMELOOP 
+        if (jp > indx) exit TIMELOOP
      enddo
 
      if ((wc(jp) == val1) .or. (wc(jp) == val2)) then
@@ -1299,7 +1299,7 @@ subroutine qc_sm(wc, flag, indx)
      do i = 2, indx
 
         if ((wc(n,i) >= 0).and.(wc(n,i-1)>=0) ) then
-           
+
            if (abs(wc(n,i)-wc(n,i-1)) < 5.E-3) then
            ! if there's no (little) change:
 
@@ -1349,7 +1349,7 @@ subroutine read_namelist(okmeso_soil_dir, okmeso_met_dir, ldasout_dir, startdate
   okmeso_met_dir  = "UNSPECIFIED"
   ldasout_dir     = "UNSPECIFIED"
 
-  
+
   namelist /okmeso/ okmeso_soil_dir, okmeso_met_dir, ldasout_dir, &
        statistics_startdate, statistics_enddate
 
@@ -1369,4 +1369,3 @@ subroutine read_namelist(okmeso_soil_dir, okmeso_met_dir, ldasout_dir, startdate
   enddate   = statistics_enddate
 
 end subroutine read_namelist
-

--- a/src/Land_models/NoahMP/HRLDAS_forcing/create_forcing.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/create_forcing.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 program create_forcing
@@ -34,7 +34,7 @@ program create_forcing
   type (geo_em_type) :: geo_em
 
 
-  integer, parameter :: MAXTEMPLATE = 10      
+  integer, parameter :: MAXTEMPLATE = 10
 
   type DataBuffer
      character(len=256)                         :: label
@@ -91,7 +91,7 @@ program create_forcing
   type (DataBuffer) :: lai
 
   integer, pointer, dimension(:,:)   :: tempint    ! temporary array
-  
+
   real , dimension(4) :: dzs, zs
 
   integer :: i, j
@@ -152,7 +152,7 @@ program create_forcing
 
 
 
-  namelist /files/ startdate, enddate, DataDir, OutputDir, & 
+  namelist /files/ startdate, enddate, DataDir, OutputDir, &
        geo_em_flnm,                                        &
        rainfall_interp, full_ic_frq, rescale_shortwave,    &
        update_snow, forcing_height_2d,                     &
@@ -164,7 +164,7 @@ program create_forcing
        PCPfile_secondary, Hfile_template, WEASDfile_template,&
        CANWTfile_template, SKINTfile_template, STfile_template, &
        SMfile_template, Zfile_template, LANDSfile_template
-       
+
 
   full_ic_frq        = 0
   rainfall_interp    = 1
@@ -222,7 +222,7 @@ program create_forcing
      write(*,*)
      stop
   endif
-  read(12,files) 
+  read(12,files)
   close(12)
 
 !--------------------------------------------------------------------------
@@ -375,7 +375,7 @@ program create_forcing
      call process(date, PCP1current, PCP1prev, PCP1post, geo_em, expand_loop)
      call process(date, PCP2current, PCP2prev, PCP2post, geo_em, expand_loop)
      if(forcing_height_2d) call process(date, Hcurrent, Hprev, Hpost, geo_em, expand_loop)
-     
+
      call open_netcdf_for_output( &
           trim(OutputDir)//date(1:4)//date(6:7)//date(9:10)//date(12:13)//".LDASIN_DOMAIN"//hgrid, &
           ncid, version, geo_em%idim, geo_em%jdim, geo_em, .false.)
@@ -396,7 +396,7 @@ program create_forcing
      ! If the sun isn't up, there shouldn't be any SW.
      ! This may be a little extreme (ignores atmospheric refraction effects, e.g.); it 
      ! causes an awfully abrupt terminator.  Will have to consider.
-     
+
      if (truncate_sw) &
        call nighttime_SW(SW1current%hdate, SW1current%field, geo_em%idim, geo_em%jdim, geo_em)
 
@@ -422,7 +422,7 @@ program create_forcing
       	 stop
        end if
      end if
-     
+
      call output_databuffer(ncid,    Tcurrent)
      call output_databuffer(ncid,    Qcurrent)
      call output_databuffer(ncid,    Pcurrent)
@@ -459,7 +459,7 @@ program create_forcing
              ncid, version, geo_em%idim, geo_em%jdim, geo_em, .true.)
 
            call output_timestring_to_netcdf(ncid, date)
-   
+
            where(geo_em%use == geo_em%iswater .or. geo_em%use == geo_em%islake) geo_em%tmn = -1.e36
 
            call output_to_netcdf(ncid,     "XLAT", "degree_north", geo_em%lat, geo_em%idim, geo_em%jdim)
@@ -615,7 +615,7 @@ program create_forcing
   deallocate(geo_em%ter, stat=ierr)
   deallocate(geo_em%use, stat=ierr)
   deallocate(geo_em%veg, stat=ierr)
-  
+
   call grib2_clear_parameter_table
 
 
@@ -633,7 +633,7 @@ contains
     character(len=64) :: val
     integer :: vcount
 
-    ! 
+    !
     ! Open the file
     !
     open(12, file=filename, status='old', form='formatted', iostat=ierr)
@@ -779,8 +779,8 @@ contains
     !
     ! Copy the databuffer type from <in> to <out>
     !
-    ! We do this to be explicit in allocating new memory for 
-    ! pointer array <out%field>, and copying the data from 
+    ! We do this to be explicit in allocating new memory for
+    ! pointer array <out%field>, and copying the data from
     ! <in%field> to <out%field> (instead of merely pointing
     ! <out%field> => <in%field>
     implicit none
@@ -804,7 +804,7 @@ contains
        nullify(out%field)
     endif
 
-    
+
   end subroutine copy_data_buffer
 
 !==============================================================================
@@ -836,9 +836,9 @@ contains
 
 
     ! The fatality level in the DataBuffer structure indicates what sort
-    ! of errors are fatal and what sort of errors we want to try to 
+    ! of errors are fatal and what sort of errors we want to try to
     ! recover from.
-    ! 
+    !
     ! fatality==0 means that any problem is a fatal error, and we stop.
     !
     ! fatality==2 means that if we cannot find a matching file, and we
@@ -1004,7 +1004,7 @@ contains
        deallocate(datastruct%data)
        nullify(datastruct%data)
 
-! Barlage 20140529: comment the following 
+! Barlage 20140529: comment the following
 !       if ( (current%label(1:6) == "STEMP_") .or. (current%label(1:6) == "SMOIS_") ) then
 !          where (geo_em%use == geo_em%iswater) current%field=-1.E36
 !       endif
@@ -1024,7 +1024,7 @@ contains
        return
 
     endif
-    
+
     ! We did not find data.  Let's try to temporally interpolate.
 
     ! A "prev" buffer must exist for us.  Check that.
@@ -1040,7 +1040,7 @@ contains
        endif
 
        write(*,'("Field label= ",A)') trim(current%label)
-       write(*,'("No previous data.")') 
+       write(*,'("No previous data.")')
        stop "FATAL ERROR: No previous data"
     endif
 
@@ -1088,7 +1088,7 @@ contains
        endif
 
        if (current%label == "RAINRATE") then
-          ! Don't temporally interpolate the rain rate.  
+          ! Don't temporally interpolate the rain rate.
           allocate(current%field(size(prev%field,1), size(prev%field,2)))
           ! Take the "post" field, because that field should be the accumulation
           ! between "prev" and "post"
@@ -1149,7 +1149,7 @@ contains
     nullify(datastruct%data)
 
     if (current%label == "RAINRATE") then
-       ! Don't temporally interpolate the rain rate.  
+       ! Don't temporally interpolate the rain rate.
        ! Simply carry the previous value forward.
        allocate(current%field(size(prev%field,1), size(prev%field,2)))
        current%field = post%field
@@ -1157,7 +1157,7 @@ contains
        call temporal_interpolation(prev, post, current)
     endif
 
-    ! We have the data we want, and prev and post are both up-to-date, 
+    ! We have the data we want, and prev and post are both up-to-date,
     ! so we can exit.
 
   end subroutine process
@@ -1166,11 +1166,11 @@ contains
 !==============================================================================
 
   subroutine expand_9pt_input(data, nx, ny, maxloop)
-  
-  ! This routine checks for missing data in the input forcing and 
+
+  ! This routine checks for missing data in the input forcing and
   !  expands using a 9pt average; Added to deal with input data such
   !  as NLDAS which doesn't have any values over water
-  
+
     implicit none
     integer,                    intent(in)      :: nx
     integer,                    intent(in)      :: ny
@@ -1606,7 +1606,7 @@ contains
     description = " "
 
 ! Barlage: is it necessary to read external grib tables? why not just read namelist table for this info 20150518
-!   
+!
 !    call grib_parameter_text_information(grib, name, units, description)
 ! Barlage: move assignment up 20150518
 !    datastruct%desc   = description
@@ -1623,7 +1623,7 @@ contains
 
     datastruct%nx = grib%mapinfo%nx
     datastruct%ny = grib%mapinfo%ny
-    
+
     call map_init(datastruct%proj)
 !KWM    datastruct%proj%lat1 = grib%mapinfo%lat1
 !KWM    if (grib%mapinfo%lon1 > 180) then
@@ -1636,7 +1636,7 @@ contains
 
        call map_set(PROJ_LATLON, datastruct%proj, lat1=grib%mapinfo%lat1, lon1=grib%mapinfo%lon1, &
             latinc=grib%mapinfo%dy, loninc=grib%mapinfo%dx, knowni=1.0, knownj=1.0)
-       
+
     else if (grib%mapinfo%hproj == "LC") then
 
        call map_set(PROJ_LC, datastruct%proj, lat1=grib%mapinfo%lat1, lon1=grib%mapinfo%lon1, &
@@ -1675,7 +1675,7 @@ contains
        endif
        datastruct%hdate(15:16) = "00"
        ! TEST:  Set zero data values to missing data for GCIP SW fields
-       ! where (datastruct%data <= 0) datastruct%data = -1.E36 
+       ! where (datastruct%data <= 0) datastruct%data = -1.E36
     endif
 
 !MB: want mm units in v3.7
@@ -1725,14 +1725,14 @@ contains
           if (processing(1:12) == "Accumulation") then
              oldmax = maxval(datastruct%data, mask=(datastruct%data > -1.E25))
              write(*,'(13x, "Maxval adjusted from ", F12.6)', advance="no") oldmax
-             where (datastruct%data > -1.E25) 
+             where (datastruct%data > -1.E25)
                 datastruct%data = datastruct%data * (1.0 / float(p2_seconds - p1_seconds))
              endwhere
              newmax = maxval(datastruct%data, mask=(datastruct%data > -1.E25))
              write(*,'(" to ", F12.6, ":    factor of ", I8)') newmax, NINT(oldmax/newmax)
              ! Change the units to mm/s, reflecting the rescaling we just did.
              datastruct%units = "mm/s"
-          else 
+          else
              stop "FATAL ERROR: Precip Problem A?"
           endif
        elseif ( (datastruct%units == "kg/m^2/s") ) then ! For example, GLDAS; MB v3.7
@@ -1999,7 +1999,7 @@ subroutine open_netcdf_for_output(output_flnm, ncid, version, ix, jx, geo_em, in
 
   ierr = nf90_put_att(ncid, NF90_GLOBAL, "MAP_PROJ", geo_em%proj%code)
   call error_handler(ierr, "Problem nf90_put_att MAP_PROJ")
- 
+
   if (init) then
 
     ierr = nf90_put_att(ncid, NF90_GLOBAL, "GRID_ID", geo_em%grid_id)
@@ -2010,13 +2010,13 @@ subroutine open_netcdf_for_output(output_flnm, ncid, version, ix, jx, geo_em, in
 
     ierr = nf90_put_att(ncid, NF90_GLOBAL, "ISLAKE", geo_em%islake)
     call error_handler(ierr, "Problem nf90_put_att ISLAKE")
-  
+
     ierr = nf90_put_att(ncid, NF90_GLOBAL, "ISURBAN", geo_em%isurban)
     call error_handler(ierr, "Problem nf90_put_att ISURBAN")
-  
+
     ierr = nf90_put_att(ncid, NF90_GLOBAL, "ISICE", geo_em%isice)
     call error_handler(ierr, "Problem nf90_put_att ISICE")
-  
+
   end if
 
 !
@@ -2041,7 +2041,7 @@ subroutine output_timestring_to_netcdf(ncid, hdate)
   implicit none
   integer,                     intent(in) :: ncid
   character(len=*),            intent(in) :: hdate
-  
+
   integer,          parameter                :: DateStrLen = 19
   character(len=1), dimension(DateStrLen, 1) :: output_hdate
   integer                                    :: dimid_datestrlen
@@ -2054,7 +2054,7 @@ subroutine output_timestring_to_netcdf(ncid, hdate)
   do i = 1, len(hdate)
      output_hdate(i,1) = hdate(i:i)
   enddo
-  
+
   ierr = nf90_inq_dimid(ncid, "Time", dimid_time)
   call error_handler(ierr, "OUTPUT_TIMESTRING_TO_NETCDF: Problem finding dimension 'Time'")
 
@@ -2135,12 +2135,12 @@ subroutine output_to_netcdf_soil(ncid, name, units, array1, array2, array3, arra
   character(len=*), intent(in) :: units
   integer, intent(in) :: idim, jdim, nsoil
   real, dimension(idim,jdim), intent(in) :: array1, array2, array3, array4
-  
+
   real, dimension(idim,jdim,nsoil) :: array3d
 
   integer :: varid, ierr
   integer :: dimid_time, dimid_ix, dimid_jx, dimid_kx
-  
+
   array3d(:,:,1) = array1
   array3d(:,:,2) = array2
   array3d(:,:,3) = array3
@@ -2297,7 +2297,7 @@ end subroutine fillsm
 !==============================================================================
 
 subroutine interp_rainfall_nearest_neighbor(datastruct, newarr, mix, mjx, geo_em)
-  ! 
+  !
   ! Fill array <newarr> with rainfall data from <datastruct>
   !
   use module_input_data_structure
@@ -2397,14 +2397,14 @@ subroutine interp_rainfall(datastruct, newarr, mix, mjx, geo_em)
   ! field's grid cells to various WRF grid cells as necessary.
 
   ! We recompute the mapping information every time, in case our source grid has changed.
-     
+
   ILOOP : do i = 1, datastruct%nx
      JLOOP : do j = 1, datastruct%ny
         ! Compute (x,y) in WRF grid of point (gx,gy) in precip grid.
 !KWM        call datastruct_xytoll(float(i), float(j), xlat, xlon, datastruct)
         call ij_to_latlon(datastruct%proj, float(i), float(j), xlat, xlon)
         call latlon_to_ij(geo_em%proj, xlat, xlon, x, y)
-        ! Now X and Y are the x and y coordinates in the WRF 
+        ! Now X and Y are the x and y coordinates in the WRF
         ! grid of the RAINFALL point i, j.
 
         if ((x > -2) .and. (y > -2) .and. (x < mix+2) .and. (y < mjx+2)) then
@@ -2552,7 +2552,7 @@ subroutine another_interp_rainfall(datastruct, newarr, mix, mjx, geo_em)
            call ij_to_latlon(datastruct%proj, float(i), float(j), xlat, xlon)
            call latlon_to_ij(geo_em%proj, xlat, xlon, mxa(i,j), mya(i,j))
 
-           ! Now MX and MY are the x and y coordinates in the WRF 
+           ! Now MX and MY are the x and y coordinates in the WRF
            ! grid of the RAINFALL point i, j.
 
         if ((mxa(i,j) > -2) .and. (mya(i,j) > -2) .and. (mxa(i,j) < mix+2) .and. (mya(i,j) < mjx+2)) then
@@ -2801,4 +2801,3 @@ end subroutine close_flnm
 
 !==============================================================================
 !==============================================================================
-

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/arguments_module.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/arguments_module.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module arguments_module
@@ -278,7 +278,7 @@ contains
     else
 ! STRING is a default string value.
 ! Handle the case of optional unflagged string arguments.
-    
+
        if (numarg > 0) then
           if (harg(1)(1:1) == "-") then
              call print_help
@@ -326,7 +326,7 @@ contains
     integer :: nval, i, ierr
 
     call initialize
-    
+
     if (numarg /= 1) then
        write(*,'(/,"WARNING: A final command-line argument MUST be present.")')
        call print_help
@@ -359,7 +359,7 @@ contains
     enddo
 
   end subroutine argsub
-    
+
 !==============================================================================
 
   subroutine print_help
@@ -417,4 +417,3 @@ end module arguments_module
 !KWM  print*, 'flnm = ', trim(flnm)
 !KWM
 !KWMend program test1
-

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/gbytesys.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/gbytesys.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !-----------------------------------------------------------------------

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/get_unused_unit.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/get_unused_unit.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 integer function get_unused_unit() result(iunit)

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/kwm_date_utilities.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/kwm_date_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_date_utilities
@@ -23,7 +23,7 @@ contains
   subroutine geth_newdate (ndate, odate, idt)
     implicit none
 
-!  From old date ('YYYY-MM-DD HH:MM:SS.ffff') and 
+!  From old date ('YYYY-MM-DD HH:MM:SS.ffff') and
 !  delta-time, compute the new date.
 
 !  on entry     -  odate  -  the old hdate.
@@ -379,7 +379,7 @@ contains
        else if (nlen.eq.13) then
           write(ndate,13) yrnew, monew, dynew, hrnew
 13        format(i4,'-',i2.2,'-',i2.2,'_',i2.2)
-          
+
        else if (nlen.eq.10) then
           write(ndate,10) yrnew, monew, dynew
 10        format(i4,'-',i2.2,'-',i2.2)
@@ -387,7 +387,7 @@ contains
        end if
 
        if (olen.ge.11) ndate(11:11) = sp
-       
+
     else
 
        if (nlen.gt.20) then
@@ -406,7 +406,7 @@ contains
        else if (nlen.eq.10) then
           write(ndate,210) yrnew, monew, dynew, hrnew
 210       format(i4,i2.2,i2.2,i2.2)
-          
+
        else if (nlen.eq.8) then
           write(ndate,8) yrnew, monew, dynew
 8         format(i4,i2.2,i2.2)
@@ -421,7 +421,7 @@ contains
   subroutine geth_idts (newdate, olddate, idt)
     implicit none
 
-!  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'), 
+!  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'),
 !  compute the time difference.
 
 !  on entry     -  newdate  -  the new hdate.
@@ -551,7 +551,7 @@ contains
              end if
           end if
        end if
-       
+
 !  Break down new hdate into parts
 
        read(ndate(6:7),  '(i2)') monew
@@ -586,7 +586,7 @@ contains
              end if
           end if
        end if
-       
+
 !  Break down new hdate into parts
 
        read(ndate(5:6),  '(i2)') monew
@@ -794,7 +794,7 @@ contains
     integer, intent(in) :: year ! Four-digit year
 
     nfeb = 28 ! By default, February has 28 days ...
-    if (mod(year,4).eq.0) then  
+    if (mod(year,4).eq.0) then
        nfeb = 29  ! But every four years, it has 29 days ...
        if (mod(year,100).eq.0) then
           nfeb = 28  ! Except every 100 years, when it has 28 days ...

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/kwm_grid_utilities.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/kwm_grid_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_grid_utilities
@@ -97,20 +97,20 @@ contains
           endif
        enddo
     enddo
-    
+
     ! STL = ARRAY( I-1:I+2 , J-1:J+2 )
 
     ! if (ANY(STL<-1.E25)) then
     !    val = -1.E36
     !    return
     ! endif
-    
+
     ! Corner points missing are OK.  Any other points missing and we have a problem.
     if ((ANY(STL(:,2:3)<-1.E25)) .or. (ANY(STL(2:3,:)<-1.E25))) then
-    
+
     ! Barlage 20150522: if this is violated, send back the average if any points are
     !                   valid, this could prevent problems if close to source boundary
-    
+
       if (ANY(STL > -1.E25)) then
         val = sum(STL, MASK = STL > -1.E25)
         number_good = count(STL > -1.E25)
@@ -118,7 +118,7 @@ contains
       else
        val = -1.E36
       end if
-      
+
       return
     endif
 
@@ -149,7 +149,7 @@ contains
   end function bint_p
 
   REAL FUNCTION ONED(X,A,B,C,D) result(val)
-    ! Points B and C must have good data.  
+    ! Points B and C must have good data.
     ! Points A and D may have the no-data indication (value less than -1.E25)
     implicit none
     real, intent(in) :: X, A, B, C, D
@@ -177,7 +177,7 @@ contains
           val = (1.0-X)*(B+X*(0.5*(C-A)+X*(0.5*(C+A)-B)))+X*(C+(1.0-X)*(0.5 &
                *(B-D)+(1.0-X)*(0.5*(B+D)-C)))
        endif
-       
+
     endif
   END FUNCTION ONED
 
@@ -285,15 +285,15 @@ contains
    ! Purpose: Weighted average of sixteen surrounding grid point values
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    real function wt_sixteen_pt_average(array, nx, ny, x, y, msgvalin, msgvalout) result(val)
- 
+
       implicit none
-  
+
       ! Arguments
       integer, intent(in) :: nx, ny
       real, pointer, dimension(:,:) :: array
       real, intent(in) :: x, y               ! The location to interpolate to
       real, intent(in) :: msgvalin,msgvalout
-    
+
       ! Local variables
       integer :: i, j, ifx, ify
       integer :: arrayistart,arrayiend,arrayjstart,arrayjend
@@ -305,8 +305,8 @@ contains
 
       ifx = floor(x)
       ify = floor(y)
-  
-      ! First see whether the point is far enough within the array to 
+
+      ! First see whether the point is far enough within the array to
       !   allow for a sixteen point average. If not, fill with missing values.
       if (ifx < 2 .or. ifx > nx-2 .or. ify < 2 .or. ify > ny-2) then
          subset = msgvalin
@@ -334,12 +334,12 @@ contains
 !	 print *, array(ifx-1:ifx+2,ify-1:ify+2)
 !	 print *, subset
 !	 stop
-  
+
       sum_weight = 0.0
       pcoef = 2.0
       do i=1,4
          do j=1,4
-   
+
             if (subset(i,j) == msgvalin) then
                weights(i,j) = 0.0
             else
@@ -347,9 +347,9 @@ contains
                weights(i,j) = max(0., 2.0 - distance(i,j))  ! from WPS
 !               weights(i,j) = min(2.0,1.0/(max(0.1,distance(i,j)))**pcoef)  ! IDW looks strange
             end if
-    
+
             sum_weight = sum_weight + weights(i,j)
-   
+
          end do
       end do
       goto 1000
@@ -368,7 +368,7 @@ contains
 	 print *, subset(:,1)
 	 print *, sum_weight
 !	 stop
-1000 continue  
+1000 continue
       if (sum_weight == 0.0) then
          val = msgvalout
       else
@@ -381,9 +381,9 @@ contains
          val = sum / sum_weight
 !	 print *, val, sum_weight
       end if
- 
+
    end function wt_sixteen_pt_average
- 
+
 
   subroutine smdsm(FLD, ix, jx, npass)
 
@@ -568,12 +568,12 @@ contains
 
 ! Compute the kernel
 
-! I'd rather do it in one step, going directly to my vector v, 
+! I'd rather do it in one step, going directly to my vector v,
 ! but I don't see how to be able to do that cleanly and still
 ! correct for the error (how much the sum differs from 1.0).
 
 ! First I compute the two-dimensional kernel array.
-    cval = 1./(twopi*sigsq) 
+    cval = 1./(twopi*sigsq)
     do i = 1, fsz
        x = float(hsz-i)
        do j = 1, fsz
@@ -625,7 +625,7 @@ contains
     real, dimension(ix,jx), intent(in)  :: slab1
     real, dimension(ix,jx), intent(out) :: slab2
     integer :: ie,je,i,j
-   
+
     IE=IX-1
     JE=JX-1
     DO I=2,IE
@@ -645,7 +645,7 @@ contains
     SLAB2(1,JX)=SLAB1(1,JE)
     SLAB2(IX,JX)=SLAB1(IE,JE)
     SLAB2(IX,1)=SLAB1(IE,1)
-   
+
   end subroutine crs2dot
 
 end module kwm_grid_utilities

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/kwm_string_utilities.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/kwm_string_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_string_utilities
@@ -68,7 +68,7 @@ contains
           return_string(j:j) = string(i:i)
        endif
     enddo
-    
+
   end function unblank
 
 !KWM  character function upcase(h)
@@ -87,7 +87,7 @@ contains
     implicit none
     character(len=*), intent(in) :: h
     integer :: i
-    
+
     return_string = " "
 
     do i = 1, len_trim(h)

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/kwm_timing_utilities.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/kwm_timing_utilities.F
@@ -2,27 +2,27 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_timing_utilities
   implicit none
   integer, parameter :: kwm_timing_dimension = 100
   integer, dimension(kwm_timing_dimension) :: Acount, Asum
-  
+
 contains
 
   subroutine timing_start(num)

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_geo_em.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_geo_em.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_geo_em
@@ -64,7 +64,7 @@ contains
   subroutine read_geo_em_file(flnm, geo_em, ierr)
 
 !---------------------------------------------------------------
-!  At the moment, all we need from the geo_em file is the 
+!  At the moment, all we need from the geo_em file is the
 !  array of monthly green vegetation fractions.
 !
 !  We also read projection/grid information, to ensure that
@@ -159,20 +159,20 @@ contains
     call get_2d("SOILTEMP", ncid, geo_em%tmn, geo_em%idim, geo_em%jdim)
     geo_em%tmn = geo_em%tmn - 0.0065 * geo_em%ter
 
-! Get Land Use categories 
+! Get Land Use categories
     allocate(geo_em%use(geo_em%idim, geo_em%jdim))
     call get_2d("LU_INDEX", ncid, geo_em%use, geo_em%idim, geo_em%jdim)
 
-! Create XLAND 
+! Create XLAND
     allocate(geo_em%msk(geo_em%idim, geo_em%jdim))
     where(geo_em%use .eq. geo_em%iswater .or.  geo_em%use .eq. geo_em%islake) geo_em%msk = 2
     where(geo_em%use .ne. geo_em%iswater .and. geo_em%use .ne. geo_em%islake) geo_em%msk = 1
 
-! Create SEAICE 
+! Create SEAICE
     allocate(geo_em%ice(geo_em%idim, geo_em%jdim))
     geo_em%ice = 0.0
 
-! Get Soil categories 
+! Get Soil categories
 !   soil is a problem since real does some manipulation, so we need to read the % data
 
     iret = nf90_get_att(ncid, NF90_GLOBAL, "ISOILWATER" , iswater_soil)
@@ -181,7 +181,7 @@ contains
     allocate(soil_top_cat(geo_em%idim, geo_em%jdim, 16))  ! potential problem with hardcoding 16?
     call get_soil_cat(ncid, soil_top_cat, geo_em%idim, geo_em%jdim, 16)
     allocate(geo_em%soi(geo_em%idim, geo_em%jdim))
-    
+
       DO i = 1 , geo_em%idim
          DO j = 1 , geo_em%jdim
             dominant_value = soil_top_cat(i,j,1)
@@ -200,7 +200,7 @@ contains
             geo_em%soi(i,j) = dominant_index
          END DO
       END DO
-    
+
     where(geo_em%use .eq. geo_em%iswater .or.  geo_em%use .eq. geo_em%islake) geo_em%soi = 14
     where(geo_em%use .ne. geo_em%iswater .and. geo_em%use .ne. geo_em%islake .and. geo_em%soi .eq. 14) geo_em%soi = 8
 
@@ -356,7 +356,7 @@ contains
       array = -1.e36
       return
     end if
-    
+
     ierr = nf90_get_var(ncid, varid, array)
     call error_handler(ierr, "STOP:  Problem getting "//trim(name)//" from geo_em file")
 
@@ -383,7 +383,7 @@ contains
 
   subroutine get_2d(name, ncid, array, idim, jdim)
     !
-    ! From the NetCDF unit <ncid>, read the variable named <name> with  
+    ! From the NetCDF unit <ncid>, read the variable named <name> with
     ! dimensions <idim> and <jdim>, filling the pre-dimensioned array <array>
     !
     implicit none

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_grib.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_grib.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_grib
@@ -50,7 +50,7 @@ contains
     !      ierr:      An error flag.  ierr == 0 -- File opened successfully.
     !                                 ierr == 1 -- There was some problem opening the file.
     !                                 ierr == 2 -- The specified file does not exist.
-    ! 
+    !
     ! Side effects:
     !      - File <filename> is opened for reading
     !      - The file stream pointer for <filename>, contained within structure <fd>,
@@ -70,7 +70,7 @@ contains
        ierr = 2
        return
     endif
-    
+
     call c_gribopen(trim(filename)//char(0), fd, ierr)
 
   end subroutine gribopen
@@ -89,7 +89,7 @@ contains
 
   subroutine getgrib(fd, grib, ierr)
     implicit none
-    ! 
+    !
     ! Purpose:
     !      Read a single grib record, but do no unpacking and no interpretation
     !      of header information beyond the size and edition nuber from GRIB 
@@ -164,13 +164,13 @@ contains
   subroutine findgrib(fd, grib, iloc)
     implicit none
     ! Purpose:
-    !      Seek in an open GRIB file for the string "GRIB", which 
+    !      Seek in an open GRIB file for the string "GRIB", which
     !      indicates the beginning of a GRIB record.
     ! Input:
     !      fd: A file stream pointer to a file opened by subroutine GRIBOPEN
     !
     ! Output:
-    !      iloc:  The location (by byte count) in the file stream <fd> 
+    !      iloc:  The location (by byte count) in the file stream <fd>
     !             at the beginning of this particular GRIB record.  Or,
     !             a negative number indicating a read problem (probably we 
     !             hit the end of the file.
@@ -204,7 +204,7 @@ contains
        return
     endif
 
-    do while ( h4 /= "GRIB") 
+    do while ( h4 /= "GRIB")
        ! Adjust our buffer and read one more byte
        h4(1:3) = h4(2:4)
        call io_fread(fd, h4(4:4), 1, iread, ierr)
@@ -220,7 +220,7 @@ contains
 
     !
     !   To have got this far, we must have found the beginning of a GRIB
-    !   record.  
+    !   record.
     !
 
     !
@@ -299,12 +299,12 @@ contains
 
   subroutine grib_next_field(fd, grib, ierr)
     implicit none
-    ! 
+    !
     ! Purpose:
     !      Unpack the next field in a GRIB file.  The field may already be
     !      available in <grib%buffer>; if not, we read from the file into 
     !      <grib%buffer>.
-    ! 
+    !
 
     integer(kind=8), intent(in) :: fd
     type (GribStruct), intent(inout) :: grib
@@ -321,7 +321,7 @@ contains
           ! print*, 'Try to read a new record'
           ! Get the next complete GRIB record (which may contain more than one field,
           ! which is why we have the complication of the outer do loop here).
-          call getgrib(fd, grib, ierr) 
+          call getgrib(fd, grib, ierr)
           if (ierr /= 0) return
        else
           ! See if we're at "7777"  If so, deallocate things and read a new record.
@@ -438,7 +438,7 @@ contains
 
 !=================================================================================
 !=================================================================================
-  
+
   subroutine grib_time_information(grib, reference_date, valid_date, process, processing, p1_seconds, p2_seconds)
     implicit none
     type (GribStruct),  intent(in)  :: grib
@@ -448,7 +448,7 @@ contains
     character(len=256), intent(out) :: processing
     integer,            intent(out) :: p1_seconds
     integer,            intent(out) :: p2_seconds
-    
+
     select case (grib%edition)
     case default
        write(*,'("WARNING: MODULE_GRIB:  GRIB_TIME_INFORMATION:  Unrecognized grib%edition", I10)') grib%edition
@@ -458,7 +458,7 @@ contains
     case (2)
        call grib2_time_information(grib, reference_date, valid_date, process, processing, p1_seconds, p2_seconds)
     end select
-    
+
   end subroutine grib_time_information
 
 !=================================================================================
@@ -466,12 +466,12 @@ contains
 
   subroutine grib_valid_date(grib, validdate)
     ! Hmmmm.  This could also be a subfunction of unpacking
-    ! GRIB2 section 4 (GRIB1 Section 1), and making <validdate> 
+    ! GRIB2 section 4 (GRIB1 Section 1), and making <validdate>
     ! an element of <grib> at the top level
     implicit none
     type (GribStruct), intent(in)  :: grib
     character(len=19), intent(out) :: validdate
-    ! 
+    !
 
     select case (grib%edition)
     case default

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_grib1.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_grib1.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_grib1
@@ -53,7 +53,7 @@ contains
 
 !=================================================================================
 !=================================================================================
-  
+
   subroutine grib1_time_information(grib, reference_date, valid_date, process, processing, p1_seconds, p2_seconds)
     implicit none
     type (GribStruct),  intent(in)  :: grib
@@ -140,7 +140,7 @@ contains
     case (20)
        level_type = "Isothermal level"
        level_units = "K"
-       level_value = grib%g1sec1%levelval 
+       level_value = grib%g1sec1%levelval
     case (100)
        level_type = "Isobaric level"
        level_units = "Pa"
@@ -264,7 +264,7 @@ contains
     case (244)
        level_type = "Convective cloud layer"
     end select
-    
+
   end subroutine grib1_level_information
 
 !=================================================================================
@@ -433,7 +433,7 @@ contains
        else
           sec2%orientation = 1
        endif
-       
+
        ! Skip those last four bytes:
        iskip = iskip + (4*8)
 
@@ -469,13 +469,13 @@ contains
        else
           sec2%j_scan_direction = -1
        endif
-       
+
        if ( btest(sec2%scanning_mode, 5) ) then
           sec2%orientation = -1
        else
           sec2%orientation = 1
        endif
-       
+
        idum          = unpack_signed_integer(buffer, 3, iskip)
        sec2%latin1 = real(idum)*1.E-3
        idum          = unpack_signed_integer(buffer, 3, iskip)
@@ -520,13 +520,13 @@ contains
        else
           sec2%j_scan_direction = -1
        endif
-       
+
        if ( btest(sec2%scanning_mode, 5) ) then
           sec2%orientation = -1
        else
           sec2%orientation = 1
        endif
-       
+
        if (sec2%center==0) then
           sec2%latin1 = 60.0
        else
@@ -710,7 +710,7 @@ contains
        mapinfo%xlonc    = -1.E33
        mapinfo%truelat1 = -1.E33
        mapinfo%truelat2 = -1.E33
-    case (3) ! Lambert Conformal 
+    case (3) ! Lambert Conformal
        mapinfo%hproj = "LC"
        mapinfo%supmap_jproj = 3
        mapinfo%nx   = sec2%nx
@@ -795,7 +795,7 @@ contains
           write(*,'("grib%g1sec2%i_scan_direction = ", I12)') grib%g1sec2%i_scan_direction
           stop "FATAL ERROR: In module module_grib1.F -- GRIB1_SGUP_NOBITMAP:   Problem recognizing grib%g1sec2%i_scan_direction"
        endif
-       
+
        if (grib%g1sec2%j_scan_direction == 1) then
           array = DFAC * (dble(grib%g1sec4%reference_value) + (dble(IX)*BFAC))
        elseif (grib%g1sec2%j_scan_direction == -1) then
@@ -850,7 +850,7 @@ contains
 ! GRIB%G1SEC4%nbits : The number of bits per data value.
 
 
-! 1) There are fewer than NDAT data values, because a bitmap was used.  
+! 1) There are fewer than NDAT data values, because a bitmap was used.
 !    Compute the number of data values (NBM).  There are 11 extra bytes
 !    in the header section 4.  NBM equals the total number of data bits (not
 !    counting the header bits), minus the number of unused buts, and then
@@ -908,7 +908,7 @@ contains
        write(*,'("grib%g1sec2%j_scan_direction = ", I12)') grib%g1sec2%j_scan_direction
        stop "FATAL ERROR: In module module_grib1.F -- GRIB1_SGUP_BITMAP:  Problem recognizing grib%g1sec2%j_scan_direction"
     endif
-       
+
 
 
 ! Unpack the data according to packing parameters DFAC, BFAC, and XEC4(1), 
@@ -967,7 +967,7 @@ contains
     case (3) ! Average
        ! Average from (reference_time + p1) to (reference time + p2)
        call geth_newdate(validdate, refdate, tfac*(sec1%p1+sec1%p2)/2)
-    case(4) ! Accumulation from refdate + P1 to refdate + P2, 
+    case(4) ! Accumulation from refdate + P1 to refdate + P2,
        ! valid at refdate + P2
        ! call geth_newdate(fdate,     refdate, tfac*sec1(17))
        call geth_newdate(validdate, refdate, tfac*sec1%p2)
@@ -1026,7 +1026,7 @@ contains
 
     READ_TABLE : do
 #ifndef NCEP_WCOSS
-       
+
 #else
        read(iunit, '(A200)', iostat=ierr) string
 #endif
@@ -1047,7 +1047,7 @@ contains
 
     enddo READ_TABLE
 #ifndef NCEP_WCOSS
-    
+
 #else
     close(iunit)
 #endif

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_grib2.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_grib2.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_grib2
@@ -44,7 +44,7 @@ contains
     implicit none
     type (GribStruct), intent(in)  :: grib
     character(len=19), intent(out) :: validdate
-    ! 
+    !
     !Local:
     character(len=19) :: refdate
     integer :: fcst_time
@@ -125,7 +125,7 @@ contains
 
   subroutine fortran_decode_jpeg2000(buffer, buffer_length, decoded)
     implicit none
-    ! 
+    !
     ! Purpose:
     !      Take a character array <buffer> which contains a JPEG2000-encoded field,
     !      and return the decoded field as an integer array.  This subroutine is 
@@ -251,7 +251,7 @@ contains
           p2_seconds = 0
           call geth_newdate(valid_date, grib%sec1%hdate, grib%sec4%time)
           write(text3, '("Forecast valid time:  ", A, 1x, A)') valid_date(1:10), valid_date(12:19)
-          
+
        end select
     case (8)
        select case (grib%sec4%PDT_4_8%statistical_process)
@@ -298,7 +298,7 @@ contains
           case (13)
              p1_seconds = p1_seconds + (grib%sec4%PDT_4_8%length_of_time_range)
           end select
-          
+
        case (2)
           write(processing, '("Maximum in ", I6, 1x, A)') &
                grib%sec4%PDT_4_8%length_of_time_range, interpret_time_unit(grib%sec4%PDT_4_8%time_range_unit)
@@ -306,7 +306,7 @@ contains
           write(processing, '("Minimum in ", I6, 1x, A)') &
                grib%sec4%PDT_4_8%length_of_time_range, interpret_time_unit(grib%sec4%PDT_4_8%time_range_unit)
        case (4)
-          write(processing, '("Difference over ", I6, 1x, A)') & 
+          write(processing, '("Difference over ", I6, 1x, A)') &
               grib%sec4%PDT_4_8%length_of_time_range, interpret_time_unit(grib%sec4%PDT_4_8%time_range_unit)
        end select
     end select
@@ -422,7 +422,7 @@ contains
 
   subroutine unpack_next_grib2_section(isection, grib)
 
-    !  Returns the section number of the section just unpacked 
+    !  Returns the section number of the section just unpacked
     implicit none
     integer, intent(out) :: isection
     type(GribStruct), intent(inout) :: grib
@@ -597,7 +597,7 @@ contains
        !
        ! Significance of Reference Time
        !
-       select case (grib%sec1%srt) 
+       select case (grib%sec1%srt)
        case (0)
           write(*,'("  Analysis at time ",A)') grib%sec1%hdate
        case (1)
@@ -632,7 +632,7 @@ contains
 
     integer :: i
 
-    ! Temporary integers to hold 
+    ! Temporary integers to hold
     integer :: ila1
     integer :: ilo1
     integer :: ila2
@@ -745,7 +745,7 @@ contains
 
     case (30)
 
-       ! Lambert Conformal Grid 
+       ! Lambert Conformal Grid
 
        GT_3_30 => sec3%GT_3_30
 
@@ -976,7 +976,7 @@ contains
     sec4 => grib%sec4
 
     sec4%size = unpack_unsigned_integer(grib%buffer, 4, grib%iskip)
-    section   = unpack_unsigned_integer(grib%buffer, 1, grib%iskip)  
+    section   = unpack_unsigned_integer(grib%buffer, 1, grib%iskip)
     if (section /= 4) then
        write(*,'("WARNING: Section 4:  We are lost!  ", I4)') section
        stop "FATAL ERROR: In module module_grib2.F -- Section 4: Problem"
@@ -1210,7 +1210,7 @@ contains
 
     case (40)
 
-       iref40 = unpack_unsigned_integer(grib%buffer, 4, grib%iskip)     
+       iref40 = unpack_unsigned_integer(grib%buffer, 4, grib%iskip)
        sec5%DRT_5_40%reference_value = xref40
 
        sec5%DRT_5_40%binary_scale_factor = unpack_signed_integer(grib%buffer, 2, grib%iskip)
@@ -1292,7 +1292,7 @@ contains
     sec6 => grib%sec6
 
     sec6%size = unpack_unsigned_integer(grib%buffer, 4, grib%iskip)
-    section   = unpack_unsigned_integer(grib%buffer, 1, grib%iskip)  
+    section   = unpack_unsigned_integer(grib%buffer, 1, grib%iskip)
     if (section /= 6) then
        write(*,'("WARNING: Section 6:  We are lost!  ", I8)') section
        stop "FATAL ERROR: In module module_grib2.F -- Section 6"
@@ -1307,7 +1307,7 @@ contains
        ! No bitmap.
        ! No action needed here.
     case (254)
-       ! Bitmap previously defined in this GRIB record. 
+       ! Bitmap previously defined in this GRIB record.
        ! No action needed here.  The previously-defined bitmap
        ! should still be stored and used as necessary.
     case (0)

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_grib2_tables.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_grib2_tables.F
@@ -2,23 +2,23 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
-module module_grib2_tables 
+module module_grib2_tables
 
   type table_entry_struct
      integer                   :: product_discipline
@@ -71,7 +71,7 @@ contains
 #else
     open(iunit, file=trim(table_filename), status='old', form='formatted', action='read', iostat=ierr)
 #endif
-     
+
     if (ierr /= 0) then
        write(*,'(/," ***** ERROR *****",/)')
        write(*,'(" ***** Problem opening file ''", A, "''")') trim(table_filename)
@@ -81,7 +81,7 @@ contains
 
     READ_TABLE : do
 #ifndef NCEP_WCOSS
-       
+
 #else
        read(iunit, '(A200)', iostat=ierr) string
 #endif
@@ -141,10 +141,10 @@ contains
 
 ! Local
     type(table_entry_struct), pointer:: table_pointer
-    
+
     ! Start us off by pointing to the top of the table.
     table_pointer => table
-    
+
     ! Seek for the end of the table.
     do while (associated(table_pointer%next))
        table_pointer => table_pointer%next
@@ -169,11 +169,11 @@ contains
 !=================================================================================
   subroutine grib2_clear_parameter_table
     implicit none
-    
+
 ! Local
     type(table_entry_struct), pointer:: table_pointer
     type(table_entry_struct), pointer:: next_pointer
-    
+
     ! Start us off by pointing to the top of the table.
     table_pointer => table
 
@@ -269,23 +269,23 @@ contains
     case default
        write(text,'("Unrecognized type of surface", I4)') surface_type_code
     case (1)
-       write(text,'("Level:  Ground or water surface")') 
+       write(text,'("Level:  Ground or water surface")')
     case (2)
-       write(text,'("Level:  Cloud base level")') 
+       write(text,'("Level:  Cloud base level")')
     case (3)
-       write(text,'("Level:  Cloud top level")') 
+       write(text,'("Level:  Cloud top level")')
     case (4)
-       write(text,'("Level:  0~S~o~N~C isotherm level")') 
+       write(text,'("Level:  0~S~o~N~C isotherm level")')
     case (5)
-       write(text,'("Level:  Adiabatic lifting condensation level")') 
+       write(text,'("Level:  Adiabatic lifting condensation level")')
     case (6)
-       write(text,'("Level:  Maximum wind level")') 
+       write(text,'("Level:  Maximum wind level")')
     case (7)
-       write(text,'("Level:  Tropopause")') 
+       write(text,'("Level:  Tropopause")')
     case (8)
-       write(text,'("Level:  Nominal top of atmosphere")') 
+       write(text,'("Level:  Nominal top of atmosphere")')
     case (9)
-       write(text,'("Level:  Sea bottom")') 
+       write(text,'("Level:  Sea bottom")')
     case (20)
        write(text,'("Level:  Isothermal level ")')
        units = "K"
@@ -293,7 +293,7 @@ contains
        write(text,'("Level:  Isobaric surface ")')
        units = "Pa"
     case (101)
-       write(text,'("Level:  Mean sea level")') 
+       write(text,'("Level:  Mean sea level")')
     case (102)
        write(text,'("Level:  Height MSL ")')
        units = "m"

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_grib_common.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_grib_common.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_grib_common
@@ -184,10 +184,10 @@ module module_grib_common
      type (GT_3_30_Struct) :: GT_3_30
   end type Section3Struct
 
-!  type PDT_4_0_Struct 
+!  type PDT_4_0_Struct
 !  end type PDT_4_0_Struct
 
-  type PDT_4_8_Struct 
+  type PDT_4_8_Struct
      integer :: end_year
      integer :: end_month
      integer :: end_day
@@ -318,7 +318,7 @@ contains
   integer function unpack_signed_integer(buffer, nbytes, iskip) RESULT (signed_integer)
     implicit none
     !
-    ! Purpose:  
+    ! Purpose:
     !      From a string of bytes in a buffer array, unpack a stream of bytes into an 
     !      integer variable, with the a priori knowledge that this stream of bytes
     !      represents a signed integer, the sign indicated by the first bit in the stream. 
@@ -369,7 +369,7 @@ contains
   integer function unpack_unsigned_integer(buffer, nbytes, iskip) RESULT (unsigned_integer)
     implicit none
     !
-    ! Purpose:  
+    ! Purpose:
     !      From a string of bytes in a buffer array, unpack a stream of bytes into an 
     !      integer variable, with the a priori knowledge that this stream of bytes
     !      represents an _unsigned_ integer.  The <iskip> indicator is then incremented 

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_input_data_structure.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_input_data_structure.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_input_data_structure

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_llxy.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_llxy.F
@@ -2,27 +2,27 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 MODULE module_llxy
 
 ! Module that defines constants, data structures, and
 ! subroutines used to convert grid indices to lat/lon
-! and vice versa.   
+! and vice versa.
 !
 ! SUPPORTED PROJECTIONS
 ! ---------------------
@@ -39,9 +39,9 @@ MODULE module_llxy
 ! obtained from NCEP's w3 library.  The original NCEP routines were less
 ! flexible (e.g., polar-stereo routines only supported truelat of 60N/60S)
 ! than what we needed, so modifications based on equations in Hoke, Hayes, and
-! Renninger (AFGWC/TN/79-003) were added to improve the flexibility.  
+! Renninger (AFGWC/TN/79-003) were added to improve the flexibility.
 ! Additionally, coding was improved to F90 standards and the routines were
-! combined into this module.  
+! combined into this module.
 !
 ! ASSUMPTIONS
 ! -----------
@@ -183,12 +183,12 @@ MODULE module_llxy
 
    ! Define some private constants
    INTEGER, PRIVATE, PARAMETER :: HIGH = 8
- 
+
    TYPE proj_info
- 
+
       INTEGER          :: code     ! Integer code for projection TYPE
       INTEGER          :: nlat     ! For Gaussian -- number of latitude points 
-                                   !  north of the equator 
+                                   !  north of the equator
       INTEGER          :: nlon     !
                                    !
       INTEGER          :: ixdim    ! For Rotated Lat/Lon -- number of mass points
@@ -227,24 +227,24 @@ MODULE module_llxy
       REAL             :: rho0     ! For Albers equal area
       REAL             :: nc       ! For Albers equal area
       REAL             :: bigc     ! For Albers equal area
-      LOGICAL          :: init     ! Flag to indicate if this struct is 
+      LOGICAL          :: init     ! Flag to indicate if this struct is
                                    !  ready for use
       LOGICAL          :: wrap     ! For Gaussian -- flag to indicate wrapping 
                                    !  around globe?
       REAL, POINTER, DIMENSION(:) :: gauss_lat  ! Latitude array for Gaussian grid
- 
+
    END TYPE proj_info
 
  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  CONTAINS
  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- 
+
    SUBROUTINE map_init(proj)
       ! Initializes the map projection structure to missing values
-  
+
       IMPLICIT NONE
       TYPE(proj_info), INTENT(INOUT)  :: proj
-  
+
       proj%lat1     = -999.9
       proj%lon1     = -999.9
       proj%lat0     = -999.9
@@ -277,7 +277,7 @@ MODULE module_llxy
       proj%nc       = 0.
       proj%bigc     = 0.
       nullify(proj%gauss_lat)
-   
+
    END SUBROUTINE map_init
 
 
@@ -285,17 +285,17 @@ MODULE module_llxy
                       loninc, stdlon, truelat1, truelat2, nlat, nlon, ixdim, jydim, &
                       stagger, phi, lambda, r_earth)
       ! Given a partially filled proj_info structure, this routine computes
-      ! polei, polej, rsw, and cone (if LC projection) to complete the 
+      ! polei, polej, rsw, and cone (if LC projection) to complete the
       ! structure.  This allows us to eliminate redundant calculations when
       ! calling the coordinate conversion routines multiple times for the
       ! same map.
       ! This will generally be the first routine called when a user wants
       ! to be able to use the coordinate conversion routines, and it
-      ! will call the appropriate subroutines based on the 
+      ! will call the appropriate subroutines based on the
       ! proj%code which indicates which projection type this is.
-  
+
       IMPLICIT NONE
-      
+
       ! Declare arguments
       INTEGER, INTENT(IN)               :: proj_code
       INTEGER, INTENT(IN), OPTIONAL     :: nlat
@@ -324,7 +324,7 @@ MODULE module_llxy
       REAL :: dummy_lon1
       REAL :: dummy_lon0
       REAL :: dummy_stdlon
-  
+
       ! First, verify that mandatory parameters are present for the specified proj_code
       IF ( proj_code == PROJ_LC ) THEN
          IF ( .NOT.PRESENT(truelat1) .OR. &
@@ -445,7 +445,7 @@ MODULE module_llxy
          PRINT '(A,I2)', 'Unknown projection code: ', proj_code
          STOP 'MAP_INIT'
       END IF
-  
+
       ! Check for validity of mandatory variables in proj
       IF ( PRESENT(lat1) ) THEN
          IF ( ABS(lat1) .GT. 90. ) THEN
@@ -455,11 +455,11 @@ MODULE module_llxy
             STOP 'MAP_INIT'
          ENDIF
       ENDIF
-  
+
       IF ( PRESENT(lon1) ) THEN
          dummy_lon1 = lon1
          IF ( ABS(dummy_lon1) .GT. 180.) THEN
-            iter = 0 
+            iter = 0
             DO WHILE (ABS(dummy_lon1) > 180. .AND. iter < 10)
                IF (dummy_lon1 < -180.) dummy_lon1 = dummy_lon1 + 360.
                IF (dummy_lon1 > 180.) dummy_lon1 = dummy_lon1 - 360.
@@ -472,11 +472,11 @@ MODULE module_llxy
             ENDIF
          ENDIF
       ENDIF
-  
+
       IF ( PRESENT(lon0) ) THEN
          dummy_lon0 = lon0
          IF ( ABS(dummy_lon0) .GT. 180.) THEN
-            iter = 0 
+            iter = 0
             DO WHILE (ABS(dummy_lon0) > 180. .AND. iter < 10)
                IF (dummy_lon0 < -180.) dummy_lon0 = dummy_lon0 + 360.
                IF (dummy_lon0 > 180.) dummy_lon0 = dummy_lon0 - 360.
@@ -489,18 +489,18 @@ MODULE module_llxy
             ENDIF
          ENDIF
       ENDIF
-  
+
       IF ( PRESENT(dx) ) THEN
          IF ((dx .LE. 0.).AND.(proj_code .NE. PROJ_LATLON)) THEN
             PRINT '(A)', 'Require grid spacing (dx) in meters be positive'
             STOP 'MAP_INIT'
          ENDIF
       ENDIF
-  
+
       IF ( PRESENT(stdlon) ) THEN
          dummy_stdlon = stdlon
          IF ((ABS(dummy_stdlon) > 180.).AND.(proj_code /= PROJ_MERC)) THEN
-            iter = 0 
+            iter = 0
             DO WHILE (ABS(dummy_stdlon) > 180. .AND. iter < 10)
                IF (dummy_stdlon < -180.) dummy_stdlon = dummy_stdlon + 360.
                IF (dummy_stdlon > 180.) dummy_stdlon = dummy_stdlon - 360.
@@ -508,20 +508,20 @@ MODULE module_llxy
             END DO
             IF (abs(dummy_stdlon) > 180.) THEN
                PRINT '(A)', 'Need orientation longitude (stdlon) as: '
-               PRINT '(A)', '   -180E <= stdlon <= 180W' 
+               PRINT '(A)', '   -180E <= stdlon <= 180W'
                STOP 'MAP_INIT'
             ENDIF
          ENDIF
       ENDIF
-  
+
       IF ( PRESENT(truelat1) ) THEN
          IF (ABS(truelat1).GT.90.) THEN
             PRINT '(A)', 'Set true latitude 1 for all projections'
             STOP 'MAP_INIT'
          ENDIF
       ENDIF
-     
-      CALL map_init(proj) 
+
+      CALL map_init(proj)
       proj%code  = proj_code
       IF ( PRESENT(lat1) )     proj%lat1     = lat1
       IF ( PRESENT(lon1) )     proj%lon1     = dummy_lon1
@@ -543,14 +543,14 @@ MODULE module_llxy
       IF ( PRESENT(phi) )      proj%phi      = phi
       IF ( PRESENT(lambda) )   proj%lambda   = lambda
       IF ( PRESENT(r_earth) )  proj%re_m     = r_earth
-  
-      IF ( PRESENT(dx) ) THEN 
+
+      IF ( PRESENT(dx) ) THEN
          IF ( (proj_code == PROJ_LC) .OR. (proj_code == PROJ_PS) .OR. &
               (proj_code == PROJ_PS_WGS84) .OR. (proj_code == PROJ_ALBERS_NAD83) .OR. &
               (proj_code == PROJ_MERC) ) THEN
             proj%dx = dx
             IF (truelat1 .LT. 0.) THEN
-               proj%hemi = -1.0 
+               proj%hemi = -1.0
             ELSE
                proj%hemi = 1.0
             ENDIF
@@ -559,7 +559,7 @@ MODULE module_llxy
       ENDIF
 
       pick_proj: SELECT CASE(proj%code)
-  
+
          CASE(PROJ_PS)
             CALL set_ps(proj)
 
@@ -568,29 +568,29 @@ MODULE module_llxy
 
          CASE(PROJ_ALBERS_NAD83)
             CALL set_albers_nad83(proj)
-   
+
          CASE(PROJ_LC)
             IF (ABS(proj%truelat2) .GT. 90.) THEN
                proj%truelat2=proj%truelat1
             ENDIF
             CALL set_lc(proj)
-      
+
          CASE (PROJ_MERC)
             CALL set_merc(proj)
-      
+
          CASE (PROJ_LATLON)
-   
+
          CASE (PROJ_GAUSS)
             CALL set_gauss(proj)
-      
+
          CASE (PROJ_CYL)
             CALL set_cyl(proj)
-      
+
          CASE (PROJ_CASSINI)
             CALL set_cassini(proj)
-      
+
          CASE (PROJ_ROTLL)
-     
+
       END SELECT pick_proj
       proj%init = .TRUE.
 
@@ -601,43 +601,43 @@ MODULE module_llxy
 
    SUBROUTINE latlon_to_ij(proj, lat, lon, i, j)
       ! Converts input lat/lon values to the cartesian (i,j) value
-      ! for the given projection. 
-  
+      ! for the given projection.
+
       IMPLICIT NONE
       TYPE(proj_info), INTENT(IN)          :: proj
       REAL, INTENT(IN)                     :: lat
       REAL, INTENT(IN)                     :: lon
       REAL, INTENT(OUT)                    :: i
       REAL, INTENT(OUT)                    :: j
-  
+
       IF (.NOT.proj%init) THEN
          PRINT '(A)', 'You have not called map_set for this projection'
          STOP 'LATLON_TO_IJ'
       ENDIF
-  
+
       SELECT CASE(proj%code)
-   
+
          CASE(PROJ_LATLON)
             CALL llij_latlon(lat,lon,proj,i,j)
-   
+
          CASE(PROJ_MERC)
             CALL llij_merc(lat,lon,proj,i,j)
-   
+
          CASE(PROJ_PS)
             CALL llij_ps(lat,lon,proj,i,j)
 
          CASE(PROJ_PS_WGS84)
             CALL llij_ps_wgs84(lat,lon,proj,i,j)
-         
+
          CASE(PROJ_ALBERS_NAD83)
             CALL llij_albers_nad83(lat,lon,proj,i,j)
-         
+
          CASE(PROJ_LC)
             CALL llij_lc(lat,lon,proj,i,j)
-   
+
          CASE(PROJ_GAUSS)
             CALL llij_gauss(lat,lon,proj,i,j)
-   
+
          CASE(PROJ_CYL)
             CALL llij_cyl(lat,lon,proj,i,j)
 
@@ -646,11 +646,11 @@ MODULE module_llxy
 
          CASE(PROJ_ROTLL)
             CALL llij_rotlatlon(lat,lon,proj,i,j)
-   
+
          CASE DEFAULT
             PRINT '(A,I2)', 'Unrecognized map projection code: ', proj%code
             STOP 'LATLON_TO_IJ'
-    
+
       END SELECT
 
       RETURN
@@ -661,51 +661,51 @@ MODULE module_llxy
    SUBROUTINE ij_to_latlon(proj, i, j, lat, lon)
       ! Computes geographical latitude and longitude for a given (i,j) point
       ! in a grid with a projection of proj
-  
+
       IMPLICIT NONE
       TYPE(proj_info),INTENT(IN)          :: proj
       REAL, INTENT(IN)                    :: i
       REAL, INTENT(IN)                    :: j
       REAL, INTENT(OUT)                   :: lat
       REAL, INTENT(OUT)                   :: lon
-  
+
       IF (.NOT.proj%init) THEN
          PRINT '(A)', 'You have not called map_set for this projection'
          STOP 'IJ_TO_LATLON'
       ENDIF
       SELECT CASE (proj%code)
-  
+
          CASE (PROJ_LATLON)
             CALL ijll_latlon(i, j, proj, lat, lon)
-   
+
          CASE (PROJ_MERC)
             CALL ijll_merc(i, j, proj, lat, lon)
-   
+
          CASE (PROJ_PS)
             CALL ijll_ps(i, j, proj, lat, lon)
 
          CASE (PROJ_PS_WGS84)
             CALL ijll_ps_wgs84(i, j, proj, lat, lon)
-   
+
          CASE (PROJ_ALBERS_NAD83)
             CALL ijll_albers_nad83(i, j, proj, lat, lon)
-   
+
          CASE (PROJ_LC)
             CALL ijll_lc(i, j, proj, lat, lon)
-   
+
          CASE (PROJ_CYL)
             CALL ijll_cyl(i, j, proj, lat, lon)
-   
+
          CASE (PROJ_CASSINI)
             CALL ijll_cassini(i, j, proj, lat, lon)
-   
+
          CASE (PROJ_ROTLL)
             CALL ijll_rotlatlon(i, j, proj, lat, lon)
-   
+
          CASE DEFAULT
             PRINT '(A,I2)', 'Unrecognized map projection code: ', proj%code
             STOP 'IJ_TO_LATLON'
-  
+
       END SELECT
       RETURN
    END SUBROUTINE ij_to_latlon
@@ -717,26 +717,26 @@ MODULE module_llxy
       ! southwest corner and computes the i/j location of the pole for use
       ! in llij_ps and ijll_ps.
       IMPLICIT NONE
-   
+
       ! Declare args
       TYPE(proj_info), INTENT(INOUT)    :: proj
-  
+
       ! Local vars
       REAL                              :: ala1
       REAL                              :: alo1
       REAL                              :: reflon
       REAL                              :: scale_top
-  
+
       ! Executable code
       reflon = proj%stdlon + 90.
-  
+
       ! Compute numerator term of map scale factor
       scale_top = 1. + proj%hemi * SIN(proj%truelat1 * rad_per_deg)
-  
+
       ! Compute radius to lower-left (SW) corner
       ala1 = proj%lat1 * rad_per_deg
       proj%rsw = proj%rebydx*COS(ala1)*scale_top/(1.+proj%hemi*SIN(ala1))
-  
+
       ! Find the pole point
       alo1 = (proj%lon1 - reflon) * rad_per_deg
       proj%polei = proj%knowni - proj%rsw * COS(alo1)
@@ -749,89 +749,89 @@ MODULE module_llxy
 
    SUBROUTINE llij_ps(lat,lon,proj,i,j)
       ! Given latitude (-90 to 90), longitude (-180 to 180), and the
-      ! standard polar-stereographic projection information via the 
+      ! standard polar-stereographic projection information via the
       ! public proj structure, this routine returns the i/j indices which
       ! if within the domain range from 1->nx and 1->ny, respectively.
-  
+
       IMPLICIT NONE
-  
+
       ! Delcare input arguments
       REAL, INTENT(IN)               :: lat
       REAL, INTENT(IN)               :: lon
       TYPE(proj_info),INTENT(IN)     :: proj
-  
-      ! Declare output arguments     
+
+      ! Declare output arguments
       REAL, INTENT(OUT)              :: i !(x-index)
       REAL, INTENT(OUT)              :: j !(y-index)
-  
+
       ! Declare local variables
-      
+
       REAL                           :: reflon
       REAL                           :: scale_top
       REAL                           :: ala
       REAL                           :: alo
       REAL                           :: rm
-  
+
       ! BEGIN CODE
-    
+
       reflon = proj%stdlon + 90.
-     
+
       ! Compute numerator term of map scale factor
-  
+
       scale_top = 1. + proj%hemi * SIN(proj%truelat1 * rad_per_deg)
-  
+
       ! Find radius to desired point
       ala = lat * rad_per_deg
       rm = proj%rebydx * COS(ala) * scale_top/(1. + proj%hemi *SIN(ala))
       alo = (lon - reflon) * rad_per_deg
       i = proj%polei + rm * COS(alo)
       j = proj%polej + proj%hemi * rm * SIN(alo)
-   
+
       RETURN
 
    END SUBROUTINE llij_ps
 
 
    SUBROUTINE ijll_ps(i, j, proj, lat, lon)
- 
-      ! This is the inverse subroutine of llij_ps.  It returns the 
+
+      ! This is the inverse subroutine of llij_ps.  It returns the
       ! latitude and longitude of an i/j point given the projection info 
-      ! structure.  
-  
+      ! structure.
+
       IMPLICIT NONE
-  
+
       ! Declare input arguments
       REAL, INTENT(IN)                    :: i    ! Column
       REAL, INTENT(IN)                    :: j    ! Row
       TYPE (proj_info), INTENT(IN)        :: proj
-      
+
       ! Declare output arguments
       REAL, INTENT(OUT)                   :: lat     ! -90 -> 90 north
       REAL, INTENT(OUT)                   :: lon     ! -180 -> 180 East
-  
+
       ! Local variables
       REAL                                :: reflon
       REAL                                :: scale_top
       REAL                                :: xx,yy
       REAL                                :: gi2, r2
       REAL                                :: arccos
-  
+
       ! Begin Code
-  
+
       ! Compute the reference longitude by rotating 90 degrees to the east
       ! to find the longitude line parallel to the positive x-axis.
       reflon = proj%stdlon + 90.
-     
+
       ! Compute numerator term of map scale factor
       scale_top = 1. + proj%hemi * SIN(proj%truelat1 * rad_per_deg)
-  
+
       ! Compute radius to point of interest
       xx = i - proj%polei
       yy = (j - proj%polej) * proj%hemi
       r2 = xx**2 + yy**2
-  
+
       ! Now the magic code
-      IF (r2 .EQ. 0.) THEN 
+      IF (r2 .EQ. 0.) THEN
          lat = proj%hemi * 90.
          lon = reflon
       ELSE
@@ -844,13 +844,13 @@ MODULE module_llxy
             lon = reflon - deg_per_rad * arccos
          ENDIF
       ENDIF
-    
+
       ! Convert to a -180 -> 180 East convention
       IF (lon .GT. 180.) lon = lon - 360.
       IF (lon .LT. -180.) lon = lon + 360.
 
       RETURN
-   
+
    END SUBROUTINE ijll_ps
 
 
@@ -861,10 +861,10 @@ MODULE module_llxy
       ! pole for use in llij_ps and ijll_ps.
 
       IMPLICIT NONE
-   
+
       ! Arguments
       TYPE(proj_info), INTENT(INOUT)    :: proj
-  
+
       ! Local variables
       real :: h, mc, tc, t, rho
 
@@ -888,19 +888,19 @@ MODULE module_llxy
 
    SUBROUTINE llij_ps_wgs84(lat,lon,proj,i,j)
       ! Given latitude (-90 to 90), longitude (-180 to 180), and the
-      ! standard polar-stereographic projection information via the 
+      ! standard polar-stereographic projection information via the
       ! public proj structure, this routine returns the i/j indices which
       ! if within the domain range from 1->nx and 1->ny, respectively.
-  
+
       IMPLICIT NONE
-  
+
       ! Arguments
       REAL, INTENT(IN)               :: lat
       REAL, INTENT(IN)               :: lon
       REAL, INTENT(OUT)              :: i !(x-index)
       REAL, INTENT(OUT)              :: j !(y-index)
       TYPE(proj_info),INTENT(IN)     :: proj
-  
+
       ! Local variables
       real :: h, mc, tc, t, rho
 
@@ -921,20 +921,20 @@ MODULE module_llxy
       ! Get i/j relative to reference i/j
       i = proj%knowni + (i - proj%polei)
       j = proj%knownj + (j - proj%polej)
-  
+
       RETURN
 
    END SUBROUTINE llij_ps_wgs84
 
 
    SUBROUTINE ijll_ps_wgs84(i, j, proj, lat, lon)
- 
-      ! This is the inverse subroutine of llij_ps.  It returns the 
+
+      ! This is the inverse subroutine of llij_ps.  It returns the
       ! latitude and longitude of an i/j point given the projection info 
-      ! structure.  
-  
+      ! structure.
+
       implicit none
-  
+
       ! Arguments
       REAL, INTENT(IN)                    :: i    ! Column
       REAL, INTENT(IN)                    :: j    ! Row
@@ -955,7 +955,7 @@ MODULE module_llxy
                 (((1.0+E_WGS84*sin(h*proj%truelat1*rad_per_deg))/(1.0-E_WGS84*sin(h*proj%truelat1*rad_per_deg)))**E_WGS84 ))
 
       rho = sqrt((x*proj%dx)**2.0 + (y*proj%dx)**2.0)
-      t = rho * tc / (A_WGS84 * mc) 
+      t = rho * tc / (A_WGS84 * mc)
 
       lon = h*proj%stdlon*rad_per_deg + h*atan2(h*x,h*(-y))
 
@@ -972,7 +972,7 @@ MODULE module_llxy
       lon = lon*deg_per_rad
 
       RETURN
-   
+
    END SUBROUTINE ijll_ps_wgs84
 
 
@@ -983,10 +983,10 @@ MODULE module_llxy
       ! pole for use in llij_albers_nad83 and ijll_albers_nad83.
 
       IMPLICIT NONE
-   
+
       ! Arguments
       TYPE(proj_info), INTENT(INOUT)    :: proj
-  
+
       ! Local variables
       real :: h, m1, m2, q1, q2, theta, q, sinphi
 
@@ -1019,7 +1019,7 @@ MODULE module_llxy
       proj%rho0 = h * (A_NAD83 / proj%dx) * sqrt(proj%bigc - proj%nc * q) / proj%nc 
       theta = proj%nc*(proj%lon1 - proj%stdlon)*rad_per_deg
 
-      proj%polei = proj%rho0 * sin(h*theta) 
+      proj%polei = proj%rho0 * sin(h*theta)
       proj%polej = proj%rho0 - proj%rho0 * cos(h*theta)
 
       RETURN
@@ -1029,19 +1029,19 @@ MODULE module_llxy
 
    SUBROUTINE llij_albers_nad83(lat,lon,proj,i,j)
       ! Given latitude (-90 to 90), longitude (-180 to 180), and the
-      ! standard projection information via the 
+      ! standard projection information via the
       ! public proj structure, this routine returns the i/j indices which
       ! if within the domain range from 1->nx and 1->ny, respectively.
-  
+
       IMPLICIT NONE
-  
+
       ! Arguments
       REAL, INTENT(IN)               :: lat
       REAL, INTENT(IN)               :: lon
       REAL, INTENT(OUT)              :: i !(x-index)
       REAL, INTENT(OUT)              :: j !(y-index)
       TYPE(proj_info),INTENT(IN)     :: proj
-  
+
       ! Local variables
       real :: h, q, rho, theta, sinphi
 
@@ -1069,13 +1069,13 @@ MODULE module_llxy
 
 
    SUBROUTINE ijll_albers_nad83(i, j, proj, lat, lon)
- 
+
       ! This is the inverse subroutine of llij_albers_nad83.  It returns the 
       ! latitude and longitude of an i/j point given the projection info 
-      ! structure.  
-  
+      ! structure.
+
       implicit none
-  
+
       ! Arguments
       REAL, INTENT(IN)                    :: i    ! Column
       REAL, INTENT(IN)                    :: j    ! Row
@@ -1108,70 +1108,70 @@ MODULE module_llxy
       lon = proj%stdlon + theta*deg_per_rad/proj%nc
 
       RETURN
-   
+
    END SUBROUTINE ijll_albers_nad83
 
 
    SUBROUTINE set_lc(proj)
       ! Initialize the remaining items in the proj structure for a
       ! lambert conformal grid.
-  
+
       IMPLICIT NONE
-      
+
       TYPE(proj_info), INTENT(INOUT)     :: proj
-  
+
       REAL                               :: arg
       REAL                               :: deltalon1
       REAL                               :: tl1r
       REAL                               :: ctl1r
-  
+
       ! Compute cone factor
       CALL lc_cone(proj%truelat1, proj%truelat2, proj%cone)
-  
+
       ! Compute longitude differences and ensure we stay out of the
       ! forbidden "cut zone"
       deltalon1 = proj%lon1 - proj%stdlon
       IF (deltalon1 .GT. +180.) deltalon1 = deltalon1 - 360.
       IF (deltalon1 .LT. -180.) deltalon1 = deltalon1 + 360.
-  
+
       ! Convert truelat1 to radian and compute COS for later use
       tl1r = proj%truelat1 * rad_per_deg
       ctl1r = COS(tl1r)
-  
+
       ! Compute the radius to our known lower-left (SW) corner
       proj%rsw = proj%rebydx * ctl1r/proj%cone * &
              (TAN((90.*proj%hemi-proj%lat1)*rad_per_deg/2.) / &
               TAN((90.*proj%hemi-proj%truelat1)*rad_per_deg/2.))**proj%cone
-  
+
       ! Find pole point
       arg = proj%cone*(deltalon1*rad_per_deg)
       proj%polei = proj%hemi*proj%knowni - proj%hemi * proj%rsw * SIN(arg)
-      proj%polej = proj%hemi*proj%knownj + proj%rsw * COS(arg)  
-  
+      proj%polej = proj%hemi*proj%knownj + proj%rsw * COS(arg)
+
       RETURN
 
-   END SUBROUTINE set_lc                             
+   END SUBROUTINE set_lc
 
 
    SUBROUTINE lc_cone(truelat1, truelat2, cone)
- 
+
    ! Subroutine to compute the cone factor of a Lambert Conformal projection
- 
+
       IMPLICIT NONE
-      
+
       ! Input Args
       REAL, INTENT(IN)             :: truelat1  ! (-90 -> 90 degrees N)
       REAL, INTENT(IN)             :: truelat2  !   "   "  "   "     "
-  
+
       ! Output Args
       REAL, INTENT(OUT)            :: cone
-  
+
       ! Locals
-  
+
       ! BEGIN CODE
-  
+
       ! First, see if this is a secant or tangent projection.  For tangent
-      ! projections, truelat1 = truelat2 and the cone is tangent to the 
+      ! projections, truelat1 = truelat2 and the cone is tangent to the
       ! Earth's surface at this latitude.  For secant projections, the cone
       ! intersects the Earth's surface at each of the distinctly different
       ! latitudes
@@ -1181,7 +1181,7 @@ MODULE module_llxy
          cone = cone /(ALOG10(TAN((45.0 - ABS(truelat1)/2.0) * rad_per_deg)) - &
                 ALOG10(TAN((45.0 - ABS(truelat2)/2.0) * rad_per_deg)))        
       ELSE
-         cone = SIN(ABS(truelat1)*rad_per_deg )  
+         cone = SIN(ABS(truelat1)*rad_per_deg )
       ENDIF
 
       RETURN
@@ -1190,25 +1190,25 @@ MODULE module_llxy
 
 
    SUBROUTINE ijll_lc( i, j, proj, lat, lon)
- 
-   ! Subroutine to convert from the (i,j) cartesian coordinate to the 
+
+   ! Subroutine to convert from the (i,j) cartesian coordinate to the
    ! geographical latitude and longitude for a Lambert Conformal projection.
- 
+
    ! History:
    ! 25 Jul 01: Corrected by B. Shaw, NOAA/FSL
-   ! 
+   !
       IMPLICIT NONE
-  
+
       ! Input Args
       REAL, INTENT(IN)              :: i        ! Cartesian X coordinate
       REAL, INTENT(IN)              :: j        ! Cartesian Y coordinate
       TYPE(proj_info),INTENT(IN)    :: proj     ! Projection info structure
-  
-      ! Output Args                 
+
+      ! Output Args
       REAL, INTENT(OUT)             :: lat      ! Latitude (-90->90 deg N)
       REAL, INTENT(OUT)             :: lon      ! Longitude (-180->180 E)
-  
-      ! Locals 
+
+      ! Locals
       REAL                          :: inew
       REAL                          :: jnew
       REAL                          :: r
@@ -1216,106 +1216,106 @@ MODULE module_llxy
       REAL                          :: r2
       REAL                          :: xx
       REAL                          :: yy
-  
+
       ! BEGIN CODE
-  
+
       chi1 = (90. - proj%hemi*proj%truelat1)*rad_per_deg
       chi2 = (90. - proj%hemi*proj%truelat2)*rad_per_deg
-  
+
       ! See if we are in the southern hemispere and flip the indices
-      ! if we are. 
+      ! if we are.
       inew = proj%hemi * i
       jnew = proj%hemi * j
-  
+
       ! Compute radius**2 to i/j location
       xx = inew - proj%polei
       yy = proj%polej - jnew
       r2 = (xx*xx + yy*yy)
       r = SQRT(r2)/proj%rebydx
-     
+
       ! Convert to lat/lon
       IF (r2 .EQ. 0.) THEN
          lat = proj%hemi * 90.
          lon = proj%stdlon
       ELSE
-         
+
          ! Longitude
          lon = proj%stdlon + deg_per_rad * ATAN2(proj%hemi*xx,yy)/proj%cone
          lon = MOD(lon+360., 360.)
-   
+
          ! Latitude.  Latitude determined by solving an equation adapted 
          ! from:
          !  Maling, D.H., 1973: Coordinate Systems and Map Projections
-         ! Equations #20 in Appendix I.  
-           
+         ! Equations #20 in Appendix I.
+
          IF (chi1 .EQ. chi2) THEN
             chi = 2.0*ATAN( ( r/TAN(chi1) )**(1./proj%cone) * TAN(chi1*0.5) )
          ELSE
             chi = 2.0*ATAN( (r*proj%cone/SIN(chi1))**(1./proj%cone) * TAN(chi1*0.5)) 
          ENDIF
          lat = (90.0-chi*deg_per_rad)*proj%hemi
-  
+
       ENDIF
-  
+
       IF (lon .GT. +180.) lon = lon - 360.
       IF (lon .LT. -180.) lon = lon + 360.
- 
+
       RETURN
 
    END SUBROUTINE ijll_lc
 
 
    SUBROUTINE llij_lc( lat, lon, proj, i, j)
- 
+
    ! Subroutine to compute the geographical latitude and longitude values
    ! to the cartesian x/y on a Lambert Conformal projection.
-     
+
       IMPLICIT NONE
-  
+
       ! Input Args
       REAL, INTENT(IN)              :: lat      ! Latitude (-90->90 deg N)
       REAL, INTENT(IN)              :: lon      ! Longitude (-180->180 E)
       TYPE(proj_info),INTENT(IN)      :: proj     ! Projection info structure
-  
-      ! Output Args                 
+
+      ! Output Args
       REAL, INTENT(OUT)             :: i        ! Cartesian X coordinate
       REAL, INTENT(OUT)             :: j        ! Cartesian Y coordinate
-  
-      ! Locals 
+
+      ! Locals
       REAL                          :: arg
       REAL                          :: deltalon
       REAL                          :: tl1r
       REAL                          :: rm
       REAL                          :: ctl1r
-      
-  
+
+
       ! BEGIN CODE
-      
+
       ! Compute deltalon between known longitude and standard lon and ensure
       ! it is not in the cut zone
       deltalon = lon - proj%stdlon
       IF (deltalon .GT. +180.) deltalon = deltalon - 360.
       IF (deltalon .LT. -180.) deltalon = deltalon + 360.
-      
+
       ! Convert truelat1 to radian and compute COS for later use
       tl1r = proj%truelat1 * rad_per_deg
-      ctl1r = COS(tl1r)     
-     
+      ctl1r = COS(tl1r)
+
       ! Radius to desired point
       rm = proj%rebydx * ctl1r/proj%cone * &
            (TAN((90.*proj%hemi-lat)*rad_per_deg/2.) / &
             TAN((90.*proj%hemi-proj%truelat1)*rad_per_deg/2.))**proj%cone
-  
+
       arg = proj%cone*(deltalon*rad_per_deg)
       i = proj%polei + proj%hemi * rm * SIN(arg)
       j = proj%polej - rm * COS(arg)
-  
+
       ! Finally, if we are in the southern hemisphere, flip the i/j
       ! values to a coordinate system where (1,1) is the SW corner
       ! (what we assume) which is different than the original NCEP
-      ! algorithms which used the NE corner as the origin in the 
+      ! algorithms which used the NE corner as the origin in the
       ! southern hemisphere (left-hand vs. right-hand coordinate?)
-      i = proj%hemi * i  
+      i = proj%hemi * i
       j = proj%hemi * j
 
       RETURN
@@ -1323,22 +1323,22 @@ MODULE module_llxy
 
 
    SUBROUTINE set_merc(proj)
-   
+
       ! Sets up the remaining basic elements for the mercator projection
-  
+
       IMPLICIT NONE
       TYPE(proj_info), INTENT(INOUT)       :: proj
       REAL                                 :: clain
-  
-  
+
+
       !  Preliminary variables
-  
+
       clain = COS(rad_per_deg*proj%truelat1)
       proj%dlon = proj%dx / (proj%re_m * clain)
-  
-      ! Compute distance from equator to origin, and store in the 
+
+      ! Compute distance from equator to origin, and store in the
       ! proj%rsw tag.
-  
+
       proj%rsw = 0.
       IF (proj%lat1 .NE. 0.) THEN
          proj%rsw = (ALOG(TAN(0.5*((proj%lat1+90.)*rad_per_deg))))/proj%dlon
@@ -1350,9 +1350,9 @@ MODULE module_llxy
 
 
    SUBROUTINE llij_merc(lat, lon, proj, i, j)
- 
+
       ! Compute i/j coordinate from lat lon for mercator projection
-    
+
       IMPLICIT NONE
       REAL, INTENT(IN)              :: lat
       REAL, INTENT(IN)              :: lon
@@ -1360,31 +1360,31 @@ MODULE module_llxy
       REAL,INTENT(OUT)              :: i
       REAL,INTENT(OUT)              :: j
       REAL                          :: deltalon
-  
+
       deltalon = lon - proj%lon1
       IF (deltalon .LT. -180.) deltalon = deltalon + 360.
       IF (deltalon .GT. 180.) deltalon = deltalon - 360.
       i = proj%knowni + (deltalon/(proj%dlon*deg_per_rad))
       j = proj%knownj + (ALOG(TAN(0.5*((lat + 90.) * rad_per_deg)))) / &
              proj%dlon - proj%rsw
-  
+
       RETURN
 
    END SUBROUTINE llij_merc
 
 
    SUBROUTINE ijll_merc(i, j, proj, lat, lon)
- 
+
       ! Compute the lat/lon from i/j for mercator projection
-  
+
       IMPLICIT NONE
       REAL,INTENT(IN)               :: i
-      REAL,INTENT(IN)               :: j    
+      REAL,INTENT(IN)               :: j
       TYPE(proj_info),INTENT(IN)    :: proj
       REAL, INTENT(OUT)             :: lat
-      REAL, INTENT(OUT)             :: lon 
-  
-  
+      REAL, INTENT(OUT)             :: lon
+
+
       lat = 2.0*ATAN(EXP(proj%dlon*(proj%rsw + j-proj%knownj)))*deg_per_rad - 90.
       lon = (i-proj%knowni)*proj%dlon*deg_per_rad + proj%lon1
       IF (lon.GT.180.) lon = lon - 360.
@@ -1395,7 +1395,7 @@ MODULE module_llxy
 
 
    SUBROUTINE llij_latlon(lat, lon, proj, i, j)
-  
+
       ! Compute the i/j location of a lat/lon on a LATLON grid.
       IMPLICIT NONE
       REAL, INTENT(IN)             :: lat
@@ -1403,29 +1403,29 @@ MODULE module_llxy
       TYPE(proj_info), INTENT(IN)  :: proj
       REAL, INTENT(OUT)            :: i
       REAL, INTENT(OUT)            :: j
-  
+
       REAL                         :: deltalat
       REAL                         :: deltalon
-  
+
       ! Compute deltalat and deltalon as the difference between the input 
       ! lat/lon and the origin lat/lon
       deltalat = lat - proj%lat1
-      deltalon = lon - proj%lon1      
-      
+      deltalon = lon - proj%lon1
+
       ! Compute i/j
       i = deltalon/proj%loninc
       j = deltalat/proj%latinc
 
       i = i + proj%knowni
       j = j + proj%knownj
-  
+
       RETURN
 
    END SUBROUTINE llij_latlon
 
 
    SUBROUTINE ijll_latlon(i, j, proj, lat, lon)
-  
+
       ! Compute the lat/lon location of an i/j on a LATLON grid.
       IMPLICIT NONE
       REAL, INTENT(IN)             :: i
@@ -1433,21 +1433,21 @@ MODULE module_llxy
       TYPE(proj_info), INTENT(IN)  :: proj
       REAL, INTENT(OUT)            :: lat
       REAL, INTENT(OUT)            :: lon
-  
+
       REAL                         :: i_work, j_work
       REAL                         :: deltalat
       REAL                         :: deltalon
-  
+
       i_work = i - proj%knowni
       j_work = j - proj%knownj
 
-      ! Compute deltalat and deltalon 
+      ! Compute deltalat and deltalon
       deltalat = j_work*proj%latinc
       deltalon = i_work*proj%loninc
-  
+
       lat = proj%lat1 + deltalat
       lon = proj%lon1 + deltalon
-  
+
       RETURN
 
    END SUBROUTINE ijll_latlon
@@ -1468,7 +1468,7 @@ MODULE module_llxy
    SUBROUTINE llij_cyl(lat, lon, proj, i, j)
 
       implicit none
-    
+
       ! Arguments
       real, intent(in) :: lat, lon
       real, intent(out) :: i, j
@@ -1501,9 +1501,9 @@ MODULE module_llxy
 
 
    SUBROUTINE ijll_cyl(i, j, proj, lat, lon)
-   
+
       implicit none
-    
+
       ! Arguments
       real, intent(in) :: i, j
       real, intent(out) :: lat, lon
@@ -1514,7 +1514,7 @@ MODULE module_llxy
       real :: deltalon
       real :: i_work, j_work
 
-      i_work = i - proj%knowni 
+      i_work = i - proj%knowni
       j_work = j - proj%knownj
 
       if (i_work < 0.)              i_work = i_work + 360./proj%loninc
@@ -1567,7 +1567,7 @@ MODULE module_llxy
    SUBROUTINE llij_cassini(lat, lon, proj, i, j)
 
       implicit none
-    
+
       ! Arguments
       real, intent(in) :: lat, lon
       real, intent(out) :: i, j
@@ -1591,9 +1591,9 @@ MODULE module_llxy
 
 
    SUBROUTINE ijll_cassini(i, j, proj, lat, lon)
-   
+
       implicit none
-    
+
       ! Arguments
       real, intent(in) :: i, j
       real, intent(out) :: lat, lon
@@ -1618,7 +1618,7 @@ MODULE module_llxy
 
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    ! Purpose: Converts between computational and geographic lat/lon for Cassini
-   !          
+   !
    ! Notes: This routine was provided by Bill Skamarock, 2007-03-27
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    SUBROUTINE rotate_coords(ilat,ilon,olat,olon,lat_np,lon_np,lon_0,direction)
@@ -1675,15 +1675,15 @@ MODULE module_llxy
 
 
    SUBROUTINE llij_rotlatlon(lat, lon, proj, i_real, j_real)
-   
+
       IMPLICIT NONE
-    
+
       ! Arguments
       REAL, INTENT(IN) :: lat, lon
       REAL             :: i, j
       REAL, INTENT(OUT) :: i_real, j_real
       TYPE (proj_info), INTENT(IN) :: proj
-      
+
       ! Local variables
       INTEGER :: ii,imt,jj,jmt,k,krows,ncol,nrow,iri
       REAL(KIND=HIGH) :: dphd,dlmd !Grid increments, degrees
@@ -1695,14 +1695,14 @@ MODULE module_llxy
 
       glatd = lat
       glond = -lon
-  
+
       dphd = proj%phi/REAL((proj%jydim-1)/2)
       dlmd = proj%lambda/REAL(proj%ixdim-1)
 
       pi = ACOS(-1.0)
       d2r = pi/180.
       r2d = 1./d2r
-  
+
       imt = 2*proj%ixdim-1
       jmt = proj%jydim/2+1
 
@@ -1712,7 +1712,7 @@ MODULE module_llxy
       dlm = dlmd*d2r
       tph0 = proj%lat1*d2r
       tlm0 = -proj%lon1*d2r
-  
+
       x = COS(tph0)*COS(glat)*COS(glon-tlm0)+SIN(tph0)*SIN(glat)
       y = -COS(glat)*SIN(glon-tlm0)
       z = COS(tph0)*SIN(glat)-SIN(tph0)*COS(glat)*COS(glon-tlm0)
@@ -1737,7 +1737,7 @@ MODULE module_llxy
       tlat = tlat*d2r
       tlon = tlon*d2r
 
-  
+
       IF (proj%stagger == HH) THEN
 
          IF (mod(nrow,2) .eq. 0) then
@@ -1747,7 +1747,7 @@ MODULE module_llxy
          ENDIF
          j_real=row
 
-  
+
          IF ((abs(MOD(nrow,2)) == 1 .AND. abs(MOD(ncol,2)) == 1) .OR. &
              (MOD(nrow,2) == 0 .AND. MOD(ncol,2) == 0)) THEN
 
@@ -1765,7 +1765,7 @@ MODULE module_llxy
                nrow = nrow+1
                ncol = ncol+1
             END IF
-   
+
          ELSE
             tlat1 = (nrow+1-jmt)*dph
             tlat2 = tlat1-dph
@@ -1782,16 +1782,16 @@ MODULE module_llxy
                ncol = ncol+1
             END IF
          END IF
-  
+
       ELSE IF (proj%stagger == VV) THEN
 
          IF (mod(nrow,2) .eq. 0) then
             i_real = col / 2.0 + 0.5
          ELSE
-            i_real = col / 2.0 
+            i_real = col / 2.0
          ENDIF
          j_real=row
-  
+
          IF ((MOD(nrow,2) == 0 .AND. abs(MOD(ncol,2)) == 1) .OR. &
              (abs(MOD(nrow,2)) == 1 .AND. MOD(ncol,2) == 0)) THEN
             tlat1 = (nrow-jmt)*dph
@@ -1802,12 +1802,12 @@ MODULE module_llxy
             dlm2 = tlon-tlon2
             d1 = ACOS(COS(tlat)*COS(tlat1)*COS(dlm1)+SIN(tlat)*SIN(tlat1))
             d2 = ACOS(COS(tlat)*COS(tlat2)*COS(dlm2)+SIN(tlat)*SIN(tlat2))
-    
+
             IF (d1 > d2) THEN
                nrow = nrow+1
                ncol = ncol+1
             END IF
-   
+
          ELSE
             tlat1 = (nrow+1-jmt)*dph
             tlat2 = tlat1-dph
@@ -1817,7 +1817,7 @@ MODULE module_llxy
             dlm2 = tlon-tlon2
             d1 = ACOS(COS(tlat)*COS(tlat1)*COS(dlm1)+SIN(tlat)*SIN(tlat1))
             d2 = ACOS(COS(tlat)*COS(tlat2)*COS(dlm2)+SIN(tlat)*SIN(tlat2))
-    
+
             IF (d1 < d2) THEN
                nrow = nrow+1
             ELSE
@@ -1825,7 +1825,7 @@ MODULE module_llxy
             END IF
          END IF
       END IF
-  
+
 
 !!! Added next line as a Kludge - not yet understood why needed
       if (ncol .le. 0) ncol=ncol-1
@@ -1846,14 +1846,14 @@ MODULE module_llxy
 
 
    SUBROUTINE ijll_rotlatlon(i, j, proj, lat,lon)
-   
+
       IMPLICIT NONE
-    
+
       ! Arguments
       REAL, INTENT(IN) :: i, j
       REAL, INTENT(OUT) :: lat, lon
       TYPE (proj_info), INTENT(IN) :: proj
-      
+
       ! Local variables
       INTEGER :: ih,jh
       INTEGER :: midcol,midrow,ncol,iadd1,iadd2,imt,jh2,knrow,krem,kv,nrow
@@ -1865,16 +1865,16 @@ MODULE module_llxy
 
       i_work = i
       j_work = j
-  
+
       if ( (j - INT(j)) .gt. 0.999) then
          j_work = j + 0.0002
       endif
 
       jh = INT(j_work)
-  
+
       dphd = proj%phi/REAL((proj%jydim-1)/2)
       dlmd = proj%lambda/REAL(proj%ixdim-1)
-    
+
       pi = ACOS(-1.0)
       d2r = pi/180.
       r2d = 1./d2r
@@ -1895,19 +1895,19 @@ MODULE module_llxy
              tlond = tlond + DLMD
           end if
        END IF
-    
+
       tlatr = tlatd*d2r
       tlonr = tlond*d2r
       arg1 = SIN(tlatr)*COS(tph0)+COS(tlatr)*SIN(tph0)*COS(tlonr)
       glatr = ASIN(arg1)
-     
+
       glatd = glatr*r2d
-     
+
       arg2 = COS(tlatr)*COS(tlonr)/(COS(glatr)*COS(tph0))-TAN(glatr)*TAN(tph0)
       IF (ABS(arg2) > 1.) arg2 = ABS(arg2)/arg2
       fctr = 1.
       IF (tlond > 0.) fctr = -1.
-     
+
       glond = tlm0*r2d+fctr*ACOS(arg2)*r2d
 
       lat = glatd
@@ -1915,41 +1915,41 @@ MODULE module_llxy
 
       IF (lon .GT. +180.) lon = lon - 360.
       IF (lon .LT. -180.) lon = lon + 360.
-   
+
    END SUBROUTINE ijll_rotlatlon
 
 
    SUBROUTINE set_gauss(proj)
-    
+
       IMPLICIT NONE
- 
+
       ! Argument
       type (proj_info), intent(inout) :: proj
- 
+
       !  Initialize the array that will hold the Gaussian latitudes.
- 
+
       IF ( ASSOCIATED( proj%gauss_lat ) ) THEN
          DEALLOCATE ( proj%gauss_lat )
       END IF
- 
+
       !  Get the needed space for our array.
- 
+
       ALLOCATE ( proj%gauss_lat(proj%nlat*2) )
- 
+
       !  Compute the Gaussian latitudes.
- 
+
       CALL gausll( proj%nlat*2 , proj%gauss_lat )
- 
+
       !  Now, these could be upside down from what we want, so let's check.
       !  We take advantage of the equatorial symmetry to remove any sort of
       !  array re-ordering.
- 
+
       IF ( ABS(proj%gauss_lat(1) - proj%lat1) .GT. 0.01 ) THEN
          proj%gauss_lat = -1. * proj%gauss_lat
       END IF
- 
+
       !  Just a sanity check.
- 
+
       IF ( ABS(proj%gauss_lat(1) - proj%lat1) .GT. 0.01 ) THEN
          PRINT '(A)','Oops, something is not right with the Gaussian latitude computation.'
          PRINT '(A,F8.3,A)','The input data gave the starting latitude as ',proj%lat1,'.'
@@ -1957,124 +1957,124 @@ MODULE module_llxy
          PRINT '(A,F8.3,A)','The difference is larger than 0.01 degrees, which is not expected.'
          STOP 'Gaussian_latitude_computation'
       END IF
- 
+
    END SUBROUTINE set_gauss
 
 
    SUBROUTINE gausll ( nlat , lat_sp )
- 
+
       IMPLICIT NONE
-   
+
       INTEGER                            :: nlat , i
       REAL (KIND=HIGH) , PARAMETER       :: pi = 3.141592653589793
       REAL (KIND=HIGH) , DIMENSION(nlat) :: cosc , gwt , sinc , colat , wos2 , lat
       REAL             , DIMENSION(nlat) :: lat_sp
-   
+
       CALL lggaus(nlat, cosc, gwt, sinc, colat, wos2)
-   
+
       DO i = 1, nlat
          lat(i) = ACOS(sinc(i)) * 180._HIGH / pi
          IF (i.gt.nlat/2) lat(i) = -lat(i)
       END DO
-   
+
       lat_sp = REAL(lat)
- 
+
    END SUBROUTINE gausll
 
 
    SUBROUTINE lggaus( nlat, cosc, gwt, sinc, colat, wos2 )
- 
+
       IMPLICIT NONE
- 
+
       !  LGGAUS finds the Gaussian latitudes by finding the roots of the
       !  ordinary Legendre polynomial of degree NLAT using Newton's
       !  iteration method.
-      
+
       !  On entry:
             integer NLAT ! the number of latitudes (degree of the polynomial)
-      
+
       !  On exit: for each Gaussian latitude
       !     COSC   - cos(colatitude) or sin(latitude)
       !     GWT    - the Gaussian weights
       !     SINC   - sin(colatitude) or cos(latitude)
       !     COLAT  - the colatitudes in radians
       !     WOS2   - Gaussian weight over sin**2(colatitude)
- 
+
       REAL (KIND=HIGH) , DIMENSION(nlat) :: cosc , gwt , sinc , colat  , wos2 
       REAL (KIND=HIGH) , PARAMETER       :: pi = 3.141592653589793
- 
+
       !  Convergence criterion for iteration of cos latitude
- 
+
       REAL , PARAMETER :: xlim  = 1.0E-14
- 
+
       INTEGER :: nzero, i, j
       REAL (KIND=HIGH) :: fi, fi1, a, b, g, gm, gp, gt, delta, c, d
- 
+
       !  The number of zeros between pole and equator
- 
+
       nzero = nlat/2
- 
+
       !  Set first guess for cos(colat)
- 
+
       DO i=1,nzero
          cosc(i) = SIN( (i-0.5)*pi/nlat + pi*0.5 )
       END DO
- 
+
       !  Constants for determining the derivative of the polynomial
       fi  = nlat
       fi1 = fi+1.0
       a   = fi*fi1 / SQRT(4.0*fi1*fi1-1.0)
       b   = fi1*fi / SQRT(4.0*fi*fi-1.0)
- 
+
       !  Loop over latitudes, iterating the search for each root
- 
+
       DO i=1,nzero
          j=0
- 
+
          !  Determine the value of the ordinary Legendre polynomial for
          !  the current guess root
- 
+
          DO
             CALL lgord( g, cosc(i), nlat )
-   
+
             !  Determine the derivative of the polynomial at this point
-   
+
             CALL lgord( gm, cosc(i), nlat-1 )
             CALL lgord( gp, cosc(i), nlat+1 )
             gt = (cosc(i)*cosc(i)-1.0) / (a*gp-b*gm)
-   
+
             !  Update the estimate of the root
-   
+
             delta   = g*gt
             cosc(i) = cosc(i) - delta
-   
+
             !  If convergence criterion has not been met, keep trying
-   
+
             j = j+1
             IF( ABS(delta).GT.xlim ) CYCLE
-   
+
             !  Determine the Gaussian weights
-   
+
             c      = 2.0 *( 1.0-cosc(i)*cosc(i) )
             CALL lgord( d, cosc(i), nlat-1 )
             d      = d*d*fi*fi
             gwt(i) = c *( fi-0.5 ) / d
             EXIT
- 
+
          END DO
- 
+
       END DO
- 
+
       !  Determine the colatitudes and sin(colat) and weights over sin**2
- 
+
       DO i=1,nzero
          colat(i)= ACOS(cosc(i))
          sinc(i) = SIN(colat(i))
          wos2(i) = gwt(i) /( sinc(i)*sinc(i) )
       END DO
- 
+
       !  If NLAT is odd, set values at the equator
- 
+
       IF( MOD(nlat,2) .NE. 0 ) THEN
          i       = nzero+1
          cosc(i) = 0.0
@@ -2086,9 +2086,9 @@ MODULE module_llxy
          sinc(i) = 1.0
          wos2(i) = gwt(i)
       END IF
- 
+
       !  Determine the southern hemisphere values by symmetry
- 
+
       DO i=nlat-nzero+1,nlat
          cosc(i) =-cosc(nlat+1-i)
          gwt(i)  = gwt(nlat+1-i)
@@ -2096,37 +2096,37 @@ MODULE module_llxy
          sinc(i) = sinc(nlat+1-i)
          wos2(i) = wos2(nlat+1-i)
       END DO
- 
+
    END SUBROUTINE lggaus
 
 
    SUBROUTINE lgord( f, cosc, n )
- 
+
       IMPLICIT NONE
- 
+
       !  LGORD calculates the value of an ordinary Legendre polynomial at a
       !  specific latitude.
-      
+
       !  On entry:
       !     cosc - COS(colatitude)
       !     n      - the degree of the polynomial
-      
+
       !  On exit:
       !     f      - the value of the Legendre polynomial of degree N at
       !              latitude ASIN(cosc)
- 
+
       REAL (KIND=HIGH) :: s1, c4, a, b, fk, f, cosc, colat, c1, fn, ang
       INTEGER :: n, k
- 
+
       !  Determine the colatitude
- 
+
       colat = ACOS(cosc)
- 
+
       c1 = SQRT(2.0_HIGH)
       DO k=1,n
          c1 = c1 * SQRT( 1.0 - 1.0/(4*k*k) )
       END DO
- 
+
       fn = n
       ang= fn * colat
       s1 = 0.0
@@ -2141,35 +2141,35 @@ MODULE module_llxy
          fk = k
          ang= colat * (fn-fk-2.0)
          c4 = ( a * (fn-b+1.0) / ( b * (fn+fn-a) ) ) * c4
-      END DO 
- 
+      END DO
+
       f = s1 * c1
- 
+
    END SUBROUTINE lgord
 
 
-   SUBROUTINE llij_gauss (lat, lon, proj, i, j) 
- 
+   SUBROUTINE llij_gauss (lat, lon, proj, i, j)
+
       IMPLICIT NONE
- 
+
       REAL    , INTENT(IN)  :: lat, lon
       REAL    , INTENT(OUT) :: i, j
       TYPE (proj_info), INTENT(IN) :: proj
- 
+
       INTEGER :: n , n_low
       LOGICAL :: found = .FALSE.
       REAL    :: diff_1 , diff_nlat
- 
+
       !  The easy one first, get the x location.  The calling routine has already made
       !  sure that the necessary assumptions concerning the sign of the deltalon and the
       !  relative east/west'ness of the longitude and the starting longitude are consistent
       !  to allow this easy computation.
- 
+
       i = ( lon - proj%lon1 ) / proj%loninc + 1.
- 
+
       !  Since this is a global data set, we need to be concerned about wrapping the
       !  fields around the globe.
- 
+
 !      IF      ( ( proj%loninc .GT. 0 ) .AND. &
 !                ( FLOOR((lon-proj%lon1)/proj%loninc) + 1 .GE. proj%ixdim ) .AND. &
 !                ( lon + proj%loninc .GE. proj%lon1 + 360 ) ) THEN
@@ -2185,27 +2185,27 @@ MODULE module_llxy
 ! !        proj%wrap = .TRUE.
 !         i = proj%ixdim
 !      END IF
- 
+
       !  Yet another quicky test, can we find bounding values?  If not, then we may be
       !  dealing with putting data to a polar projection, so just give them them maximal
       !  value for the location.  This is an OK assumption for the interpolation across the
       !  top of the pole, given how close the longitude lines are.
- 
+
       IF ( ABS(lat) .GT. ABS(proj%gauss_lat(1)) ) THEN
- 
+
          diff_1    = lat - proj%gauss_lat(1)
          diff_nlat = lat - proj%gauss_lat(proj%nlat*2)
- 
+
          IF ( ABS(diff_1) .LT. ABS(diff_nlat) ) THEN
             j = 1
          ELSE
             j = proj%nlat*2
          END IF
- 
+
       !  If the latitude is between the two bounding values, we have to search and interpolate.
- 
+
       ELSE
- 
+
          DO n = 1 , proj%nlat*2 -1
             IF ( ( proj%gauss_lat(n) - lat ) * ( proj%gauss_lat(n+1) - lat ) .LE. 0 ) THEN
                found = .TRUE.
@@ -2213,20 +2213,20 @@ MODULE module_llxy
                EXIT
             END IF
          END DO
- 
+
          !  Everything still OK?
-  
+
          IF ( .NOT. found ) THEN
             PRINT '(A)','Troubles in river city.  No bounding values of latitude found in the Gaussian routines.'
             STOP 'Gee_no_bounding_lats_Gaussian'
          END IF
- 
+
          j = ( ( proj%gauss_lat(n_low) - lat                     ) * ( n_low + 1 ) + &
                ( lat                   - proj%gauss_lat(n_low+1) ) * ( n_low     ) ) / &
                ( proj%gauss_lat(n_low) - proj%gauss_lat(n_low+1) )
- 
+
       END IF
 
-   END SUBROUTINE llij_gauss 
-  
+   END SUBROUTINE llij_gauss
+
 END MODULE module_llxy

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_mapinfo.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_mapinfo.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_mapinfo

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_wrfinputfile.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/module_wrfinputfile.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_wrfinputfile
@@ -46,8 +46,8 @@ module module_wrfinputfile
 contains
 
   subroutine read_wrfinput_file(flnm, wrfinput, ierr)
-    ! 
-    ! Reads the wrfinput file identified by <flnm>, and fills out 
+    !
+    ! Reads the wrfinput file identified by <flnm>, and fills out
     ! the <wrfinput> structure with the appropriate values.
     !
     implicit none
@@ -108,7 +108,7 @@ contains
     allocate(wrfinput%ter(wrfinput%idim, wrfinput%jdim))
     call get_2d("HGT", ncid, wrfinput%ter, wrfinput%idim, wrfinput%jdim)
 
-    ! Get Land Use categories 
+    ! Get Land Use categories
     allocate(wrfinput%use(wrfinput%idim, wrfinput%jdim))
     call get_2d("IVGTYP", ncid, wrfinput%use, wrfinput%idim, wrfinput%jdim)
 
@@ -240,7 +240,7 @@ contains
 
   subroutine get_2d(name, ncid, array, idim, jdim)
     !
-    ! From the NetCDF unit <ncid>, read the variable named <name> with  
+    ! From the NetCDF unit <ncid>, read the variable named <name> with
     ! dimensions <idim> and <jdim>, filling the pre-dimensioned array <array>
     !
     implicit none

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/swap4f.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/swap4f.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 subroutine swap4f(in,nn)
@@ -39,7 +39,7 @@ subroutine swap4f(in,nn)
      ia = in(i+(nbytes-1):i:-1)
      in(i:i+(nbytes-1)) = ia
   enddo
-	
+
 #endif
 end
 !KWM -------------------------------------------------------------------------
@@ -102,8 +102,8 @@ end
 !KWM	data l/32/,u/127/
 !KWM	do 10 i=1,in
 !KWM	n(i)=m(i)
-!KWM	if(n(i).lt.  l) n(i)=l  
-!KWM	if(n(i).gt.  u) n(i)=u   
+!KWM	if(n(i).lt.  l) n(i)=l
+!KWM	if(n(i).gt.  u) n(i)=u
 !KWM   10	continue
 !KWM	return
 !KWM#endif

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/trig_degrees.F
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/trig_degrees.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !

--- a/src/Land_models/NoahMP/HRLDAS_forcing/run/examples/GLDAS/combine_precips.f90
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/run/examples/GLDAS/combine_precips.f90
@@ -62,6 +62,6 @@ if(iret/=0) stop 11
 
 call baclose(lugbout,iret)
 if(iret/=0) stop 12
- 
+
 
 end

--- a/src/Land_models/NoahMP/HRLDAS_forcing/run/examples/GLDAS/create_UV.f90
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/run/examples/GLDAS/create_UV.f90
@@ -42,7 +42,7 @@ if(iret/=0) stop 5
 
 call baclose(lugbout1,iret)
 if(iret/=0) stop 6
- 
+
 
 ! CREATE FAKE V AND SET TO ZERO
 
@@ -58,6 +58,6 @@ if(iret/=0) stop 8
 
 call baclose(lugbout2,iret)
 if(iret/=0) stop 9
- 
+
 
 end

--- a/src/Land_models/NoahMP/HRLDAS_forcing/run/examples/GLDAS/fill_SSRD.f90
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/run/examples/GLDAS/fill_SSRD.f90
@@ -68,7 +68,7 @@ if(check1) then
 
 end if
 
-if(check2) then 
+if(check2) then
 
   call baopenr(lugbin2,infile2,iret)
   if(iret/=0) stop 12
@@ -93,7 +93,7 @@ if(debug) print *, count(cza(:,4)<0.and.data_in2>0)
 
 ! START MESSING WITH THE INPUT DATA
 
-where(data_in1 <= 0 .or. cza(:,1) <= 0.0) 
+where(data_in1 <= 0 .or. cza(:,1) <= 0.0)
   data_in1 = 0.0
   cza(:,1) = 0.0
 end where
@@ -109,25 +109,25 @@ data_out(:,4) = data_in2
 data_out(:,2) = (2.0*data_in1 + data_in2)/3.0  ! default to linear interp
 data_out(:,3) = (data_in1 + 2.0*data_in2)/3.0
 
-where(data_in1 > critnrg .and. data_in2 <= critnrg .and. cza(:,1) > critcos) 
+where(data_in1 > critnrg .and. data_in2 <= critnrg .and. cza(:,1) > critcos)
   data_out(:,2) = cza(:,2)/cza(:,1) * data_in1   ! if sun sufficently high
   data_out(:,3) = cza(:,3)/cza(:,1) * data_in1   ! around sunset, use left value
 end where
 
-where(data_in1 <= critnrg .and. data_in2 > critnrg .and. cza(:,4) > critcos) 
+where(data_in1 <= critnrg .and. data_in2 > critnrg .and. cza(:,4) > critcos)
   data_out(:,2) = cza(:,2)/cza(:,4) * data_in2   ! if sun sufficently high
   data_out(:,3) = cza(:,3)/cza(:,4) * data_in2   ! around sunrise, use right value
 end where
 
 where(data_in1 > critnrg .and. data_in2 > critnrg .and. cza(:,1) > critcos .and. cza(:,4) > critcos)
-  data_out(:,3) = cza(:,3)/cza(:,4) * data_in2  ! mid-day with sufficient sun 
+  data_out(:,3) = cza(:,3)/cza(:,4) * data_in2  ! mid-day with sufficient sun
   data_out(:,2) = cza(:,2)/cza(:,1) * data_in1  !   so use zenith angle
 end where
 
 ! WRITE OUT NEW FILES
 
 do i = 1,4
-  
+
   where(data_out(:,i) <= 0 .or. cza(:,i) <= 0.0) data_out(:,i) = 0.0
 
   if(debug) print *, cza(testpt,i), data_out(testpt,i), data_in1(testpt), data_in2(testpt)
@@ -148,7 +148,7 @@ do i = 1,4
   call baclose(lugbout+i,iret)
   if(iret/=0) stop 6
 
-end do 
+end do
 
 if(debug) print *
 
@@ -164,7 +164,7 @@ subroutine get_cza(jday, gmthour, latrad, lonrad, cza)
 
   real :: gg, tc, declin, sha(maxpts)
   real, parameter :: pi = 3.14159265
-  
+
   ! Fractional day of the year, in radians
   gg = (360./365.25) * (JDAY+gmthour/24.) * pi/180.
 

--- a/src/Land_models/NoahMP/HRLDAS_forcing/run/examples/NARR/fill_DSWRF.f90
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/run/examples/NARR/fill_DSWRF.f90
@@ -114,7 +114,7 @@ if (debug) print *, cza(testpt,i), data_out(testpt,i), data_in(testpt)     ! 178
   call baclose(lugbout+i,iret)
   if(iret/=0) stop 6
 
-end do 
+end do
 
 contains
 
@@ -128,7 +128,7 @@ subroutine get_cza(jday, gmthour, latrad, lonrad, cza)
 
   real :: gg, tc, declin, sha(maxpts)
   real, parameter :: pi = 3.14159265
-  
+
   ! Fractional day of the year, in radians
   gg = (360./365.25) * (JDAY+gmthour/24.) * pi/180.
 

--- a/src/Land_models/NoahMP/IO_code/main_hrldas_driver.F
+++ b/src/Land_models/NoahMP/IO_code/main_hrldas_driver.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 program noah_hrldas_driver
@@ -35,16 +35,16 @@ program noah_hrldas_driver
   use forcing
   use geometry
   use orchestrator_base
-  
+
   implicit none
   integer :: ITIME, NTIME
   type(state_type) :: state
-  
+
   call orchestrator%init()
-  
+
   call land_driver_ini(NTIME, state)
-  
-#ifdef WRF_HYDRO   
+
+#ifdef WRF_HYDRO
   do ITIME = 1, NTIME
 #else
   do ITIME = 0, NTIME
@@ -56,5 +56,5 @@ program noah_hrldas_driver
   !Pass state for destruction
   call hydro_finish()
 #endif
-     
+
 end program noah_hrldas_driver

--- a/src/Land_models/NoahMP/Utility_routines/kwm_string_utilities.F
+++ b/src/Land_models/NoahMP/Utility_routines/kwm_string_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module kwm_string_utilities
@@ -68,7 +68,7 @@ contains
           return_string(j:j) = string(i:i)
        endif
     enddo
-    
+
   end function unblank
 
 !KWM  character function upcase(h)
@@ -87,7 +87,7 @@ contains
     implicit none
     character(len=*), intent(in) :: h
     integer :: i
-    
+
     return_string = " "
 
     do i = 1, len_trim(h)

--- a/src/Land_models/NoahMP/Utility_routines/module_date_utilities.F
+++ b/src/Land_models/NoahMP/Utility_routines/module_date_utilities.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module Module_Date_utilities
@@ -459,7 +459,7 @@ contains
 
     implicit none
 
-    !  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'), 
+    !  From 2 input mdates ('YYYY-MM-DD HH:MM:SS.ffff'),
     !  compute the time difference.
 
     !  on entry     -  newdate  -  the new hdate.
@@ -687,7 +687,7 @@ contains
     opass = .true.
 
     !  Check that the month of NDATE makes sense.
-    
+
     if ((monew.gt.12).or.(monew.lt.1)) then
        write(*,*) 'GETH_IDTS:  Month of NDATE = ', monew
        npass = .false.
@@ -853,7 +853,7 @@ contains
     integer, intent(in) :: year ! Four-digit year
 
     nfeb = 28 ! By default, February has 28 days ...
-    if (mod(year,4).eq.0) then  
+    if (mod(year,4).eq.0) then
        nfeb = 29  ! But every four years, it has 29 days ...
        if (mod(year,100).eq.0) then
           nfeb = 28  ! Except every 100 years, when it has 28 days ...

--- a/src/Land_models/NoahMP/Utility_routines/module_model_constants.F
+++ b/src/Land_models/NoahMP/Utility_routines/module_model_constants.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !WRF:MODEL_LAYER:CONSTANTS
@@ -65,7 +65,7 @@
    REAL    , PARAMETER :: cvovcp       = 1./cpovcv
    REAL    , PARAMETER :: rvovrd       = r_v/r_d
 
-   REAL    , PARAMETER :: reradius     = 1./6370.0e03 
+   REAL    , PARAMETER :: reradius     = 1./6370.0e03
 
    REAL    , PARAMETER :: asselin      = .025
 !   REAL    , PARAMETER :: asselin      = .0
@@ -149,7 +149,7 @@
        REAL , PARAMETER ::  wght=0.35
        REAL , PARAMETER ::  wpc=0.075
        REAL , PARAMETER ::  z0land=0.10
-#ifdef HWRF 
+#ifdef HWRF
        REAL , PARAMETER ::  z0max=0.01
 #else
        REAL , PARAMETER ::  z0max=0.008

--- a/src/Land_models/NoahMP/data_structures/forcing.f90
+++ b/src/Land_models/NoahMP/data_structures/forcing.f90
@@ -1,3 +1,3 @@
 module forcing
-  
+
 end module forcing

--- a/src/Land_models/NoahMP/data_structures/parameters.f90
+++ b/src/Land_models/NoahMP/data_structures/parameters.f90
@@ -1,3 +1,3 @@
 module parameters
-  
+
 end module parameters

--- a/src/Land_models/NoahMP/data_structures/state.f90
+++ b/src/Land_models/NoahMP/data_structures/state.f90
@@ -18,25 +18,25 @@ contains
   subroutine init_undefined(this)
     use config_base, only: noah_lsm
     implicit none
-    
+
     class(state_type) :: this
     integer, parameter :: NSNOW = 3 !As definined in module_NoahMP,hrldas_driver.F. TODO Getting from a config later
     REAL, PARAMETER :: undefined_real = 9.9692099683868690E36 ! TODO Getting from a config later
     integer :: xstart, xend, ystart, yend, nsoil
-    
+
     xstart = noah_lsm%xstart
     xend = noah_lsm%xend
     ystart = noah_lsm%ystart
     yend = noah_lsm%yend
     nsoil = noah_lsm%nsoil
-    
+
     ALLOCATE ( this%TSNOXY    (XSTART:XEND,-NSNOW+1:0,    YSTART:YEND), source = undefined_real )  ! snow temperature [K]
     ALLOCATE ( this%ZSNSOXY   (XSTART:XEND,-NSNOW+1:NSOIL,YSTART:YEND), source = undefined_real )  ! snow layer depth [m]
     ALLOCATE ( this%SNICEXY   (XSTART:XEND,-NSNOW+1:0,    YSTART:YEND), source = undefined_real )  ! snow layer ice [mm]
     ALLOCATE ( this%SNLIQXY   (XSTART:XEND,-NSNOW+1:0,    YSTART:YEND), source = undefined_real )  ! snow layer liquid water [mm]
     ALLOCATE ( this%SNOW      (XSTART:XEND,YSTART:YEND), source = undefined_real )  ! snow water equivalent [mm]
     ALLOCATE ( this%SNOWH     (XSTART:XEND,YSTART:YEND), source = undefined_real )  ! physical snow depth [m]
-    
+
   end subroutine init_undefined
 
 end module state_module

--- a/src/Land_models/NoahMP/phys/module_sf_noahmp_groundwater.F
+++ b/src/Land_models/NoahMP/phys/module_sf_noahmp_groundwater.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 MODULE module_sf_noahmp_groundwater
@@ -24,7 +24,7 @@ MODULE module_sf_noahmp_groundwater
 ! plus the routine to update soil moisture and water table due to those two fluxes
 ! according to the Miguez-Macho & Fan groundwater scheme (Miguez-Macho et al., JGR 2007).
 ! Module written by Gonzalo Miguez-Macho , U. de Santiago de Compostela, Galicia, Spain
-! November 2012 
+! November 2012
 !===============================================================================
 
 CONTAINS
@@ -72,11 +72,11 @@ CONTAINS
                                                        RIVERBED, &
                                                       RIVERCOND
 
-! IN and OUT 
+! IN and OUT
 
     REAL,     DIMENSION( ims:ime , 1:nsoil, jms:jme ), &
          &    INTENT(INOUT)   ::                          SMOIS, &
-         &                                                SH2OXY 
+         &                                                SH2OXY
 
 
     REAL,    DIMENSION( ims:ime, jms:jme )                     , &
@@ -94,9 +94,9 @@ CONTAINS
          &   INTENT(OUT)      ::                            QRF, &  !groundwater - river water flux
                                                         QSPRING     !water springing at the surface from groundwater convergence in the column
 
-!LOCAL  
-  
-  INTEGER                          :: I,J,K  
+!LOCAL
+
+  INTEGER                          :: I,J,K
   REAL, DIMENSION(       0:NSOIL)  :: ZSOIL !depth of soil layer-bottom [m]
   REAL,  DIMENSION(      1:NSOIL)  :: SMCEQ  !equilibrium soil water  content [m3/m3]
   REAL,  DIMENSION(      1:NSOIL)  :: SMC,SH2O
@@ -105,7 +105,7 @@ CONTAINS
                                                 ,WPLUS,WMINUS
   REAL,      DIMENSION( ims:ime, jms:jme )    :: QLAT
   INTEGER,   DIMENSION( ims:ime, jms:jme )    :: LANDMASK !-1 for water (ice or no ice) and glacial areas, 1 for land where the LSM does its soil moisture calculations.
-  
+
   REAL :: BEXP,DKSAT,PSISAT,SMCMAX,SMCWLT
 
     DELTAT = WTDDT * 60. !timestep in seconds for this calculation
@@ -138,8 +138,8 @@ CALL LATERALFLOW(ISLTYP,WTD,QLAT,FDEPTH,TOPO,LANDMASK,DELTAT,AREA       &
           IF(LANDMASK(I,J).GT.0)THEN
              IF(WTD(I,J) .GT. RIVERBED(I,J) .AND.  EQWTD(I,J) .GT. RIVERBED(I,J)) THEN
                RCOND = RIVERCOND(I,J) * EXP(PEXP(I,J)*(WTD(I,J)-EQWTD(I,J)))
-             ELSE    
-               RCOND = RIVERCOND(I,J)       
+             ELSE
+               RCOND = RIVERCOND(I,J)
              ENDIF
              QRF(I,J) = RCOND * (WTD(I,J)-RIVERBED(I,J)) * DELTAT/AREA(I,J)
 !for now, dont allow it to go from river to groundwater
@@ -249,7 +249,7 @@ END  SUBROUTINE WTABLE_mmf_noahmp
   REAL, DIMENSION(19)      :: KLATFACTOR
   DATA KLATFACTOR /2.,3.,4.,10.,10.,12.,14.,20.,24.,28.,40.,48.,2.,0.,10.,0.,20.,2.,2./
 
-  REAL,    PARAMETER :: PI = 3.14159265 
+  REAL,    PARAMETER :: PI = 3.14159265
   REAL,    PARAMETER :: FANGLE = 0.22754493   ! = 0.5*sqrt(0.5*tan(pi/8))
 
 itsh=max(its-1,ids)
@@ -284,10 +284,10 @@ jteh=min(jte,jde-2)
        DO I=itsh,iteh
           IF(LANDMASK(I,J).GT.0)THEN
                  Q=0.
-                             
+
                  Q  = Q + (KCELL(I-1,J+1)+KCELL(I,J)) &
                         * (HEAD(I-1,J+1)-HEAD(I,J))/SQRT(2.)
-                             
+
                  Q  = Q +  (KCELL(I-1,J)+KCELL(I,J)) &
                         *  (HEAD(I-1,J)-HEAD(I,J))
 
@@ -302,7 +302,7 @@ jteh=min(jte,jde-2)
 
                  Q  = Q +  (KCELL(I+1,J+1)+KCELL(I,J)) &
                         * (HEAD(I+1,J+1)-HEAD(I,J))/SQRT(2.)
-  
+
                  Q  = Q +  (KCELL(I+1,J)+KCELL(I,J)) &
                         * (HEAD(I+1,J)-HEAD(I,J))
 

--- a/src/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
+++ b/src/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
@@ -1517,7 +1517,7 @@ CONTAINS
                    SNOW     (I,J) = PSNOWTOTSWEXY(I,J)
                    SNOWH    (I,J) = PSNOWHEIGHTXY(I,J)
                    ACSNOM   (I,J) = FLOW_ICE(I,J)+FLOW_SNOW(I,J)
-                   CANWAT   (I,J) = 0. 
+                   CANWAT   (I,J) = 0.
 #ifdef WRF_HYDRO
                    if(present(ACCETRAN)) ACCETRAN(I,J) = 0.
                    if(present(ACCECAN))  ACCECAN(I,J)  = 0.

--- a/src/Land_models/NoahMP/phys/surfex/ini_csts.F
+++ b/src/Land_models/NoahMP/phys/surfex/ini_csts.F
@@ -7,7 +7,7 @@ CONTAINS
 !SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
 !SFX_LIC for details. version 1.
 !     #########
-      SUBROUTINE INI_CSTS 
+      SUBROUTINE INI_CSTS
 !     ##################
 !
 !!****  *INI_CSTS * - routine to initialize the module MODD_CST
@@ -16,12 +16,12 @@ CONTAINS
 !!    -------
 !       The purpose of this routine is to initialize  the physical constants
 !     stored in  module MODD_CST.
-!      
+!
 !
 !!**  METHOD
 !!    ------
-!!      The physical constants are set to their numerical values 
-!!     
+!!      The physical constants are set to their numerical values
+!!
 !!
 !!    EXTERNAL
 !!    --------
@@ -34,7 +34,7 @@ CONTAINS
 !!    REFERENCE
 !!    ---------
 !!      Book2 of the documentation (module MODD_CST, routine INI_CSTS)
-!!      
+!!
 !!
 !!    AUTHOR
 !!    ------
@@ -42,7 +42,7 @@ CONTAINS
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    18/05/94 
+!!      Original    18/05/94
 !!      J. Stein    02/01/95  add the volumic mass of liquid water
 !!      J.-P. Pinty 13/12/95  add the water vapor pressure over solid ice
 !!      J. Stein    29/06/97  add XTH00
@@ -73,7 +73,7 @@ USE MODD_CSTS
 !USE MODI_INI_SURF_CSTS
 !
 IMPLICIT NONE
-!  
+!
 !-------------------------------------------------------------------------------
 !
 !*       1.     FUNDAMENTAL CONSTANTS
@@ -82,7 +82,7 @@ IMPLICIT NONE
 LOGICAL               :: LREPROD_OPER,LMEBREC
 REAL           :: XEVERG_RSMIN, XEVERG_VEG, XANSFRACMEL,XTEMPANS
 REAL          :: XANSMIN, XANSMAX, XAGLAMIN, XAGLAMAX, XEMISSN, XUNDEF
-REAL          :: XVAGING_NOGLACIER, XVAGING_GLACIER 
+REAL          :: XVAGING_NOGLACIER, XVAGING_GLACIER
 
  CHARACTER(LEN=3) :: CDGAVG, CIMPLICIT_WIND,CQSAT,CCHARNOCK
  CHARACTER(LEN=4) :: CDGDIF
@@ -211,13 +211,13 @@ XALPI  = LOG(XESTT) + (XBETAI /XTT) + (XGAMI *LOG(XTT))
 ! * Reproductibility for SURFEX OPER
 !
 LREPROD_OPER = .FALSE. ! default
-LMEBREC            = .FALSE. 
+LMEBREC            = .FALSE.
 !
 !
 ! * Vegetation parameters for tropical forest
 !
-!XEVERG_RSMIN : old = 250. (Manzi 1993) but observations range 
-!               from 140 to 180. According to Delire et al. (1997) and 
+!XEVERG_RSMIN : old = 250. (Manzi 1993) but observations range
+!               from 140 to 180. According to Delire et al. (1997) and
 !               new tests over 6 local sites, 175. is recommended
 !               Should be the default after check with AROME/ALADIN
 !
@@ -257,7 +257,7 @@ IF(LMEBREC)THEN
 !
   XANSFRACMEL = 0.85 ! (-)
 !
-! Threeshold temperature above which the snow albedo starts to decrease 
+! Threeshold temperature above which the snow albedo starts to decrease
 !
   XTEMPANS = 268.15 ! (K)
 !
@@ -275,7 +275,7 @@ ENDIF
 
 !
 ! Use recommended settings for snow albedo (FALSE = ISBA default)
-! 
+!
 LMEBREC=.FALSE.
 !
 ! Fraction of maximum value of the albedo of snow that is reached for melting
@@ -291,7 +291,7 @@ XAGLAMIN = 0.8 ! orig 0.8 ! (-) trude test with 0.7
 XAGLAMAX = 0.85 ! (-)
 !
 ! Use recommended settings for snow albedo (FALSE = ISBA default)
-! 
+!
 LMEBREC=.FALSE.
 !
 ! Fraction of maximum value of the albedo of snow that is reached for melting
@@ -323,7 +323,7 @@ XVAGING_GLACIER   = 900.
 !
 !-------------------------------------------------------------------------------
 !
-END SUBROUTINE INI_CSTS 
+END SUBROUTINE INI_CSTS
 
 
 END MODULE MODI_INI_CSTS

--- a/src/Land_models/NoahMP/phys/surfex/modd_csts.F
+++ b/src/Land_models/NoahMP/phys/surfex/modd_csts.F
@@ -3,34 +3,34 @@
 !SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
 !SFX_LIC for details. version 1.
 !     ###############
-      MODULE MODD_CSTS      
+      MODULE MODD_CSTS
 !     ###############
 !
-!!****  *MODD_CSTS* - declaration of Physic constants 
+!!****  *MODD_CSTS* - declaration of Physic constants
 !!
 !!    PURPOSE
 !!    -------
-!       The purpose of this declarative module is to declare  the 
-!     Physics constants.    
+!       The purpose of this declarative module is to declare  the
+!     Physics constants.
 !
 !!
 !!**  IMPLICIT ARGUMENTS
 !!    ------------------
-!!      None 
+!!      None
 !!
 !!    REFERENCE
 !!    ---------
-!!          
+!!
 !!    AUTHOR
 !!    ------
 !!      V. Ducrocq   *Meteo France*
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    16/05/94  
-!!      J. Stein    02/01/95  add xrholw                    
+!!      Original    16/05/94
+!!      J. Stein    02/01/95  add xrholw
 !!      J.-P. Pinty 13/12/95  add XALPI,XBETAI,XGAMI
-!!      J. Stein    25/07/97  add XTH00                    
+!!      J. Stein    25/07/97  add XTH00
 !!      V. Masson   05/10/98  add XRHOLI
 !!      C. Mari     31/10/00  add NDAYSEC
 !!      J. Escobar     06/13  add XSURF_TIMY XSURF_TIMY_12 XSURF_EPSILON for REAL*4
@@ -39,7 +39,7 @@
 !*       0.   DECLARATIONS
 !             ------------
 !
-IMPLICIT NONE 
+IMPLICIT NONE
 REAL,SAVE :: XPI                ! Pi
 !
 REAL,SAVE :: XDAY,XSIYEA,XSIDAY ! day duration, sideral year duration,
@@ -48,7 +48,7 @@ REAL,SAVE :: XDAY,XSIYEA,XSIDAY ! day duration, sideral year duration,
 REAL,SAVE :: XKARMAN            ! von karman constant
 REAL,SAVE :: XLIGHTSPEED        ! light speed
 REAL,SAVE :: XPLANCK            ! Planck constant
-REAL,SAVE :: XBOLTZ             ! Boltzman constant 
+REAL,SAVE :: XBOLTZ             ! Boltzman constant
 REAL,SAVE :: XAVOGADRO          ! Avogadro number
 !
 REAL,SAVE :: XRADIUS,XOMEGA     ! Earth radius, earth rotation
@@ -71,9 +71,9 @@ REAL,SAVE :: XLVTT              ! Vaporization heat constant
 REAL,SAVE :: XLSTT              ! Sublimation heat constant
 REAL,SAVE :: XLMTT              ! Melting heat constant
 REAL,SAVE :: XESTT              ! Saturation vapor pressure  at triple point
-                                ! temperature  
-REAL,SAVE :: XALPW,XBETAW,XGAMW ! Constants for saturation vapor 
-                                !  pressure  function 
+                                ! temperature
+REAL,SAVE :: XALPW,XBETAW,XGAMW ! Constants for saturation vapor
+                                !  pressure  function
 REAL,SAVE :: XALPI,XBETAI,XGAMI ! Constants for saturation vapor
                                 !  pressure  function over solid ice
 REAL, SAVE        :: XTH00      ! reference value  for the potential
@@ -92,4 +92,3 @@ REAL,SAVE     :: XZ0ICEZ0SNOW, XRHOTHRESHOLD_ICE
 
 !
 END MODULE MODD_CSTS
-

--- a/src/Land_models/NoahMP/phys/surfex/modd_snow_metamo.F
+++ b/src/Land_models/NoahMP/phys/surfex/modd_snow_metamo.F
@@ -12,17 +12,17 @@
 !!                          to snow metamorphism!!
 !!    PURPOSE
 !!    -------
-!       The purpose of this declarative module is to specify  the 
+!       The purpose of this declarative module is to specify  the
 !     parameters related to the metamorphism parameterization of snow.
 !
 !!
 !!**  IMPLICIT ARGUMENTS
 !!    ------------------
-!!      None 
+!!      None
 !!
 !!    REFERENCE
 !!    ---------
-!!      
+!!
 !!
 !!    AUTHOR
 !!    ------
@@ -30,7 +30,7 @@
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original       02/2008                
+!!      Original       02/2008
 !-------------------------------------------------------------------------------
 !
 !*       0.   DECLARATIONS
@@ -59,16 +59,16 @@ REAL, PARAMETER        :: XVVISC6 = 60.         ! factor for viscosity adjusteme
 !                                                             (especially this one ; inconsistency with Crocus v2.4)
 REAL, PARAMETER        :: XVVISC7 = 10.         ! factor for viscosity adjustement to grain type - to be checked
 REAL, PARAMETER        :: XVRO11 = 250.  ! normalization term for density dependence of the viscosity calculation (UNIT : kg m-3)
-! 
+!
 ! Maximum value for TPSNOW%GRAN2
 REAL, PARAMETER                 :: XVGRAN1 = 99.
 REAL, PARAMETER                 :: XGRAN = 99.
 !
-INTEGER, PARAMETER            :: NVHIS1 = 1                
-INTEGER, PARAMETER            :: NVHIS2 = 2                
-INTEGER, PARAMETER            :: NVHIS3 = 3                
-INTEGER, PARAMETER            :: NVHIS4 = 4                
-INTEGER, PARAMETER            :: NVHIS5 = 5 
+INTEGER, PARAMETER            :: NVHIS1 = 1
+INTEGER, PARAMETER            :: NVHIS2 = 2
+INTEGER, PARAMETER            :: NVHIS3 = 3
+INTEGER, PARAMETER            :: NVHIS4 = 4
+INTEGER, PARAMETER            :: NVHIS5 = 5
 !
 ! Properties of fresh snow
 REAL, PARAMETER                 :: XNDEN1 = 17.12
@@ -85,56 +85,56 @@ REAL, PARAMETER                 :: XUPOURC = 100.
 !
 ! Parameters for Marbouty's function
 !
-REAL, PARAMETER                 :: XVTANG1 = 40.              
-REAL, PARAMETER                 :: XVTANG2 = 6.              
-REAL, PARAMETER                 :: XVTANG3 = 22.              
-REAL, PARAMETER                 :: XVTANG4 = .7               
-REAL, PARAMETER                 :: XVTANG5 = .3               
-REAL, PARAMETER                 :: XVTANG6 = 6.               
-REAL, PARAMETER                 :: XVTANG7 = 1.               
-REAL, PARAMETER                 :: XVTANG8 = .8               
-REAL, PARAMETER                 :: XVTANG9 = 16.              
-REAL, PARAMETER                 :: XVTANGA = .2               
-REAL, PARAMETER                 :: XVTANGB = .2               
-REAL, PARAMETER                 :: XVTANGC = 18.             
-REAL, PARAMETER                 :: XVRANG1 = 400.               
-REAL, PARAMETER                 :: XVRANG2 = 150.              
-REAL, PARAMETER                 :: XVGANG1 = 70.               
-REAL, PARAMETER                 :: XVGANG2 = 25.              
-REAL, PARAMETER                 :: XVGANG3 = 40.               
-REAL, PARAMETER                 :: XVGANG4 = 50.               
-REAL, PARAMETER                 :: XVGANG5 = .1               
-REAL, PARAMETER                 :: XVGANG6 = 15.              
-REAL, PARAMETER                 :: XVGANG7 = .1               
-REAL, PARAMETER                 :: XVGANG8 = .55              
-REAL, PARAMETER                 :: XVGANG9 = .65              
-REAL, PARAMETER                 :: XVGANGA = .2               
-REAL, PARAMETER                 :: XVGANGB = .85              
-REAL, PARAMETER                 :: XVGANGC = .15      
+REAL, PARAMETER                 :: XVTANG1 = 40.
+REAL, PARAMETER                 :: XVTANG2 = 6.
+REAL, PARAMETER                 :: XVTANG3 = 22.
+REAL, PARAMETER                 :: XVTANG4 = .7
+REAL, PARAMETER                 :: XVTANG5 = .3
+REAL, PARAMETER                 :: XVTANG6 = 6.
+REAL, PARAMETER                 :: XVTANG7 = 1.
+REAL, PARAMETER                 :: XVTANG8 = .8
+REAL, PARAMETER                 :: XVTANG9 = 16.
+REAL, PARAMETER                 :: XVTANGA = .2
+REAL, PARAMETER                 :: XVTANGB = .2
+REAL, PARAMETER                 :: XVTANGC = 18.
+REAL, PARAMETER                 :: XVRANG1 = 400.
+REAL, PARAMETER                 :: XVRANG2 = 150.
+REAL, PARAMETER                 :: XVGANG1 = 70.
+REAL, PARAMETER                 :: XVGANG2 = 25.
+REAL, PARAMETER                 :: XVGANG3 = 40.
+REAL, PARAMETER                 :: XVGANG4 = 50.
+REAL, PARAMETER                 :: XVGANG5 = .1
+REAL, PARAMETER                 :: XVGANG6 = 15.
+REAL, PARAMETER                 :: XVGANG7 = .1
+REAL, PARAMETER                 :: XVGANG8 = .55
+REAL, PARAMETER                 :: XVGANG9 = .65
+REAL, PARAMETER                 :: XVGANGA = .2
+REAL, PARAMETER                 :: XVGANGB = .85
+REAL, PARAMETER                 :: XVGANGC = .15
 !
 ! Parameters for snow metamorphism
 !
 REAL, PARAMETER                 :: XVDENT1 = 2314.81481
-REAL, PARAMETER                 :: XVDENT2 = 7.2338E-7 
-REAL, PARAMETER                 :: XVGRAN6 = 51.              
-REAL, PARAMETER                 :: XVVAP1 = -6000.            
-REAL, PARAMETER                 :: XVVAP2 = .4                
-REAL, PARAMETER                 :: XVDIAM1 = 4.E-4               
-REAL, PARAMETER                 :: XVDIAM2 = 5.E-4              
-REAL, PARAMETER                 :: XVDIAM3 = 3.E-4               
+REAL, PARAMETER                 :: XVDENT2 = 7.2338E-7
+REAL, PARAMETER                 :: XVGRAN6 = 51.
+REAL, PARAMETER                 :: XVVAP1 = -6000.
+REAL, PARAMETER                 :: XVVAP2 = .4
+REAL, PARAMETER                 :: XVDIAM1 = 4.E-4
+REAL, PARAMETER                 :: XVDIAM2 = 5.E-4
+REAL, PARAMETER                 :: XVDIAM3 = 3.E-4
 REAL, PARAMETER                 :: XVDIAM4 = 2.E-4
 REAL, PARAMETER                 :: XVDIAM5 = 1.E-4
-REAL, PARAMETER                 :: XVDIAM6 = 1.E-4               
-REAL, PARAMETER                 :: XVSPHE1 = 1.               
-REAL, PARAMETER                 :: XVSPHE2 = 11574.074             
-REAL, PARAMETER                 :: XVSPHE3 = .5               
-REAL, PARAMETER                 :: XVSPHE4 = .1               
-REAL, PARAMETER                 :: XVTAIL1 = 1.28E-17          
-REAL, PARAMETER                 :: XVTAIL2 = 4.22E-19         
-REAL, PARAMETER                 :: XVGRAT1 = 5.              
-REAL, PARAMETER                 :: XVGRAT2 = 15.             
-REAL, PARAMETER                 :: XVFI = 1.0417E-9                 
-REAL, PARAMETER                 :: XVTELV1 = 0.005 
+REAL, PARAMETER                 :: XVDIAM6 = 1.E-4
+REAL, PARAMETER                 :: XVSPHE1 = 1.
+REAL, PARAMETER                 :: XVSPHE2 = 11574.074
+REAL, PARAMETER                 :: XVSPHE3 = .5
+REAL, PARAMETER                 :: XVSPHE4 = .1
+REAL, PARAMETER                 :: XVTAIL1 = 1.28E-17
+REAL, PARAMETER                 :: XVTAIL2 = 4.22E-19
+REAL, PARAMETER                 :: XVGRAT1 = 5.
+REAL, PARAMETER                 :: XVGRAT2 = 15.
+REAL, PARAMETER                 :: XVFI = 1.0417E-9
+REAL, PARAMETER                 :: XVTELV1 = 0.005
 !
 INTEGER,PARAMETER               :: NVDENT1 = 3
 !
@@ -146,6 +146,3 @@ INTEGER :: NID_FILE
 REAL, DIMENSION(:,:,:), POINTER :: XDRDT0,XTAU,XKAPPA   ! field read
 !
 END MODULE MODD_SNOW_METAMO
-
-
-

--- a/src/Land_models/NoahMP/phys/surfex/modd_snow_par.F
+++ b/src/Land_models/NoahMP/phys/surfex/modd_snow_par.F
@@ -11,17 +11,17 @@
 !!
 !!    PURPOSE
 !!    -------
-!       The purpose of this declarative module is to specify  the 
+!       The purpose of this declarative module is to specify  the
 !     parameters related to the surface parameterization of snow.
 !
 !!
 !!**  IMPLICIT ARGUMENTS
 !!    ------------------
-!!      None 
+!!      None
 !!
 !!    REFERENCE
 !!    ---------
-!!      
+!!
 !!
 !!    AUTHOR
 !!    ------
@@ -29,7 +29,7 @@
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original       01/2004                    
+!!      Original       01/2004
 !! P. Samuelsson  10/2014   MEB complements
 !-------------------------------------------------------------------------------
 !
@@ -50,7 +50,7 @@ REAL, PARAMETER       :: XEMISSN = 0.99   ! trude. Check  how this stands up to 
 ! Minimum and maximum values of the albedo of snow:
 !
 !REAL, SAVE       :: XANSMIN
-!REAL, SAVE       :: XANSMAX 
+!REAL, SAVE       :: XANSMAX
 REAL, PARAMETER     :: XANSMIN=0.50    ! (orig 0.50, trude test with 0.55 (0.6))   ! trude
 REAL, PARAMETER     :: XANSMAX =0.85  !trude
 
@@ -65,7 +65,7 @@ REAL, PARAMETER       :: XAGLAMAX = 0.85  ! trude
 
 !
 ! Use recommended settings for snow albedo (FALSE = ISBA default)
-! 
+!
 LOGICAL,SAVE     :: LMEBREC
 !
 ! Fraction of maximum value of the albedo of snow that is reached for melting
@@ -73,14 +73,14 @@ LOGICAL,SAVE     :: LMEBREC
 !
 REAL, SAVE       :: XANSFRACMEL
 !
-! Threeshold temperature above which the snow albedo starts to decrease 
+! Threeshold temperature above which the snow albedo starts to decrease
 !
 REAL, SAVE       :: XTEMPANS
 !
 ! Minimum value of the albedo of snow reached under canopy vegetation:
 !
 REAL, SAVE       :: XANSMINMEB
-! 
+!
 ! Prescribed ice albedo in 3 spectral bands for glacier simulation with CROCUS scheme.
 !REAL, SAVE       :: XALBICE1,XALBICE2,XALBICE3
 !REAL, PARAMETER       :: XALBICE1 = 0.23   ! (0.23 from Gerbaux,  0.38 orig crocus)     ! trude 
@@ -102,7 +102,7 @@ REAL, PARAMETER       :: XALBICE3 = 0.08  ! 0.06 from Gerbaux ,   0.08 orig croc
 !for ageing effects
 !REAL, SAVE      :: XVAGING_NOGLACIER, XVAGING_GLACIER
 REAL, PARAMETER      :: XVAGING_NOGLACIER = 60.
-REAL, PARAMETER      ::  XVAGING_GLACIER  = 900. 
+REAL, PARAMETER      ::  XVAGING_GLACIER  = 900.
 
 ! percentage of the total pore volume to compute the max liquid water holding capacity
 !REAL, SAVE      :: XPERCENTAGEPORE
@@ -111,14 +111,14 @@ REAL, PARAMETER      :: XPERCENTAGEPORE = 0.03   !   5   ! trude try 3 instead o
 ! Height (m) of aged snow in glacier case (allows Pn=1)
 !
 REAL, SAVE       :: XHGLA
-! 
+!
 ! Coefficient for calculation of snow fraction over vegetation
 !
 REAL, SAVE       :: XWSNV
 !
 ! Roughness length of pure snow surface (m)
 !
-!REAL, SAVE       :: XZ0SN  
+!REAL, SAVE       :: XZ0SN
 !REAL, PARAMETER       :: XZ0SN =0.00005  ! trude,  (0.05 mm)
 !REAL, PARAMETER        :: XZ0SN =0.00013  ! trude,  (0.13 mm)
 REAL, PARAMETER        :: XZ0SN =0.001  ! trude,  (1.0 mm)
@@ -133,7 +133,7 @@ REAL, PARAMETER       :: XZ0HSN   =0.00015   ! trude (test 5 mm instead of 0.5 m
 ! Roughness length ratio between ice and snow
 !REAL, SAVE       :: XZ0ICEZ0SNOW     ! trude comment out. declared in modd_csts
 !
-! Snow Melt timescale with D95 (s): needed to prevent time step 
+! Snow Melt timescale with D95 (s): needed to prevent time step
 ! dependence of melt when snow fraction < unity.
 !
 REAL, SAVE       :: XTAU_SMELT
@@ -147,7 +147,7 @@ REAL, SAVE       :: XTAU_SMELT
 !
 REAL, PARAMETER       :: XWCRN      = 10.0   ! (kg m-2) Veg (default value)
 REAL, PARAMETER       :: XWCRN_EXPL =  1.0   ! (kg m-2) Veg explicit
-REAL, PARAMETER       :: XWCRN_ROOF =  1.0   ! (kg m-2)  Roofs 
+REAL, PARAMETER       :: XWCRN_ROOF =  1.0   ! (kg m-2)  Roofs
 REAL, PARAMETER       :: XWCRN_ROAD =  1.0   ! (kg m-2)  Roads
 REAL, PARAMETER       :: XWCRN_VEG  =  1.0   ! (kg m-2)  Urban veg
 !
@@ -179,7 +179,7 @@ REAL, PARAMETER       :: XANS_T_ROOF     = 0.174   ! (-)  Roofs
 REAL, PARAMETER       :: XANS_T_ROAD     = 0.174   ! (-)  Roads (alley simul)
 REAL, PARAMETER       :: XANS_T_MEB    = 0.480     ! (-) Surface under canopy vegetation
 !
-! Minimum and maximum values of the density of snow 
+! Minimum and maximum values of the density of snow
 ! for Force-Restore snow option
 !
 REAL, PARAMETER       :: XRHOSMIN = 100.       ! (kg m-3)   Veg (Default value)
@@ -190,7 +190,7 @@ REAL, PARAMETER       :: XRHOSMAX = 300.       ! (kg m-3)   Veg (Default value)
 REAL, PARAMETER       :: XRHOSMAX_ROOF = 300.  ! (kg m-3)   Roofs
 REAL, PARAMETER       :: XRHOSMAX_ROAD = 350.  ! (kg m-3)   Roads
 !
-! Minimum and maximum values of the density of snow 
+! Minimum and maximum values of the density of snow
 ! for ISBA-ES snow option
 !
 REAL, PARAMETER       :: XRHOSMIN_ES =  50.  ! (kg m-3)
@@ -199,23 +199,23 @@ REAL, PARAMETER       :: XRHOSMAX_ES = 750.  ! (kg m-3)
 ! ISBA-ES Critical snow depth at which snow grid thicknesses constant
 !
 REAL, PARAMETER       :: XSNOWCRITD = 0.03  ! (m)
-!                                       
-! ISBA-ES Minimum total snow depth for thermal calculations. 
-! Used to prevent numerical problems as snow becomes vanishingly thin. 
+!
+! ISBA-ES Minimum total snow depth for thermal calculations.
+! Used to prevent numerical problems as snow becomes vanishingly thin.
 !
 REAL, PARAMETER      :: XSNOWDMIN = 0.000001  ! (m)
-!                                      
+!
 ! Maximum Richardson number limit for very stable conditions using the ISBA-ES 'RIL' option
 !
 REAL, PARAMETER       :: X_RI_MAX = 0.20
 !REAL, PARAMETER       :: X_RI_MAX = 0.026  !  trude test lower limit
-!                                       
+!
 ! ISBA-ES Maximum snow liquid water holding capacity (fraction by mass) parameters:
 !
-REAL, PARAMETER       :: XWSNOWHOLDMAX2   = 0.10  ! (-) 
+REAL, PARAMETER       :: XWSNOWHOLDMAX2   = 0.10  ! (-)
 REAL, PARAMETER       :: XWSNOWHOLDMAX1   = 0.03  ! (-)
 REAL, PARAMETER       :: XSNOWRHOHOLD     = 200.0 ! (kg/m3)
-!                                       
+!
 ! ISBA-ES arameters for grain size computation :
 !
 REAL, PARAMETER       :: XSNOW_AGRAIN = 1.6e-4   ! (m)
@@ -319,7 +319,7 @@ REAL, PARAMETER :: XDZMIN_TOP_BIS = 0.005
 REAL, PARAMETER :: XDZMIN_BOT = 0.02
 REAL, PARAMETER :: XSPLIT_COEF = 8.
 !
-! Coeefficients for snow layer agregation 
+! Coeefficients for snow layer agregation
 REAL, PARAMETER :: XAGREG_COEF_1 = 5.
 REAL, PARAMETER :: XAGREG_COEF_2 = 4.5
 !
@@ -347,10 +347,10 @@ REAL, PARAMETER :: XVDRIFT2 = 0.085 !  coefficient for computing
 ! the drift index
 REAL, PARAMETER :: XVDRIFT3 = 3.25  !  coefficient for computing
 ! the drift index
-REAL, PARAMETER :: XVSIZEMIN = 3.E-4 !  minimum size decrease 
+REAL, PARAMETER :: XVSIZEMIN = 3.E-4 !  minimum size decrease
 ! by drift  UNIT = m
 !
-! modif_EB pour sublim 
+! modif_EB pour sublim
 ! a pour but de tenir compte du fait que le vent moyen est > rafales
 ! on en tient compte egalement pour diminuer la duree de l'effet
 REAL, PARAMETER :: XCOEF_FF = 1.25 ! coefficient for gust diagnosis from average wind 
@@ -361,11 +361,11 @@ REAL, PARAMETER :: XQS_REF = 2.E-5 ! valeur de reference de ZQS pour effet neige
 !
 ! ISBA-ES snow grid parameters
 !
-REAL, PARAMETER, DIMENSION(3)     :: XSGCOEF1  = (/0.25, 0.50, 0.25/) 
-REAL, PARAMETER, DIMENSION(2)     :: XSGCOEF2  = (/0.05, 0.34/)       
+REAL, PARAMETER, DIMENSION(3)     :: XSGCOEF1  = (/0.25, 0.50, 0.25/)
+REAL, PARAMETER, DIMENSION(2)     :: XSGCOEF2  = (/0.05, 0.34/)
 REAL, PARAMETER, DIMENSION(10)    :: XSGCOEF3  = (/0.025, 0.033, 0.043, &
                                      0.055, 0.071, 0.091, 0.117, 0.150, &
-                                     0.193, 0.247/) 
+                                     0.193, 0.247/)
 !
 ! Minimum total snow depth at which surface layer thickness is constant:
 !
@@ -389,15 +389,3 @@ REAL,    PARAMETER :: XUNDEF = 1.E+20
 !------------------------------------------------------------------------------
 !
 END MODULE MODD_SNOW_PAR
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/Land_models/NoahMP/phys/surfex/modd_surf_atm.F
+++ b/src/Land_models/NoahMP/phys/surfex/modd_surf_atm.F
@@ -15,7 +15,7 @@
 !!
 !!**  IMPLICIT ARGUMENTS
 !!    ------------------
-!!      None 
+!!      None
 !!
 !!    REFERENCE
 !!    ---------

--- a/src/Land_models/NoahMP/phys/surfex/mode_snow3l.F
+++ b/src/Land_models/NoahMP/phys/surfex/mode_snow3l.F
@@ -19,14 +19,14 @@
 !!
 !!    EXTERNAL
 !!    --------
-!!       
+!!
 !!    IMPLICIT ARGUMENTS
-!!    ------------------ 
+!!    ------------------
 !!
 !!    REFERENCE
 !!    ---------
 !!    Boone and Etchevers, J. HydroMeteor., 2001
-!!      
+!!
 !!
 !!    AUTHOR
 !!    ------
@@ -41,15 +41,15 @@
 !!                              - New algorithm to compute snow grid :
 !                       10 layers
 !!                              - Routine to aggregate snow grain type
-!                       from 2 layers    
+!                       from 2 layers
 !!                              _ Routine to compute average grain
-!                       type when snow depth< 3 cm. 
+!                       type when snow depth< 3 cm.
 !     S. Morin          02/2011 - Add routines for Crocus
 !     A. Boone          02/2012 - Add optimization of do-loops.
 !     C. Carmagnola     12/2012 - Add the case CSNOWMETAMO!='B92' in subroutine SNOW3LAVGRAIN and in function SNOW3LDIFTYP
 !     M. Lafaysse       01/2013 - Remove SNOWCROWLIQMAX routines (not used)
 !     M. Lafaysse       08/2013 - simplification of routine SNOW3LAVGRAIN (logical GDENDRITIC)
-!     B. Decharme       07/2013 - SNOW3LGRID cleanning 
+!     B. Decharme       07/2013 - SNOW3LGRID cleanning
 !                                 New algorithm to compute snow grid for 6-L or 12-L
 !     A. Boone          10/2014 - Added snow thermal conductivity routines
 !     B. Decharme       01/2015 - Added optical snow grain size diameter
@@ -166,11 +166,11 @@ ZSNOWRHO(:,:,:) = MIN(XRHOSMAX_ES, PSNOWRHO(:,:,:))
 ! Maximum ratio of liquid to SWE:
 !
 ZHOLDMAXR(:,:,:) = XWSNOWHOLDMAX1 + (XWSNOWHOLDMAX2-XWSNOWHOLDMAX1)*    &
-                  MAX(0.,XSNOWRHOHOLD-ZSNOWRHO(:,:,:))/XSNOWRHOHOLD 
+                  MAX(0.,XSNOWRHOHOLD-ZSNOWRHO(:,:,:))/XSNOWRHOHOLD
 !
 ! Maximum liquid water holding capacity of the snow (kg/m3):
 !
-PWLIQMAX(:,:,:) = ZHOLDMAXR(:,:,:)*ZSNOWRHO(:,:,:)           
+PWLIQMAX(:,:,:) = ZHOLDMAXR(:,:,:)*ZSNOWRHO(:,:,:)
 !IF (LHOOK) CALL DR_HOOK('MODE_SNOW3L:SNOW3LWLIQMAX_3D',1,ZHOOK_HANDLE)
 !
 END FUNCTION SNOW3LWLIQMAX_3D
@@ -209,11 +209,11 @@ ZSNOWRHO(:,:) = MIN(XRHOSMAX_ES, PSNOWRHO(:,:))
 ! Maximum ratio of liquid to SWE:
 !
 ZHOLDMAXR(:,:) = XWSNOWHOLDMAX1 + (XWSNOWHOLDMAX2-XWSNOWHOLDMAX1)*    &
-                  MAX(0.,XSNOWRHOHOLD-ZSNOWRHO(:,:))/XSNOWRHOHOLD 
+                  MAX(0.,XSNOWRHOHOLD-ZSNOWRHO(:,:))/XSNOWRHOHOLD
 !
 ! Maximum liquid water holding capacity of the snow (kg/m3):
 !
-PWLIQMAX(:,:) = ZHOLDMAXR(:,:)*ZSNOWRHO(:,:)               
+PWLIQMAX(:,:) = ZHOLDMAXR(:,:)*ZSNOWRHO(:,:)
 !IF (LHOOK) CALL DR_HOOK('MODE_SNOW3L:SNOW3LWLIQMAX_2D',1,ZHOOK_HANDLE)
 !
 END FUNCTION SNOW3LWLIQMAX_2D
@@ -252,11 +252,11 @@ ZSNOWRHO(:) = MIN(XRHOSMAX_ES, PSNOWRHO(:))
 ! Maximum ratio of liquid to SWE:
 !
 ZHOLDMAXR(:) = XWSNOWHOLDMAX1 + (XWSNOWHOLDMAX2-XWSNOWHOLDMAX1)*    &
-                  MAX(0.,XSNOWRHOHOLD-ZSNOWRHO(:))/XSNOWRHOHOLD 
+                  MAX(0.,XSNOWRHOHOLD-ZSNOWRHO(:))/XSNOWRHOHOLD
 !
 ! Maximum liquid water holding capacity of the snow (kg/m3):
 !
-PWLIQMAX(:) = ZHOLDMAXR(:)*ZSNOWRHO(:)                
+PWLIQMAX(:) = ZHOLDMAXR(:)*ZSNOWRHO(:)
 !IF (LHOOK) CALL DR_HOOK('MODE_SNOW3L:SNOW3LWLIQMAX_1D',1,ZHOOK_HANDLE)
 !
 END FUNCTION SNOW3LWLIQMAX_1D
@@ -299,7 +299,7 @@ ZSNOWRHO(:,:,:) = MIN(XRHOSMAX_ES, PSNOWRHO(:,:,:))
 ! Maximum ratio of liquid to SWE:
 !
 ZHOLDMAXR(:,:,:) = XWSNOWHOLDMAX1 + (XWSNOWHOLDMAX2-XWSNOWHOLDMAX1)*    &
-                  MAX(0.,XSNOWRHOHOLD-ZSNOWRHO(:,:,:))/XSNOWRHOHOLD 
+                  MAX(0.,XSNOWRHOHOLD-ZSNOWRHO(:,:,:))/XSNOWRHOHOLD
 !
 ! Maximum liquid water holding capacity of the snow (m):
 !
@@ -343,7 +343,7 @@ ZSNOWRHO(:,:) = MIN(XRHOSMAX_ES, PSNOWRHO(:,:))
 ! Maximum ratio of liquid to SWE:
 !
 ZHOLDMAXR(:,:) = XWSNOWHOLDMAX1 + (XWSNOWHOLDMAX2-XWSNOWHOLDMAX1)*    &
-                  MAX(0.,XSNOWRHOHOLD-ZSNOWRHO(:,:))/XSNOWRHOHOLD 
+                  MAX(0.,XSNOWRHOHOLD-ZSNOWRHO(:,:))/XSNOWRHOHOLD
 !
 ! Maximum liquid water holding capacity of the snow (m):
 !
@@ -361,7 +361,7 @@ END FUNCTION SNOW3LHOLD_2D
 !
 USE MODD_CSTS,     ONLY : XRHOLW
 USE MODD_SNOW_PAR, ONLY : XRHOSMAX_ES, XSNOWRHOHOLD,     &
-                          XWSNOWHOLDMAX2, XWSNOWHOLDMAX1 
+                          XWSNOWHOLDMAX2, XWSNOWHOLDMAX1
 !
 !USE YOMHOOK   ,ONLY : LHOOK,   DR_HOOK
 !USE PARKIND1  ,ONLY : JPRB
@@ -387,11 +387,11 @@ ZSNOWRHO(:) = MIN(XRHOSMAX_ES, PSNOWRHO(:))
 ! Maximum ratio of liquid to SWE:
 !
 ZHOLDMAXR(:) = XWSNOWHOLDMAX1 + (XWSNOWHOLDMAX2-XWSNOWHOLDMAX1)*     &
-                  MAX(0.,XSNOWRHOHOLD-ZSNOWRHO(:))/XSNOWRHOHOLD 
+                  MAX(0.,XSNOWRHOHOLD-ZSNOWRHO(:))/XSNOWRHOHOLD
 !
 ! Maximum liquid water holding capacity of the snow (m):
 !
-PWHOLDMAX(:) = ZHOLDMAXR(:)*PSNOWDZ(:)*ZSNOWRHO(:)/XRHOLW               
+PWHOLDMAX(:) = ZHOLDMAXR(:)*PSNOWDZ(:)*ZSNOWRHO(:)/XRHOLW
 !IF (LHOOK) CALL DR_HOOK('MODE_SNOW3L:SNOW3LHOLD_1D',1,ZHOOK_HANDLE)
 !
 END FUNCTION SNOW3LHOLD_1D
@@ -431,11 +431,11 @@ ZSNOWRHO = MIN(XRHOSMAX_ES, PSNOWRHO)
 ! Maximum ratio of liquid to SWE:
 !
 ZHOLDMAXR = XWSNOWHOLDMAX1 + (XWSNOWHOLDMAX2-XWSNOWHOLDMAX1) *     &
-                             MAX(0.,XSNOWRHOHOLD-ZSNOWRHO)/XSNOWRHOHOLD 
+                             MAX(0.,XSNOWRHOHOLD-ZSNOWRHO)/XSNOWRHOHOLD
 !
 ! Maximum liquid water holding capacity of the snow (m):
 !
-PWHOLDMAX = ZHOLDMAXR*PSNOWDZ*ZSNOWRHO/XRHOLW              
+PWHOLDMAX = ZHOLDMAXR*PSNOWDZ*ZSNOWRHO/XRHOLW
 !IF (LHOOK) CALL DR_HOOK('MODE_SNOW3L:SNOW3LHOLD_0D',1,ZHOOK_HANDLE)
 !
 END FUNCTION SNOW3LHOLD_0D
@@ -462,8 +462,8 @@ REAL, DIMENSION(:,:,:), INTENT(IN)                 :: PSNOWDZ, PSNOWLIQ, PSNOWRH
 REAL, DIMENSION(SIZE(PSNOWRHO,1),SIZE(PSNOWRHO,2),SIZE(PSNOWRHO,3)) :: PWHOLDMAX
 !REAL(KIND=JPRB) :: ZHOOK_HANDLE
 !-------------------------------------------------------------------------------
-! computation of water holding capacity based on Crocus, 
-!taking into account the conversion between wet and dry density - 
+! computation of water holding capacity based on Crocus,
+!taking into account the conversion between wet and dry density -
 !S. Morin/V. Vionnet 2010 12 09
 
 ! PWHOLDMAX is expressed in m water for each layer
@@ -506,8 +506,8 @@ REAL, DIMENSION(:,:), INTENT(IN)                   :: PSNOWDZ, PSNOWRHO, PSNOWLI
 REAL, DIMENSION(SIZE(PSNOWRHO,1),SIZE(PSNOWRHO,2)) :: PWHOLDMAX
 !REAL(KIND=JPRB) :: ZHOOK_HANDLE
 !-------------------------------------------------------------------------------
-! computation of water holding capacity based on Crocus, 
-!taking into account the conversion between wet and dry density - 
+! computation of water holding capacity based on Crocus,
+!taking into account the conversion between wet and dry density -
 !S. Morin/V. Vionnet 2010 12 09
 
 ! PWHOLDMAX is expressed in m water for each layer
@@ -551,7 +551,7 @@ REAL, DIMENSION(:), INTENT(IN)                     :: PSNOWDZ, PSNOWRHO, PSNOWLI
 REAL, DIMENSION(SIZE(PSNOWRHO))                    :: PWHOLDMAX
 !REAL(KIND=JPRB) :: ZHOOK_HANDLE
 !-------------------------------------------------------------------------------
-! computation of water holding capacity based on Crocus, 
+! computation of water holding capacity based on Crocus,
 !taking into account the conversion between wet and dry density -
 !S. Morin/V. Vionnet 2010 12 09
 
@@ -594,8 +594,8 @@ REAL, INTENT(IN)        :: PSNOWDZ, PSNOWRHO, PSNOWLIQ
 REAL                    :: PWHOLDMAX
 !REAL(KIND=JPRB) :: ZHOOK_HANDLE
 !-------------------------------------------------------------------------------
-! computation of water holding capacity based on Crocus, 
-!taking into account the conversion between wet and dry density - 
+! computation of water holding capacity based on Crocus,
+!taking into account the conversion between wet and dry density -
 !S. Morin/V. Vionnet 2010 12 09
 
 ! PWHOLDMAX is expressed in m water for each layer
@@ -776,7 +776,7 @@ END FUNCTION SNOW3LSCAP_0D
 !        01/08: JM WILLEMET      - ERROR ON THE FORMULATION OF G FUNCTION (WITH GRADIENT) IS CORRECTED 
 
 USE MODD_CSTS, ONLY : XTT
-USE MODD_SNOW_METAMO  
+USE MODD_SNOW_METAMO
 !
 !USE YOMHOOK   ,ONLY : LHOOK,   DR_HOOK
 !USE PARKIND1  ,ONLY : JPRB
@@ -842,8 +842,8 @@ ENDIF
 !
 !IF (LHOOK) CALL DR_HOOK('MODE_SNOW3L:SNOW3L_MARBOUTY',1,ZHOOK_HANDLE)
 !
-END FUNCTION SNOW3L_MARBOUTY     
-!       
+END FUNCTION SNOW3L_MARBOUTY
+!
 !####################################################################
 !####################################################################
 !####################################################################
@@ -885,22 +885,22 @@ REAL, DIMENSION(:,:), INTENT(IN ), OPTIONAL :: PSNOWDZ_OLD
 INTEGER                           :: JJ, JI
 !
 INTEGER                           :: INLVLS, INI
-!   
+!
 REAL,     DIMENSION(SIZE(PSNOW))  :: ZWORK
 !
 LOGICAL , DIMENSION(SIZE(PSNOW))  :: GREGRID
 
 ! ISBA-ES snow grid parameters
 !
-REAL, PARAMETER, DIMENSION(3)     :: ZSGCOEF1  = (/0.25, 0.50, 0.25/) 
-REAL, PARAMETER, DIMENSION(2)     :: ZSGCOEF2  = (/0.05, 0.34/)       
-!      
-REAL, PARAMETER, DIMENSION(3)     :: ZSGCOEF   = (/0.3, 0.4, 0.3/) 
+REAL, PARAMETER, DIMENSION(3)     :: ZSGCOEF1  = (/0.25, 0.50, 0.25/)
+REAL, PARAMETER, DIMENSION(2)     :: ZSGCOEF2  = (/0.05, 0.34/)
+!
+REAL, PARAMETER, DIMENSION(3)     :: ZSGCOEF   = (/0.3, 0.4, 0.3/)
 !
 ! Minimum total snow depth at which surface layer thickness is constant:
 !
 REAL, PARAMETER                   :: ZSNOWTRANS = 0.20                ! (m)
-!      
+!
 ! Minimum snow depth by layer for 6-L or 12-L configuration :
 !
 REAL, PARAMETER                   ::  ZDZ1=0.01
@@ -934,7 +934,7 @@ GREGRID(:) = .TRUE.
 ! 1. Calculate current grid for 3-layer (default) configuration):
 ! ---------------------------------------------------------------
 ! Based on formulation of Lynch-Stieglitz (1994)
-! except for 3 modifications: 
+! except for 3 modifications:
 ! i) smooth transition here at ZSNOWTRANS
 ! ii) constant ratio for very thin snow:
 ! iii) ratio of layer 2 to surface layer <= 10
@@ -965,7 +965,7 @@ ELSEIF(INLVLS == 3)THEN
 !
 ! When using simple finite differences, limit the thickness
 ! factor between the top and 2nd layers to at most 10
-! 
+!
       PSNOWDZ(:,2) = MIN(10*ZSGCOEF2(1),  PSNOWDZ(:,2))
       PSNOWDZ(:,3) = PSNOW(:) - PSNOWDZ(:,2) - PSNOWDZ(:,1)
    END WHERE
@@ -987,11 +987,11 @@ ELSEIF(INLVLS == 6)THEN
                & PSNOWDZ_OLD(:,6) > ZCOEF2 * MIN(ZDZN1,PSNOW(:)/INLVLS)
   ENDIF
 !
-  WHERE(GREGRID(:))  
-!      top layers 
-       PSNOWDZ(:,1) = MIN(ZDZ1,PSNOW(:)/INLVLS) 
-       PSNOWDZ(:,2) = MIN(ZDZ2,PSNOW(:)/INLVLS) 
-!      last layers 
+  WHERE(GREGRID(:))
+!      top layers
+       PSNOWDZ(:,1) = MIN(ZDZ1,PSNOW(:)/INLVLS)
+       PSNOWDZ(:,2) = MIN(ZDZ2,PSNOW(:)/INLVLS)
+!      last layers
        PSNOWDZ(:,6) = MIN(ZDZN1,PSNOW(:)/INLVLS)
 !      remaining snow for remaining layers
        ZWORK(:)     = PSNOW(:) - PSNOWDZ(:,1) - PSNOWDZ(:,2) - PSNOWDZ(:,6)
@@ -1001,8 +1001,8 @@ ELSEIF(INLVLS == 6)THEN
 !      layer 3 tickness >= layer 2 tickness
        ZWORK(:)=MIN(0.0,PSNOWDZ(:,3)-PSNOWDZ(:,2))
        PSNOWDZ(:,3)=PSNOWDZ(:,3)-ZWORK(:)
-       PSNOWDZ(:,4)=PSNOWDZ(:,4)+ZWORK(:) 
-!      layer 5 tickness >= layer 6 tickness  
+       PSNOWDZ(:,4)=PSNOWDZ(:,4)+ZWORK(:)
+!      layer 5 tickness >= layer 6 tickness
        ZWORK(:)=MIN(0.0,PSNOWDZ(:,5)-PSNOWDZ(:,6))
        PSNOWDZ(:,5)=PSNOWDZ(:,5)-ZWORK(:)
        PSNOWDZ(:,4)=PSNOWDZ(:,4)+ZWORK(:)
@@ -1021,15 +1021,15 @@ ELSEIF(INLVLS == 9)THEN
                & PSNOWDZ_OLD(:,2) < ZCOEF1 * MIN(ZDZ2 ,PSNOW(:)/INLVLS) .OR. &
                & PSNOWDZ_OLD(:,2) > ZCOEF2 * MIN(ZDZ2 ,PSNOW(:)/INLVLS) .OR. &
                & PSNOWDZ_OLD(:,9) < ZCOEF1 * MIN(ZDZN0,PSNOW(:)/INLVLS) .OR. &
-               & PSNOWDZ_OLD(:,9) > ZCOEF2 * MIN(ZDZN0,PSNOW(:)/INLVLS) 
+               & PSNOWDZ_OLD(:,9) > ZCOEF2 * MIN(ZDZN0,PSNOW(:)/INLVLS)
   ENDIF
-!             
-  WHERE(GREGRID(:))  
-!      top layers 
-       PSNOWDZ(:,1) = MIN(ZDZ1,PSNOW(:)/INLVLS) 
-       PSNOWDZ(:,2) = MIN(ZDZ2,PSNOW(:)/INLVLS) 
+!
+  WHERE(GREGRID(:))
+!      top layers
+       PSNOWDZ(:,1) = MIN(ZDZ1,PSNOW(:)/INLVLS)
+       PSNOWDZ(:,2) = MIN(ZDZ2,PSNOW(:)/INLVLS)
        PSNOWDZ(:,3) = MIN(ZDZ3,PSNOW(:)/INLVLS)
-!      last layers 
+!      last layers
        PSNOWDZ(:,9)= MIN(ZDZN0,PSNOW(:)/INLVLS)
        PSNOWDZ(:,8)= MIN(ZDZN1,PSNOW(:)/INLVLS)
        PSNOWDZ(:,7)= MIN(ZDZN2,PSNOW(:)/INLVLS)
@@ -1042,8 +1042,8 @@ ELSEIF(INLVLS == 9)THEN
 !      layer 4 tickness >= layer 3 tickness
        ZWORK(:)=MIN(0.0,PSNOWDZ(:,4)-PSNOWDZ(:,3))
        PSNOWDZ(:,4)=PSNOWDZ(:,4)-ZWORK(:)
-       PSNOWDZ(:,5)=PSNOWDZ(:,5)+ZWORK(:) 
-!      layer 6 tickness >= layer 7 tickness  
+       PSNOWDZ(:,5)=PSNOWDZ(:,5)+ZWORK(:)
+!      layer 6 tickness >= layer 7 tickness
        ZWORK(:)=MIN(0.0,PSNOWDZ(:,6)-PSNOWDZ(:,7))
        PSNOWDZ(:,6)=PSNOWDZ(:,6)-ZWORK(:)
        PSNOWDZ(:,5)=PSNOWDZ(:,5)+ZWORK(:)
@@ -1064,15 +1064,15 @@ ELSEIF(INLVLS == 12)THEN
                & PSNOWDZ_OLD(:,12) < ZCOEF1 * MIN(ZDZN0,PSNOW(:)/INLVLS) .OR. &
                & PSNOWDZ_OLD(:,12) > ZCOEF2 * MIN(ZDZN0,PSNOW(:)/INLVLS) 
   ENDIF
-!             
-  WHERE(GREGRID(:))  
-!      top layers 
-       PSNOWDZ(:,1) = MIN(ZDZ1,PSNOW(:)/INLVLS) 
-       PSNOWDZ(:,2) = MIN(ZDZ2,PSNOW(:)/INLVLS) 
+!
+  WHERE(GREGRID(:))
+!      top layers
+       PSNOWDZ(:,1) = MIN(ZDZ1,PSNOW(:)/INLVLS)
+       PSNOWDZ(:,2) = MIN(ZDZ2,PSNOW(:)/INLVLS)
        PSNOWDZ(:,3) = MIN(ZDZ3,PSNOW(:)/INLVLS)
        PSNOWDZ(:,4) = MIN(ZDZ4,PSNOW(:)/INLVLS)
        PSNOWDZ(:,5) = MIN(ZDZ5,PSNOW(:)/INLVLS)
-!      last layers 
+!      last layers
        PSNOWDZ(:,12)= MIN(ZDZN0,PSNOW(:)/INLVLS)
        PSNOWDZ(:,11)= MIN(ZDZN1,PSNOW(:)/INLVLS)
        PSNOWDZ(:,10)= MIN(ZDZN2,PSNOW(:)/INLVLS)
@@ -1087,8 +1087,8 @@ ELSEIF(INLVLS == 12)THEN
 !      layer 6 tickness >= layer 5 tickness
        ZWORK(:)=MIN(0.0,PSNOWDZ(:,6)-PSNOWDZ(:,5))
        PSNOWDZ(:,6)=PSNOWDZ(:,6)-ZWORK(:)
-       PSNOWDZ(:,7)=PSNOWDZ(:,7)+ZWORK(:) 
-!      layer 8 tickness >= layer 9 tickness  
+       PSNOWDZ(:,7)=PSNOWDZ(:,7)+ZWORK(:)
+!      layer 8 tickness >= layer 9 tickness
        ZWORK(:)=MIN(0.0,PSNOWDZ(:,8)-PSNOWDZ(:,9))
        PSNOWDZ(:,8)=PSNOWDZ(:,8)-ZWORK(:)
        PSNOWDZ(:,7)=PSNOWDZ(:,7)+ZWORK(:)
@@ -1096,7 +1096,7 @@ ELSEIF(INLVLS == 12)THEN
 !
 ! 4. Calculate other non-optimized grid :
 ! ---------------------------------------
-! 
+!
 ELSEIF(INLVLS<10.AND.INLVLS/=3.AND.INLVLS/=6.AND.INLVLS/=9) THEN
 !
   DO JJ=1,INLVLS
@@ -1108,7 +1108,7 @@ ELSEIF(INLVLS<10.AND.INLVLS/=3.AND.INLVLS/=6.AND.INLVLS/=9) THEN
   PSNOWDZ(:,INLVLS) = PSNOWDZ(:,INLVLS) + (PSNOWDZ(:,1) - MIN(0.05, PSNOWDZ(:,1)))
   PSNOWDZ(:,1)      = MIN(0.05, PSNOWDZ(:,1))
 !
-ELSE !(INLVLS>=10 and /=12)  
+ELSE !(INLVLS>=10 and /=12)
 !
 ! critere a satisfaire pour remaillage
 !
@@ -1121,18 +1121,18 @@ ELSE !(INLVLS>=10 and /=12)
                & PSNOWDZ_OLD(:,INLVLS) > ZCOEF2 * MIN(0.05*PSNOW(:),PSNOW(:)/INLVLS) 
   ENDIF
 !
-  WHERE(GREGRID(:))  
-       PSNOWDZ(:,1     ) = MIN(ZDZ1         ,PSNOW(:)/INLVLS) 
-       PSNOWDZ(:,2     ) = MIN(ZDZ2         ,PSNOW(:)/INLVLS) 
+  WHERE(GREGRID(:))
+       PSNOWDZ(:,1     ) = MIN(ZDZ1         ,PSNOW(:)/INLVLS)
+       PSNOWDZ(:,2     ) = MIN(ZDZ2         ,PSNOW(:)/INLVLS)
        PSNOWDZ(:,3     ) = MIN(ZDZ3         ,PSNOW(:)/INLVLS)
        PSNOWDZ(:,4     ) = MIN(ZDZ4         ,PSNOW(:)/INLVLS)
-       PSNOWDZ(:,5     ) = MIN(ZDZ5         ,PSNOW(:)/INLVLS)          
-       PSNOWDZ(:,INLVLS) = MIN(0.05*PSNOW(:),PSNOW(:)/INLVLS) 
+       PSNOWDZ(:,5     ) = MIN(ZDZ5         ,PSNOW(:)/INLVLS)
+       PSNOWDZ(:,INLVLS) = MIN(0.05*PSNOW(:),PSNOW(:)/INLVLS)
   ENDWHERE
 !
   DO JJ=6,INLVLS-1,1
      DO JI=1,INI
-        IF(GREGRID(JI))THEN           
+        IF(GREGRID(JI))THEN
           ZWORK(JI) = PSNOWDZ(JI,1)+PSNOWDZ(JI,2)+PSNOWDZ(JI,3)+PSNOWDZ(JI,4)+PSNOWDZ(JI,5)
           PSNOWDZ(JI,JJ) = (PSNOW(JI)-ZWORK(JI)-PSNOWDZ(JI,INLVLS))/(INLVLS-6) 
         ENDIF
@@ -1145,9 +1145,9 @@ DO JJ=1,INLVLS
    DO JI=1,INI
       IF(PSNOW(JI)==XUNDEF)THEN
          PSNOWDZ(JI,JJ) = XUNDEF
-      ELSEIF(.NOT.GREGRID(JI))THEN           
+      ELSEIF(.NOT.GREGRID(JI))THEN
          PSNOWDZ(JI,JJ)=PSNOWDZ_OLD(JI,JJ)
-      ENDIF      
+      ENDIF
    ENDDO
 ENDDO
 !
@@ -1203,15 +1203,15 @@ LOGICAL                           :: GREGRID
 
 ! ISBA-ES snow grid parameters
 !
-REAL, PARAMETER, DIMENSION(3)     :: ZSGCOEF1  = (/0.25, 0.50, 0.25/) 
-REAL, PARAMETER, DIMENSION(2)     :: ZSGCOEF2  = (/0.05, 0.34/)       
-!      
-REAL, PARAMETER, DIMENSION(3)     :: ZSGCOEF   = (/0.3, 0.4, 0.3/) 
+REAL, PARAMETER, DIMENSION(3)     :: ZSGCOEF1  = (/0.25, 0.50, 0.25/)
+REAL, PARAMETER, DIMENSION(2)     :: ZSGCOEF2  = (/0.05, 0.34/)
+!
+REAL, PARAMETER, DIMENSION(3)     :: ZSGCOEF   = (/0.3, 0.4, 0.3/)
 !
 ! Minimum total snow depth at which surface layer thickness is constant:
 !
 REAL, PARAMETER                   :: ZSNOWTRANS  = 0.20                ! (m)
-!      
+!
 ! Minimum snow depth by layer for 6-L or 12-L configuration :
 !
 REAL, PARAMETER                   ::  ZDZ1=0.01
@@ -1243,7 +1243,7 @@ GREGRID = .TRUE.
 ! 1. Calculate current grid for 3-layer (default) configuration):
 ! ---------------------------------------------------------------
 ! Based on formulation of Lynch-Stieglitz (1994)
-! except for 3 modifications: 
+! except for 3 modifications:
 ! i) smooth transition here at ZSNOWTRANS
 ! ii) constant ratio for very thin snow:
 ! iii) ratio of layer 2 to surface layer <= 10
@@ -1272,7 +1272,7 @@ ELSEIF(INLVLS == 3)THEN
 !
 ! When using simple finite differences, limit the thickness
 ! factor between the top and 2nd layers to at most 10
-! 
+!
       PSNOWDZ(2) = MIN(10*ZSGCOEF2(1),  PSNOWDZ(2))
       PSNOWDZ(3) = PSNOW - PSNOWDZ(2) - PSNOWDZ(1)
    END IF
@@ -1295,10 +1295,10 @@ ELSEIF(INLVLS == 6)THEN
   ENDIF
 !
   IF(GREGRID)THEN
-!      top layers 
-       PSNOWDZ(1) = MIN(ZDZ1,PSNOW/INLVLS) 
-       PSNOWDZ(2) = MIN(ZDZ2,PSNOW/INLVLS) 
-!      last layers 
+!      top layers
+       PSNOWDZ(1) = MIN(ZDZ1,PSNOW/INLVLS)
+       PSNOWDZ(2) = MIN(ZDZ2,PSNOW/INLVLS)
+!      last layers
        PSNOWDZ(6) = MIN(ZDZN1,PSNOW/INLVLS)
 !      remaining snow for remaining layers
        ZWORK      = PSNOW - PSNOWDZ(1) - PSNOWDZ(2) - PSNOWDZ(6)
@@ -1309,7 +1309,7 @@ ELSEIF(INLVLS == 6)THEN
        ZWORK=MIN(0.0,PSNOWDZ(3)-PSNOWDZ(2))
        PSNOWDZ(3)=PSNOWDZ(3)-ZWORK
        PSNOWDZ(4)=PSNOWDZ(4)+ZWORK
-!      layer 5 tickness >= layer 6 tickness  
+!      layer 5 tickness >= layer 6 tickness
        ZWORK=MIN(0.0,PSNOWDZ(5)-PSNOWDZ(6))
        PSNOWDZ(5)=PSNOWDZ(5)-ZWORK
        PSNOWDZ(4)=PSNOWDZ(4)+ZWORK
@@ -1328,15 +1328,15 @@ ELSEIF(INLVLS == 9)THEN
                & PSNOWDZ_OLD(2) < ZCOEF1 * MIN(ZDZ2 ,PSNOW/INLVLS) .OR. &
                & PSNOWDZ_OLD(2) > ZCOEF2 * MIN(ZDZ2 ,PSNOW/INLVLS) .OR. &
                & PSNOWDZ_OLD(9) < ZCOEF1 * MIN(ZDZN0,PSNOW/INLVLS) .OR. &
-               & PSNOWDZ_OLD(9) > ZCOEF2 * MIN(ZDZN0,PSNOW/INLVLS) 
+               & PSNOWDZ_OLD(9) > ZCOEF2 * MIN(ZDZN0,PSNOW/INLVLS)
   ENDIF
-!             
+!
   IF(GREGRID)THEN
-!      top layers 
-       PSNOWDZ(1) = MIN(ZDZ1,PSNOW/INLVLS) 
-       PSNOWDZ(2) = MIN(ZDZ2,PSNOW/INLVLS) 
+!      top layers
+       PSNOWDZ(1) = MIN(ZDZ1,PSNOW/INLVLS)
+       PSNOWDZ(2) = MIN(ZDZ2,PSNOW/INLVLS)
        PSNOWDZ(3) = MIN(ZDZ3,PSNOW/INLVLS)
-!      last layers 
+!      last layers
        PSNOWDZ(9)= MIN(ZDZN0,PSNOW/INLVLS)
        PSNOWDZ(8)= MIN(ZDZN1,PSNOW/INLVLS)
        PSNOWDZ(7)= MIN(ZDZN2,PSNOW/INLVLS)
@@ -1350,7 +1350,7 @@ ELSEIF(INLVLS == 9)THEN
        ZWORK=MIN(0.0,PSNOWDZ(4)-PSNOWDZ(3))
        PSNOWDZ(4)=PSNOWDZ(4)-ZWORK
        PSNOWDZ(5)=PSNOWDZ(5)+ZWORK
-!      layer 6 tickness >= layer 7 tickness  
+!      layer 6 tickness >= layer 7 tickness
        ZWORK=MIN(0.0,PSNOWDZ(6)-PSNOWDZ(7))
        PSNOWDZ(6)=PSNOWDZ(6)-ZWORK
        PSNOWDZ(5)=PSNOWDZ(5)+ZWORK
@@ -1369,17 +1369,17 @@ ELSEIF(INLVLS == 12)THEN
                & PSNOWDZ_OLD(2)  < ZCOEF1 * MIN(ZDZ2 ,PSNOW/INLVLS) .OR. &
                & PSNOWDZ_OLD(2)  > ZCOEF2 * MIN(ZDZ2 ,PSNOW/INLVLS) .OR. &
                & PSNOWDZ_OLD(12) < ZCOEF1 * MIN(ZDZN0,PSNOW/INLVLS) .OR. &
-               & PSNOWDZ_OLD(12) > ZCOEF2 * MIN(ZDZN0,PSNOW/INLVLS) 
+               & PSNOWDZ_OLD(12) > ZCOEF2 * MIN(ZDZN0,PSNOW/INLVLS)
   ENDIF
 !
   IF (GREGRID)THEN
-!    top layers 
-     PSNOWDZ(1) = MIN(ZDZ1,PSNOW/INLVLS) 
-     PSNOWDZ(2) = MIN(ZDZ2,PSNOW/INLVLS) 
+!    top layers
+     PSNOWDZ(1) = MIN(ZDZ1,PSNOW/INLVLS)
+     PSNOWDZ(2) = MIN(ZDZ2,PSNOW/INLVLS)
      PSNOWDZ(3) = MIN(ZDZ3,PSNOW/INLVLS)
      PSNOWDZ(4) = MIN(ZDZ4,PSNOW/INLVLS)
      PSNOWDZ(5) = MIN(ZDZ5,PSNOW/INLVLS)
-!    last layers 
+!    last layers
      PSNOWDZ(12)= MIN(ZDZN0,PSNOW/INLVLS)
      PSNOWDZ(11)= MIN(ZDZN1,PSNOW/INLVLS)
      PSNOWDZ(10)= MIN(ZDZN2,PSNOW/INLVLS)
@@ -1394,8 +1394,8 @@ ELSEIF(INLVLS == 12)THEN
 !    layer 6 tickness >= layer 5 tickness
      ZWORK=MIN(0.0,PSNOWDZ(6)-PSNOWDZ(5))
      PSNOWDZ(6)=PSNOWDZ(6)-ZWORK
-     PSNOWDZ(7)=PSNOWDZ(7)+ZWORK 
-!    layer 8 tickness >= layer 9 tickness  
+     PSNOWDZ(7)=PSNOWDZ(7)+ZWORK
+!    layer 8 tickness >= layer 9 tickness
      ZWORK=MIN(0.0,PSNOWDZ(8)-PSNOWDZ(9))
      PSNOWDZ(8)=PSNOWDZ(8)-ZWORK
      PSNOWDZ(7)=PSNOWDZ(7)+ZWORK
@@ -1403,9 +1403,9 @@ ELSEIF(INLVLS == 12)THEN
 !
 ! 4. Calculate other non-optimized grid to allow CROCUS PREP :
 ! ------------------------------------------------------------
-! 
+!
 ELSE IF(INLVLS<10.AND.INLVLS/=3.AND.INLVLS/=6.AND.INLVLS/=9) THEN
-!        
+!
   DO JJ=1,INLVLS
      PSNOWDZ(JJ)  = PSNOW/INLVLS
   ENDDO
@@ -1413,7 +1413,7 @@ ELSE IF(INLVLS<10.AND.INLVLS/=3.AND.INLVLS/=6.AND.INLVLS/=9) THEN
   PSNOWDZ(INLVLS) = PSNOWDZ(INLVLS) + (PSNOWDZ(1) - MIN(0.05, PSNOWDZ(1)))
   PSNOWDZ(1)      = MIN(0.05, PSNOWDZ(1))
 !
-ELSE   
+ELSE
 !
   IF(PRESENT(PSNOWDZ_OLD))THEN
     GREGRID    = PSNOWDZ_OLD(     1) < ZCOEF1 * MIN(ZDZ1      ,PSNOW/INLVLS) .OR. &
@@ -1425,15 +1425,15 @@ ELSE
   ENDIF
 !
   IF (GREGRID)THEN
-     PSNOWDZ(     1) = MIN(ZDZ1      ,PSNOW/INLVLS) 
+     PSNOWDZ(     1) = MIN(ZDZ1      ,PSNOW/INLVLS)
      PSNOWDZ(     2) = MIN(ZDZ2      ,PSNOW/INLVLS)
      PSNOWDZ(     3) = MIN(ZDZ3      ,PSNOW/INLVLS)
      PSNOWDZ(     4) = MIN(ZDZ4      ,PSNOW/INLVLS)
      PSNOWDZ(     5) = MIN(ZDZ5      ,PSNOW/INLVLS)
-     PSNOWDZ(INLVLS) = MIN(0.05*PSNOW,PSNOW/INLVLS) 
-     ZWORK = SUM(PSNOWDZ(1:5))          
+     PSNOWDZ(INLVLS) = MIN(0.05*PSNOW,PSNOW/INLVLS)
+     ZWORK = SUM(PSNOWDZ(1:5))
      DO JJ=6,INLVLS-1,1
-        PSNOWDZ(JJ) = (PSNOW - ZWORK -PSNOWDZ(INLVLS))/(INLVLS-6) 
+        PSNOWDZ(JJ) = (PSNOW - ZWORK -PSNOWDZ(INLVLS))/(INLVLS-6)
      END DO
   ENDIF
 !
@@ -1455,7 +1455,7 @@ END SUBROUTINE SNOW3LGRID_1D
 !###################################################################################
 SUBROUTINE SNOW3LAGREG(PSNOWDZN,PSNOWDZ,PSNOWRHO,PSNOWGRAN1, PSNOWGRAN2, &
                        PSNOWHIST,PSNOWGRAN1N,PSNOWGRAN2N,PSNOWHISTN,     &
-                       KL1,KL2,PSNOWDDZ                        ) 
+                       KL1,KL2,PSNOWDDZ                        )
 !
 USE MODD_SNOW_METAMO
 !
@@ -1464,28 +1464,28 @@ USE MODD_SNOW_METAMO
 !
 IMPLICIT NONE
 !
-!       0.1 declarations of arguments        
-!        
-REAL, DIMENSION(:), INTENT(IN)  :: PSNOWDZN,PSNOWDZ,PSNOWRHO,PSNOWDDZ  
-!                                                    
-REAL, DIMENSION(:), INTENT(IN)  :: PSNOWGRAN1,PSNOWGRAN2,PSNOWHIST 
+!       0.1 declarations of arguments
+!
+REAL, DIMENSION(:), INTENT(IN)  :: PSNOWDZN,PSNOWDZ,PSNOWRHO,PSNOWDDZ
+!
+REAL, DIMENSION(:), INTENT(IN)  :: PSNOWGRAN1,PSNOWGRAN2,PSNOWHIST
 REAL, DIMENSION(:), INTENT(OUT) :: PSNOWGRAN1N,PSNOWGRAN2N,PSNOWHISTN                                              
 !
 INTEGER, INTENT(IN) :: KL1  ! Indice couche de reference (i)
-INTEGER, INTENT(IN) :: KL2 ! Indice de la couche (i-1 ou i+1) dont une 
+INTEGER, INTENT(IN) :: KL2 ! Indice de la couche (i-1 ou i+1) dont une
                                 ! partie est aggregee à la couche (i)
 !
 !       0.2 declaration of local variables
-!        
+!
 REAL, DIMENSION(SIZE(PSNOWRHO,1)) :: ZSNOWRHO
 REAL, DIMENSION(SIZE(PSNOWRHO,1)) :: ZDIAMD,ZDIAMV,ZSPHERD,ZSPHERV,&
-                                     ZDIAMN,ZSPHERN,ZDENT 
+                                     ZDIAMN,ZSPHERN,ZDENT
 !
 REAL :: ZDELTA, ZCOMP
 !
 INTEGER :: IDENT, IVIEU, IL
 !
-!REAL(KIND=JPRB) :: ZHOOK_HANDLE 
+!REAL(KIND=JPRB) :: ZHOOK_HANDLE
 !
 !IF (LHOOK) CALL DR_HOOK('MODE_SNOW3L:SNOW3LAGREG',0,ZHOOK_HANDLE)
 !
@@ -1511,7 +1511,7 @@ ENDIF
 !
 IF (  PSNOWGRAN1(KL1)*PSNOWGRAN1(KL2)>0.0 .OR. &
     ( PSNOWGRAN1(KL1)==0.0 .AND. PSNOWGRAN1(KL2)>=0.0 ) .OR. &
-    ( PSNOWGRAN1(KL2)==0.0 .AND. PSNOWGRAN1(KL1)>=0.0 ) ) THEN 
+    ( PSNOWGRAN1(KL2)==0.0 .AND. PSNOWGRAN1(KL1)>=0.0 ) ) THEN
   !
   !code original vincent          PSNOWGRAN1N(KL1)=(PSNOWGRAN1(KL1)*PSNOWRHO(KL1)&
   !code original vincent        *(PSNOWDZN(KL1)-(1.0-ZDELTA)*ABS(PSNOWDDZ(KL1))-ZDELTA*&
@@ -1530,36 +1530,36 @@ IF (  PSNOWGRAN1(KL1)*PSNOWGRAN1(KL2)>0.0 .OR. &
   !code original vincent        *ABS(PSNOWDDZ(KL1))-ZDELTA*ABS(PSNOWDDZ(KL2)))*        &
   !code original vincent        PSNOWRHO(KL1)+((1.0-ZDELTA)*ABS(PSNOWDDZ(KL1))+        &   
   !code original vincent        ZDELTA*ABS(PSNOWDDZ(KL2)))*PSNOWRHO(KL2))
-  !     
+  !
   !plm
   CALL GET_AGREG(KL1,KL2,PSNOWGRAN1(KL1),PSNOWGRAN1(KL2),PSNOWGRAN1N(KL1))
   !
   CALL GET_AGREG(KL1,KL2,PSNOWGRAN2(KL1),PSNOWGRAN2(KL2),PSNOWGRAN2N(KL1))
   !
   !plm
-  !     
+  !
 ELSE
   !
   !       2.2 Different types
-  !        
+  !
   IF ( PSNOWGRAN1(KL1)<0.0 ) THEN
     IDENT = KL1
     IVIEU = KL2
   ELSE
     IDENT = KL2
     IVIEU = KL1
-  ENDIF  
-  !                        
+  ENDIF
+  !
   ZDIAMD (KL1) = - PSNOWGRAN1(IDENT)/XGRAN * XDIAET + ( 1.0 + PSNOWGRAN1(IDENT)/XGRAN ) * &
                  ( PSNOWGRAN2(IDENT)/XGRAN * XDIAGF + ( 1.0 - PSNOWGRAN2(IDENT)/XGRAN ) * XDIAFP )
   !
-  ZSPHERD(KL1) = PSNOWGRAN2(IDENT)/XGRAN                
+  ZSPHERD(KL1) = PSNOWGRAN2(IDENT)/XGRAN
   ZDIAMV (KL1) = PSNOWGRAN2(IVIEU)
   ZSPHERV(KL1) = PSNOWGRAN1(IVIEU)/XGRAN
   !IF(KL1==1)THEN
   !write(*,*) 'ZDD1',ZDIAMD(1),'ZSD1',ZSPHERD(1)
   !write(*,*) 'ZDV1',ZDIAMV(1),'ZSV1',ZSPHERV(1)
-  !ENDIF       
+  !ENDIF
   !
   IF ( IDENT==KL1 ) THEN
     !code original vincent        ZDIAMN(KL1)= (ZDIAMD(KL1)*PSNOWRHO(IDENT)*&
@@ -1575,7 +1575,7 @@ ELSE
     CALL GET_AGREG(IDENT,IVIEU,ZDIAMD(KL1),ZDIAMV(KL1),ZDIAMN(KL1))
     !
     !plm
-    !         
+    !
     !code original vincent        ZSPHERN(KL1)= (ZSPHERD(KL1)*PSNOWRHO(IDENT)*&
     !code original vincent            (PSNOWDZN(IDENT)-(1.0-ZDELTA)*ABS(PSNOWDDZ(KL1))-ZDELTA*      &
     !code original vincent            ABS(PSNOWDDZ(KL2)))+ZSPHERV(KL1)*PSNOWRHO(IVIEU)*(       &
@@ -1598,7 +1598,7 @@ ELSE
     !code original vincent            ABS(PSNOWDDZ(KL1))-ZDELTA*ABS(PSNOWDDZ(KL2)))*    &
     !code original vincent            PSNOWRHO(KL1)+((1.0-ZDELTA)*ABS(PSNOWDDZ(KL1))+   &
     !code original vincent            ZDELTA*ABS(PSNOWDDZ(KL2)))*PSNOWRHO(KL2))
-    !code original vincent!            
+    !code original vincent!
     !code original vincent         ZSPHERN(KL1)= (ZSPHERD(KL1)*PSNOWRHO(IDENT)*&
     !code original vincent            ((1.0-ZDELTA)*ABS(PSNOWDDZ(KL1))+ZDELTA*ABS(PSNOWDDZ(KL2)))&
     !code original vincent            +ZSPHERV(KL1)*PSNOWRHO(IVIEU)*(PSNOWDZN(IVIEU)-(1.0-ZDELTA)* & 
@@ -1610,17 +1610,17 @@ ELSE
     !plm
     !
     CALL GET_AGREG(IVIEU,IDENT,ZDIAMV(KL1),ZDIAMD(KL1),ZDIAMN(KL1))
-    !           
+    !
     CALL GET_AGREG(IVIEU,IDENT,ZSPHERV(KL1),ZSPHERD(KL1),ZSPHERN(KL1))
     !plm
     !
   ENDIF
-  !       
+  !
   ZCOMP = ZSPHERN(KL1) * XDIAGF + ( 1.-ZSPHERN(KL1) ) * XDIAFP
   IF( ZDIAMN(KL1) < ZCOMP ) THEN
     !
-    ZDENT(KL1) = ( ZDIAMN(KL1) - ZCOMP ) / ( XDIAET - ZCOMP ) 
-    !IF(KL1==1) write(*,*) 'ZDENT',ZDENT(1)   
+    ZDENT(KL1) = ( ZDIAMN(KL1) - ZCOMP ) / ( XDIAET - ZCOMP )
+    !IF(KL1==1) write(*,*) 'ZDENT',ZDENT(1)
     PSNOWGRAN1N(KL1) = - XGRAN * ZDENT  (KL1)
     PSNOWGRAN2N(KL1) =   XGRAN * ZSPHERN(KL1)
     !
@@ -1630,12 +1630,12 @@ ELSE
     PSNOWGRAN2N(KL1) = ZDIAMN(KL1)
     !
   ENDIF
-  !  
+  !
 ENDIF
 !
 !IF (LHOOK) CALL DR_HOOK('MODE_SNOW3L:SNOW3LAGREG',1,ZHOOK_HANDLE)
 !
-!       3. Update snow grains parameters : GRAN1, GRAN2        
+!       3. Update snow grains parameters : GRAN1, GRAN2
 !        PSNOWGRAN1(KL1)=ZSNOWGRAN1(KL1)
 !        PSNOWGRAN2(KL1)=ZSNOWGRAN2(KL1)
 !
@@ -1660,15 +1660,15 @@ PFIELD = ( PFIELD1 * PSNOWRHO(KID1) * ( PSNOWDZN(KID1) - ABS(PSNOWDDZ(IL)) ) &
 !
 END SUBROUTINE GET_AGREG
 !
-END SUBROUTINE SNOW3LAGREG    
+END SUBROUTINE SNOW3LAGREG
 !###############################################################################    
 !###############################################################################
 !
-!       
+!
 !ajout EB : ajout des arguments "N" pour faire idem variables d'origine
 SUBROUTINE SNOW3LAVGRAIN(PSNOWGRAN1,PSNOWGRAN2,PSNOWHIST,                &
                          PSNOWGRAN1N,PSNOWGRAN2N,PSNOWHISTN,PNDENT,PNVIEU,&
-                         HSNOWMETAMO) 
+                         HSNOWMETAMO)
 !
 USE MODD_SNOW_METAMO, ONLY : XVDIAM6, XUEPSI
 !
@@ -1677,18 +1677,18 @@ USE MODD_SNOW_METAMO, ONLY : XVDIAM6, XUEPSI
 !
 IMPLICIT NONE
 !
-!       0.1 declarations of arguments        
-!        
-REAL, DIMENSION(:,:), INTENT(INOUT)  :: PSNOWGRAN1,PSNOWGRAN2,PSNOWHIST 
+!       0.1 declarations of arguments
+!
+REAL, DIMENSION(:,:), INTENT(INOUT)  :: PSNOWGRAN1,PSNOWGRAN2,PSNOWHIST
 ! ajout EB
 REAL, DIMENSION(:,:), INTENT(INOUT)  :: PSNOWGRAN1N,PSNOWGRAN2N,PSNOWHISTN 
 !
-REAL, DIMENSION(:), INTENT(IN)    :: PNDENT, PNVIEU          
+REAL, DIMENSION(:), INTENT(IN)    :: PNDENT, PNVIEU
 !
  CHARACTER(3), INTENT(IN)              :: HSNOWMETAMO
 !       0.2 declaration of local variables
 !
-REAL, DIMENSION(SIZE(PSNOWGRAN1,1)) :: ZGRAN1, ZGRAN2, ZHIST 
+REAL, DIMENSION(SIZE(PSNOWGRAN1,1)) :: ZGRAN1, ZGRAN2, ZHIST
 !
 LOGICAL, DIMENSION(SIZE(PSNOWGRAN1,1),SIZE(PSNOWGRAN1,2)) :: GDENDRITIC
 !
@@ -1696,24 +1696,24 @@ INTEGER :: JI, JL
 INTEGER :: INLVLS, INI
 !
 !REAL(KIND=JPRB) :: ZHOOK_HANDLE
-!         
-!       0.3 initialization         
+!
+!       0.3 initialization
 !
 !IF (LHOOK) CALL DR_HOOK('MODE_SNOW3L:SNOW3LAVGRAIN',0,ZHOOK_HANDLE)
 !
-INLVLS    = SIZE(PSNOWGRAN1,2) 
+INLVLS    = SIZE(PSNOWGRAN1,2)
 INI       = SIZE(PSNOWGRAN1,1)
 !
 ZGRAN1(:) = 0.0
 ZGRAN2(:) = 0.0
 ZHIST (:) = 0.0
-!     
+!
 DO JI = 1,INI
   !
   IF ( PNDENT(JI)==0.0 .AND. PNVIEU(JI)==0.0 ) THEN
     !
     ZGRAN1(JI) = 1.0
-    ZGRAN2(JI) = 1.0 
+    ZGRAN2(JI) = 1.0
     ZHIST (JI) = 1.0
     !
   ELSE
@@ -1735,7 +1735,7 @@ DO JI = 1,INI
         ENDIF
       ENDDO
       !
-      PSNOWGRAN1N(JI,:) = ZGRAN1(JI) / PNDENT(JI)   
+      PSNOWGRAN1N(JI,:) = ZGRAN1(JI) / PNDENT(JI)
       PSNOWGRAN2N(JI,:) = ZGRAN2(JI) / PNDENT(JI)
       PSNOWHISTN (JI,:) = 0.0
       !
@@ -1745,14 +1745,14 @@ DO JI = 1,INI
         IF ( .NOT.GDENDRITIC(JI,JL) ) THEN
           ZGRAN1(JI) = ZGRAN1(JI) + PSNOWGRAN1(JI,JL)
           ZGRAN2(JI) = ZGRAN2(JI) + PSNOWGRAN2(JI,JL)
-          ZHIST (JI) = ZHIST (JI) + PSNOWHIST (JI,JL) 
+          ZHIST (JI) = ZHIST (JI) + PSNOWHIST (JI,JL)
         ENDIF
       ENDDO
       !
       PSNOWGRAN1N(JI,:) = ZGRAN1(JI) / PNVIEU(JI)
       PSNOWGRAN2N(JI,:) = ZGRAN2(JI) / PNVIEU(JI)
       PSNOWHISTN (JI,:) = ZHIST (JI) / PNVIEU(JI)
-      !    
+      !
     ENDIF
     !
   ENDIF
@@ -1760,12 +1760,12 @@ DO JI = 1,INI
 ENDDO
 
 
- 
+
 !
 !IF (LHOOK) CALL DR_HOOK('MODE_SNOW3L:SNOW3LAVGRAIN',1,ZHOOK_HANDLE)
 !
-END SUBROUTINE SNOW3LAVGRAIN         
-!        
+END SUBROUTINE SNOW3LAVGRAIN
+!
 !####################################################################
 !####################################################################
 !####################################################################
@@ -1790,7 +1790,7 @@ REAL :: ZDIFTYPE, ZCOEF3, ZCOEF4
 !*      0.2    calcul de la difference entre type de grains
 !IF (LHOOK) CALL DR_HOOK('MODE_SNOW3L:SNOW3LDIFTYP',0,ZHOOK_HANDLE)
 !
-IF ( HSNOWMETAMO=='B92' ) THEN 
+IF ( HSNOWMETAMO=='B92' ) THEN
   !
   IF ( ( PGRAIN1<0.  .AND. PGRAIN2>=0.) .OR. ( PGRAIN1>=0. .AND. PGRAIN2<0. ) ) THEN
     ZDIFTYPE = 200.
@@ -1803,17 +1803,17 @@ IF ( HSNOWMETAMO=='B92' ) THEN
 ELSE
   !
   ZCOEF3 = XVDIAM6 * (4.-PGRAIN3) - XUEPSI
-  ZCOEF4 = XVDIAM6 * (4.-PGRAIN4) - XUEPSI 
+  ZCOEF4 = XVDIAM6 * (4.-PGRAIN4) - XUEPSI
   IF ( ( PGRAIN1<ZCOEF3 .AND. PGRAIN2>=ZCOEF4 ) .OR. ( PGRAIN1>=ZCOEF3 .AND. PGRAIN2<ZCOEF4 ) ) THEN
     ZDIFTYPE = 200.
   ELSEIF ( PGRAIN1<ZCOEF3 ) THEN
     ZDIFTYPE = ABS( (PGRAIN3-PGRAIN4)*XGRAN ) * .5 + &
                ABS( ( (PGRAIN1/XVDIAM6 - 4. + PGRAIN3) / (PGRAIN3 - 3.) - &
                       (PGRAIN2/XVDIAM6 - 4. + PGRAIN4) / (PGRAIN4 - 3.) ) * XGRAN ) * .5
-             
+
   ELSE
     ZDIFTYPE = ABS( (PGRAIN3-PGRAIN4)*XGRAN )      + ABS( ZCOEF3-ZCOEF4 ) * 5. * 10000.
-  ENDIF  
+  ENDIF
   !
 ENDIF
 !
@@ -1857,7 +1857,7 @@ INTEGER :: JST_NEW, JST_OLD
 !REAL(KIND=JPRB) :: ZHOOK_HANDLE
 !
 !IF (LHOOK) CALL DR_HOOK('GET_MASS_HEAT',0,ZHOOK_HANDLE)
-!     
+!
 !      write(6,*) "in get_mass_heat"   ! trude
 
 PSNOWRHON  (:) = 0.
@@ -1879,7 +1879,7 @@ DO JST_NEW = 1,KNLVLS_NEW
   ZHISTMOYN   = 0.
   ZAGEMOYN    = 0.
   !
-  ! lopp over the ols snow layers 
+  ! lopp over the ols snow layers
 !   write(6,*) "-------"
   DO JST_OLD = 1,KNLVLS_OLD
 !      write(6,*) "knlvls_old ", knlvls_old, jst_old, jst_new
@@ -1892,10 +1892,10 @@ DO JST_NEW = 1,KNLVLS_NEW
       ! JST_OLD higher than JJ_NEW ==> no contribution
     ELSE
       ! old layer contributes to the new one
-      ! computation of its contributing ratio and mass/heat 
+      ! computation of its contributing ratio and mass/heat
       ZPROPOR = ( MIN( PSNOWZTOP_OLD(JST_OLD), PSNOWZTOP_NEW(JST_NEW) )   &
                 - MAX( PSNOWZBOT_OLD(JST_OLD), PSNOWZBOT_NEW(JST_NEW) ) ) &
-                 / PSNOWDZO(JST_OLD) 
+                 / PSNOWDZO(JST_OLD)
       ZMASDZ_OLD = ZPROPOR * PSNOWRHOO(JST_OLD) * PSNOWDZO(JST_OLD)
 !      write(6,*) "zpropor ", zpropor
 !      write(6,*) "psnowrhoo ", psnowrhoo(jst_old)
@@ -1914,7 +1914,7 @@ DO JST_NEW = 1,KNLVLS_NEW
         IF ( PSNOWGRAN1O(JST_OLD)<0. ) THEN
           ZDIAM = -PSNOWGRAN1O(JST_OLD)*XD1/XX + (1.+PSNOWGRAN1O(JST_OLD)/XX) * &
                  ( PSNOWGRAN2O(JST_OLD)*XD2/XX + (1.-PSNOWGRAN2O(JST_OLD)/XX)*XD3 ) 
-          ZDIAM = ZDIAM/10000.      
+          ZDIAM = ZDIAM/10000.
           ZDENTMOYN  = ZDENTMOYN  - ZMASDZ_OLD * PSNOWGRAN1O(JST_OLD) / XX
           ZSPHERMOYN = ZSPHERMOYN + ZMASDZ_OLD * PSNOWGRAN2O(JST_OLD) / XX
         ELSE
@@ -1937,7 +1937,7 @@ DO JST_NEW = 1,KNLVLS_NEW
     ENDIF
     !
   ENDDO
-  ! 
+  !
   ! the new layer inherits from the weihted average properties of the old ones
   ! heat and mass
   PSNOWHEATN(JST_NEW) = ZSNOWHEAN
@@ -1955,7 +1955,7 @@ DO JST_NEW = 1,KNLVLS_NEW
   !
   IF ( HSNOWMETAMO=='B92' ) THEN
     !
-    ! size between D2 and D3 and dendricity < 0         
+    ! size between D2 and D3 and dendricity < 0
     ! sphericity is firts preserved, if possible. If not,
     ! denditricity =0
     PSNOWGRAN1N(JST_NEW) = -XX * ZDENTMOYN
@@ -1993,7 +1993,7 @@ DO JST_NEW = 1,KNLVLS_NEW
       !
       ! dendritic snow
       ! inconsistency with ZDIAM ==>  dendricity = 0
-      ! size between D2 and D3 and dendricity == 0          
+      ! size between D2 and D3 and dendricity == 0
       PSNOWGRAN1N(JST_NEW) = XX * ZSPHERMOYN
       PSNOWGRAN2N(JST_NEW) = ZDIAM
       !
@@ -2009,7 +2009,7 @@ DO JST_NEW = 1,KNLVLS_NEW
   PSNOWHISTN(JST_NEW) = NINT( ZHISTMOYN/ZMASTOTN )
   PSNOWAGEN (JST_NEW) = ZAGEMOYN / ZMASTOTN
   !
-ENDDO     
+ENDDO
 !
 !IF (LHOOK) CALL DR_HOOK('GET_MASS_HEAT',1,ZHOOK_HANDLE)
 !
@@ -2038,11 +2038,11 @@ IF ( HSNOWMETAMO=='B92' ) THEN
   !
   IF( PSNOWGRAN1<0. ) THEN
     PDIAM = -PSNOWGRAN1*XD1/XX + (1.+PSNOWGRAN1/XX) * &
-           ( PSNOWGRAN2*XD2/XX + (1.-PSNOWGRAN2/XX) * XD3 ) 
-    PDIAM = PDIAM/10000.      
-  ELSE 
+           ( PSNOWGRAN2*XD2/XX + (1.-PSNOWGRAN2/XX) * XD3 )
+    PDIAM = PDIAM/10000.
+  ELSE
     PDIAM = PSNOWGRAN2*PSNOWGRAN1/XX + &
-            MAX( 0.0004, 0.5*PSNOWGRAN2 ) * ( 1.-PSNOWGRAN1/XX )      
+            MAX( 0.0004, 0.5*PSNOWGRAN2 ) * ( 1.-PSNOWGRAN1/XX )
   ENDIF
   !
 ELSE
@@ -2065,7 +2065,7 @@ END SUBROUTINE GET_DIAM
 !!    PURPOSE
 !!    -------
 !     Calculate snow thermal conductivity from
-!     Sun et al. 1999, J. of Geophys. Res., 104, 19587-19579 (vapor) 
+!     Sun et al. 1999, J. of Geophys. Res., 104, 19587-19579 (vapor)
 !     and Yen, 1981, CRREL Rep 81-10 (snow)
 !     or Anderson, 1976, NOAA Tech. Rep. NWS 19 (snow).
 !
@@ -2076,7 +2076,7 @@ USE MODD_SNOW_PAR, ONLY : XVRKZ6, XSNOWTHRMCOND1, &
                           XSNOWTHRMCOND2,         &
                           XSNOWTHRMCOND_AVAP,     &
                           XSNOWTHRMCOND_BVAP,     &
-                          XSNOWTHRMCOND_CVAP 
+                          XSNOWTHRMCOND_CVAP
 !
 !USE YOMHOOK   ,ONLY : LHOOK,   DR_HOOK
 !USE PARKIND1  ,ONLY : JPRB
@@ -2146,7 +2146,7 @@ FUNCTION SNOW3LDOPT_2D(PSNOWRHO,PSNOWAGE) RESULT(PDOPT)
 !!    -------
 !     Calculate the optical grain diameter.
 !
-USE MODD_SNOW_PAR, ONLY : XDSGRAIN_MAX,XSNOW_AGRAIN, & 
+USE MODD_SNOW_PAR, ONLY : XDSGRAIN_MAX,XSNOW_AGRAIN, &
                           XSNOW_BGRAIN,XSNOW_CGRAIN
 !
 !USE YOMHOOK   ,ONLY : LHOOK,   DR_HOOK
@@ -2183,7 +2183,7 @@ FUNCTION SNOW3LDOPT_1D(PSNOWRHO,PSNOWAGE) RESULT(PDOPT)
 !!    -------
 !     Calculate the optical grain diameter.
 !
-USE MODD_SNOW_PAR, ONLY : XDSGRAIN_MAX,XSNOW_AGRAIN, & 
+USE MODD_SNOW_PAR, ONLY : XDSGRAIN_MAX,XSNOW_AGRAIN, &
                           XSNOW_BGRAIN,XSNOW_CGRAIN
 !
 !USE YOMHOOK   ,ONLY : LHOOK,   DR_HOOK
@@ -2220,7 +2220,7 @@ FUNCTION SNOW3LDOPT_0D(PSNOWRHO,PSNOWAGE) RESULT(PDOPT)
 !!    -------
 !     Calculate the optical grain diameter.
 !
-USE MODD_SNOW_PAR, ONLY : XDSGRAIN_MAX,XSNOW_AGRAIN, & 
+USE MODD_SNOW_PAR, ONLY : XDSGRAIN_MAX,XSNOW_AGRAIN, &
                           XSNOW_BGRAIN,XSNOW_CGRAIN
 !
 !USE YOMHOOK   ,ONLY : LHOOK,   DR_HOOK
@@ -2254,12 +2254,12 @@ END FUNCTION SNOW3LDOPT_0D
 !####################################################################
 !####################################################################
 SUBROUTINE SNOW3LALB(PALBEDOSC,PSPECTRALALBEDO,PSNOWRHO,PSNOWAGE,   &
-                     PPERMSNOWFRAC,PPS)  
+                     PPERMSNOWFRAC,PPS)
 !
 !!    PURPOSE
 !!    -------
 !     Calculate the snow surface albedo. Use the method of
-!     CROCUS with 3 spectral albedo depending on snow density 
+!     CROCUS with 3 spectral albedo depending on snow density
 !     and age
 !
 !
@@ -2357,4 +2357,3 @@ END SUBROUTINE SNOW3LALB
 !####################################################################
 !####################################################################
 END MODULE MODE_SNOW3L
-

--- a/src/Land_models/NoahMP/phys/surfex/mode_surf_coefs.F
+++ b/src/Land_models/NoahMP/phys/surfex/mode_surf_coefs.F
@@ -11,17 +11,17 @@ CONTAINS
 !SFX_LIC for details. version 1.
 !   ######################################################################
     SUBROUTINE SURFACE_AERO_COND(PRI, PZREF, PUREF, PVMOD, PZ0,&
-                                     PZ0H, PAC, PRA, PCH           ) 
+                                     PZ0H, PAC, PRA, PCH           )
 !   ######################################################################
 !
-!!****  *SURFACE_AERO_COND*  
+!!****  *SURFACE_AERO_COND*
 !!
 !!    PURPOSE
 !!    -------
 !
 !     Computes the drag coefficients for heat and momentum near the ground
-!         
-!     
+!
+!
 !!**  METHOD
 !!    ------
 !
@@ -45,11 +45,11 @@ CONTAINS
 !!
 !!    MODD_CST
 !!
-!!      
+!!
 !!    REFERENCE
 !!    ---------
 !!
-!!      
+!!
 !!    AUTHOR
 !!    ------
 !!
@@ -57,7 +57,7 @@ CONTAINS
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    20/01/98 
+!!      Original    20/01/98
 !!                  02/04/01 (P Jabouille) limitation of Z0 with 0.5 PUREF
 !-------------------------------------------------------------------------------
 !
@@ -97,7 +97,7 @@ REAL, DIMENSION(:), INTENT(OUT)   :: PCH      ! drag coefficient for heat
 !
 REAL, DIMENSION(SIZE(PRI)) :: ZZ0, ZZ0H, ZMU,          &
                                ZFH, ZCHSTAR, ZPH, ZCDN, &
-                               ZSTA, ZDI, ZWORK1, ZWORK2, ZWORK3 
+                               ZSTA, ZDI, ZWORK1, ZWORK2, ZWORK3
 REAL, DIMENSION(SIZE(PRI)) :: ZVMOD
 !
 INTEGER                    :: JJ
@@ -132,7 +132,7 @@ DO JJ=1,SIZE(PRI)
   ZCHSTAR(JJ) = CHSTAR(ZMU(JJ))
   ZPH(JJ)     = PH(ZMU(JJ))
 !
-! 
+!
   ZCDN(JJ) = (XKARMAN/ZWORK1(JJ))**2.
 !
 !
@@ -144,13 +144,13 @@ DO JJ=1,SIZE(PRI)
                    +ZCHSTAR(JJ)*ZCDN(JJ)*15.                         &
                                 *ZWORK2(JJ)**ZPH(JJ)  &
                                 *ZFH(JJ) * SQRT(-ZSTA(JJ))           &
-                  ) 
+                  )
     PAC(JJ) = ZCDN(JJ)*(ZVMOD(JJ)-15.* ZSTA(JJ)*ZDI(JJ))*ZFH(JJ)
 
   ELSE
     ZDI(JJ) = SQRT(ZWORK3(JJ) + 5. * ZSTA(JJ) )
     PAC(JJ) = ZCDN(JJ)*ZVMOD(JJ)/(1.+15.*ZSTA(JJ)*ZDI(JJ)  &
-             / ZWORK3(JJ) /ZVMOD(JJ) )*ZFH(JJ)    
+             / ZWORK3(JJ) /ZVMOD(JJ) )*ZFH(JJ)
   ENDIF
 !
   PRA(JJ) = 1. / PAC(JJ)
@@ -166,17 +166,17 @@ END SUBROUTINE SURFACE_AERO_COND
 
 !   #################################################################
     SUBROUTINE SURFACE_CD(PRI, PZREF, PUREF, PZ0EFF, PZ0H,   &
-                              PCD, PCDN) 
+                              PCD, PCDN)
 !   #################################################################
 !
-!!****  *SURFACE_CD*  
+!!****  *SURFACE_CD*
 !!
 !!    PURPOSE
 !!    -------
 !
 !     Computes the drag coefficients for momentum near the ground
-!         
-!     
+!
+!
 !!**  METHOD
 !!    ------
 !
@@ -201,11 +201,11 @@ END SUBROUTINE SURFACE_AERO_COND
 !!    MODD_CST
 !!    MODD_GROUND_PAR
 !!
-!!      
+!!
 !!    REFERENCE
 !!    ---------
 !!
-!!      
+!!
 !!    AUTHOR
 !!    ------
 !!
@@ -213,7 +213,7 @@ END SUBROUTINE SURFACE_AERO_COND
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    20/01/98 
+!!      Original    20/01/98
 !!                  02/04/01 (P Jabouille) limitation of Z0 with 0.5 PUREF
 !-------------------------------------------------------------------------------
 !
@@ -250,7 +250,7 @@ REAL, DIMENSION(:), INTENT(OUT)   :: PCDN     ! neutral drag coefficient for mom
 !
 !
 REAL                       :: ZZ0EFF, ZZ0H, ZMU,     &
-                               ZCMSTAR, ZPM, ZCM, ZFM 
+                               ZCMSTAR, ZPM, ZCM, ZFM
 INTEGER                    :: JJ
 !REAL(KIND=JPRB) :: ZHOOK_HANDLE
 
@@ -298,17 +298,17 @@ END SUBROUTINE SURFACE_CD
 
 !     #########
     SUBROUTINE SURFACE_RI(PTG, PQS, PEXNS, PEXNA, PTA, PQA,   &
-                               PZREF, PUREF, PDIRCOSZW, PVMOD, PRI )  
+                               PZREF, PUREF, PDIRCOSZW, PVMOD, PRI )
 !   ######################################################################
 !
-!!****  *SURFACE_RI*  
+!!****  *SURFACE_RI*
 !!
 !!    PURPOSE
 !!    -------
 !
 !     Computes the richardson number near the ground
-!         
-!     
+!
+!
 !!**  METHOD
 !!    ------
 !
@@ -325,11 +325,11 @@ END SUBROUTINE SURFACE_CD
 !!    MODD_CST
 !!    MODD_GROUND_PAR
 !!
-!!      
+!!
 !!    REFERENCE
 !!    ---------
 !!
-!!      
+!!
 !!    AUTHOR
 !!    ------
 !!
@@ -337,7 +337,7 @@ END SUBROUTINE SURFACE_CD
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    22/09/98 
+!!      Original    22/09/98
 !-------------------------------------------------------------------------------
 !
 !*       0.     DECLARATIONS
@@ -388,23 +388,23 @@ REAL, DIMENSION(SIZE(PVMOD)) :: ZVMOD
 !
 !       1.     Richardson number
 !              -----------------
-!                
+!
 !                                                 virtual potential        
-!                                                 temperature at the 
+!                                                 temperature at the
 !                                                 first atmospheric level and
 !                                                 at the surface
 !
 !IF (LHOOK) CALL DR_HOOK('SURFACE_RI',0,ZHOOK_HANDLE)
 !
-ZTHVA(:)=PTA(:)/PEXNA(:)*( 1.+(XRV/XRD-1.)*PQA(:) )   
+ZTHVA(:)=PTA(:)/PEXNA(:)*( 1.+(XRV/XRD-1.)*PQA(:) )
 ZTHVS(:)=PTG(:)/PEXNS(:)*( 1.+(XRV/XRD-1.)*PQS(:) )
-!                                                 
+!
 ZVMOD(:) = WIND_THRESHOLD(PVMOD(:),PUREF(:))
 !
                                                 ! Richardson's number
 PRI(:) = XG * PDIRCOSZW(:) * PUREF(:) * PUREF(:)              &
           * (ZTHVA(:)-ZTHVS(:)) / (0.5 * (ZTHVA(:)+ZTHVS(:)) )  &
-          / (ZVMOD(:)*ZVMOD(:)) /PZREF(:)  
+          / (ZVMOD(:)*ZVMOD(:)) /PZREF(:)
 !
 PRI(:) = MIN(PRI(:),XRIMAX)
 !
@@ -418,14 +418,14 @@ END SUBROUTINE SURFACE_RI
     FUNCTION WIND_THRESHOLD(PWIND,PUREF) RESULT(PWIND_NEW)
 !   ############################################################################
 !
-!!****  *WIND_THRESHOLD*  
+!!****  *WIND_THRESHOLD*
 !!
 !!    PURPOSE
 !!    -------
 !
 !     Set a minimum value to the wind for exchange coefficient computations.
 !     This minimum value depends on the forcing height
-!     
+!
 !!    AUTHOR
 !!    ------
 !!
@@ -433,7 +433,7 @@ END SUBROUTINE SURFACE_RI
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    09/2007 
+!!      Original    09/2007
 !-------------------------------------------------------------------------------
 !
 USE MODD_SURF_ATM, ONLY: XCISMIN, XVMODMIN, LALDTHRES
@@ -466,7 +466,7 @@ REAL, DIMENSION(SIZE(PWIND))     :: PWIND_NEW  ! modified wind
 !
 !IF (LHOOK) CALL DR_HOOK('WIND_THRESHOLD',0,ZHOOK_HANDLE)
 IF (.NOT.LALDTHRES) THEN
-!        
+!
 !  minimum value for exchange coefficients computations : 1m/s / 10m
    PWIND_NEW = MAX(PWIND , 0.1 * MIN(10.,PUREF) )
 ELSE

--- a/src/Land_models/NoahMP/phys/surfex/mode_thermos.F
+++ b/src/Land_models/NoahMP/phys/surfex/mode_thermos.F
@@ -10,12 +10,12 @@
 !!
 !!    PURPOSE
 !!    -------
-!      
+!
 !
 !!
 !!**  IMPLICIT ARGUMENTS
 !!    ------------------
-!!       NONE          
+!!       NONE
 !!
 !!    REFERENCE
 !!    ---------
@@ -27,13 +27,13 @@
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    28/08/94 
+!!      Original    28/08/94
 !!      Modified    01/2006 : sea flux parameterization.
 !!      B. Decharme 05/2013 : Qsat function of XTT
 !!                            so, Qsat=Qsati if Tg <= XTT and inversely
 !!      S. Belamari 03/2014 : new formula (QSAT_SEAWATER2) for sat. air pressure
 !!                            over seawater (with explicit salinity dependency)
-!!                            
+!!
 !--------------------------------------------------------------------------------
 !
 !*       0.    DECLARATIONS
@@ -55,7 +55,7 @@ INTERFACE DPSAT
 END INTERFACE
 
 INTERFACE QSAT
-  MODULE PROCEDURE QSATW_0D         
+  MODULE PROCEDURE QSATW_0D
   MODULE PROCEDURE QSATW_1D
   MODULE PROCEDURE QSATW_2D
 END INTERFACE
@@ -96,7 +96,7 @@ IMPLICIT NONE
 !
 !
 REAL, INTENT(IN)                :: PT     ! Temperature (Kelvin)
-REAL                            :: PPSAT  ! saturation vapor 
+REAL                            :: PPSAT  ! saturation vapor
                                           ! specific humidity
                                           ! with respect to
                                           ! water (kg/kg)
@@ -118,7 +118,7 @@ ZGAM  = XGAMW
 IF(CQSAT=='NEW'.AND.PT<=XTT)THEN
  ZALP  = XALPI
  ZBETA = XBETAI
- ZGAM  = XGAMI       
+ ZGAM  = XGAMI
 ENDIF
 !
 PPSAT = EXP( ZALP - ZBETA/PT - ZGAM*LOG(PT) )
@@ -168,7 +168,7 @@ IF(CQSAT=='NEW')THEN
  WHERE(PT<=XTT)
    ZALP  (:) = XALPI
    ZBETA (:) = XBETAI
-   ZGAM  (:) = XGAMI 
+   ZGAM  (:) = XGAMI
  ENDWHERE
 ENDIF
 !
@@ -230,7 +230,7 @@ IF(CQSAT=='NEW')THEN
  WHERE(PT(:,:)<=XTT)
    ZALP  (:,:) = XALPI
    ZBETA (:,:) = XBETAI
-   ZGAM  (:,:) = XGAMI 
+   ZGAM  (:,:) = XGAMI
  ENDWHERE
 ENDIF
 !
@@ -269,7 +269,7 @@ IMPLICIT NONE
 !
 REAL, DIMENSION(:), INTENT(IN) :: PT      ! Temperature (Kelvin)
 !
-REAL, DIMENSION(SIZE(PT))      :: PDPSAT  
+REAL, DIMENSION(SIZE(PT))      :: PDPSAT
 !
 REAL, DIMENSION(SIZE(PT))      :: ZBETA, ZGAM
 !
@@ -288,7 +288,7 @@ ZGAM (:) = XGAMW
 IF(CQSAT=='NEW')THEN
  WHERE(PT<=XTT)
    ZBETA (:) = XBETAI
-   ZGAM  (:) = XGAMI 
+   ZGAM  (:) = XGAMI
  ENDWHERE
 ENDIF
 !
@@ -308,26 +308,26 @@ END FUNCTION DPSAT_1D
 !!
 !!    PURPOSE
 !!    -------
-!       The purpose of this function is to compute the saturation vapor 
-!     pressure from temperature 
-!      
+!       The purpose of this function is to compute the saturation vapor
+!     pressure from temperature
+!
 !
 !!**  METHOD
 !!    ------
 !!       Given temperature T (PT), the saturation vapor pressure es(T)
 !!    (FOES(PT)) is computed by integration of the Clapeyron equation
 !!    from the triple point temperature Tt (XTT) and the saturation vapor 
-!!    pressure of the triple point es(Tt) (XESTT), i.e  
-!!     
+!!    pressure of the triple point es(Tt) (XESTT), i.e
+!!
 !!         es(T)= EXP( alphaw - betaw /T - gammaw Log(T) )
-!!  
+!!
 !!     with :
-!!       alphaw (XALPW) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt) 
+!!       alphaw (XALPW) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt)
 !!       betaw (XBETAW) = Lv(Tt)/Rv + gammaw Tt
 !!       gammaw (XGAMW) = (Cl -Cpv) /Rv
 !!
 !!      Then, the specific humidity at saturation is deduced.
-!!  
+!!
 !!
 !!    EXTERNAL
 !!    --------
@@ -338,11 +338,11 @@ END FUNCTION DPSAT_1D
 !!      Module MODD_CST : comtains physical constants
 !!        XALPW   : Constant for saturation vapor pressure function
 !!        XBETAW  : Constant for saturation vapor pressure function
-!!        XGAMW   : Constant for saturation vapor pressure function  
-!!      
+!!        XGAMW   : Constant for saturation vapor pressure function
+!!
 !!    REFERENCE
 !!    ---------
-!!      Book2 of documentation of Meso-NH 
+!!      Book2 of documentation of Meso-NH
 !!
 !!
 !!    AUTHOR
@@ -351,7 +351,7 @@ END FUNCTION DPSAT_1D
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    21/09/98 
+!!      Original    21/09/98
 !-------------------------------------------------------------------------------
 !
 !*       0.    DECLARATIONS
@@ -366,16 +366,16 @@ IMPLICIT NONE
 !
 REAL, INTENT(IN)                :: PT     ! Temperature (Kelvin)
 REAL, INTENT(IN)                :: PP     ! Pressure (Pa)
-REAL                            :: PQSAT  ! saturation vapor 
+REAL                            :: PQSAT  ! saturation vapor
                                                         ! specific humidity
                                                         ! with respect to
                                                         ! water (kg/kg)
 !
 !*       0.2   Declarations of local variables
 !
-REAL                           :: ZFOES  ! saturation vapor 
+REAL                           :: ZFOES  ! saturation vapor
                                                         ! pressure
-                                                        ! (Pascal) 
+                                                        ! (Pascal)
 !
 REAL                           :: ZWORK1
 REAL                           :: ZWORK2
@@ -410,26 +410,26 @@ END FUNCTION QSATW_0D
 !!
 !!    PURPOSE
 !!    -------
-!       The purpose of this function is to compute the saturation vapor 
-!     pressure from temperature 
-!      
+!       The purpose of this function is to compute the saturation vapor
+!     pressure from temperature
+!
 !
 !!**  METHOD
 !!    ------
 !!       Given temperature T (PT), the saturation vapor pressure es(T)
 !!    (FOES(PT)) is computed by integration of the Clapeyron equation
 !!    from the triple point temperature Tt (XTT) and the saturation vapor 
-!!    pressure of the triple point es(Tt) (XESTT), i.e  
-!!     
+!!    pressure of the triple point es(Tt) (XESTT), i.e
+!!
 !!         es(T)= EXP( alphaw - betaw /T - gammaw Log(T) )
-!!  
+!!
 !!     with :
-!!       alphaw (XALPW) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt) 
+!!       alphaw (XALPW) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt)
 !!       betaw (XBETAW) = Lv(Tt)/Rv + gammaw Tt
 !!       gammaw (XGAMW) = (Cl -Cpv) /Rv
 !!
 !!      Then, the specific humidity at saturation is deduced.
-!!  
+!!
 !!
 !!    EXTERNAL
 !!    --------
@@ -440,11 +440,11 @@ END FUNCTION QSATW_0D
 !!      Module MODD_CST : comtains physical constants
 !!        XALPW   : Constant for saturation vapor pressure function
 !!        XBETAW  : Constant for saturation vapor pressure function
-!!        XGAMW   : Constant for saturation vapor pressure function  
-!!      
+!!        XGAMW   : Constant for saturation vapor pressure function
+!!
 !!    REFERENCE
 !!    ---------
-!!      Book2 of documentation of Meso-NH 
+!!      Book2 of documentation of Meso-NH
 !!
 !!
 !!    AUTHOR
@@ -453,7 +453,7 @@ END FUNCTION QSATW_0D
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    21/09/98 
+!!      Original    21/09/98
 !-------------------------------------------------------------------------------
 !
 !*       0.    DECLARATIONS
@@ -479,10 +479,10 @@ REAL, DIMENSION(SIZE(PT))                   :: PQSAT  ! saturation vapor
 !
 REAL, DIMENSION(SIZE(PT))                   :: ZFOES  ! saturation vapor 
                                                         ! pressure
-                                                        ! (Pascal) 
+                                                        ! (Pascal)
 !
 REAL, DIMENSION(SIZE(PT))                   :: ZWORK1
-REAL                                        :: ZWORK2 
+REAL                                        :: ZWORK2
 !REAL(KIND=JPRB) :: ZHOOK_HANDLE
 !-------------------------------------------------------------------------------
 !
@@ -519,26 +519,26 @@ END FUNCTION QSATW_1D
 !!
 !!    PURPOSE
 !!    -------
-!       The purpose of this function is to compute the saturation vapor 
-!     pressure from temperature 
-!      
+!       The purpose of this function is to compute the saturation vapor
+!     pressure from temperature
+!
 !
 !!**  METHOD
 !!    ------
 !!       Given temperature T (PT), the saturation vapor pressure es(T)
 !!    (FOES(PT)) is computed by integration of the Clapeyron equation
 !!    from the triple point temperature Tt (XTT) and the saturation vapor 
-!!    pressure of the triple point es(Tt) (XESTT), i.e  
-!!     
+!!    pressure of the triple point es(Tt) (XESTT), i.e
+!!
 !!         es(T)= EXP( alphaw - betaw /T - gammaw Log(T) )
-!!  
+!!
 !!     with :
-!!       alphaw (XALPW) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt) 
+!!       alphaw (XALPW) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt)
 !!       betaw (XBETAW) = Lv(Tt)/Rv + gammaw Tt
 !!       gammaw (XGAMW) = (Cl -Cpv) /Rv
 !!
 !!      Then, the specific humidity at saturation is deduced.
-!!  
+!!
 !!
 !!    EXTERNAL
 !!    --------
@@ -549,11 +549,11 @@ END FUNCTION QSATW_1D
 !!      Module MODD_CST : comtains physical constants
 !!        XALPW   : Constant for saturation vapor pressure function
 !!        XBETAW  : Constant for saturation vapor pressure function
-!!        XGAMW   : Constant for saturation vapor pressure function  
-!!      
+!!        XGAMW   : Constant for saturation vapor pressure function
+!!
 !!    REFERENCE
 !!    ---------
-!!      Book2 of documentation of Meso-NH 
+!!      Book2 of documentation of Meso-NH
 !!
 !!
 !!    AUTHOR
@@ -562,7 +562,7 @@ END FUNCTION QSATW_1D
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    21/09/98 
+!!      Original    21/09/98
 !-------------------------------------------------------------------------------
 !
 !*       0.    DECLARATIONS
@@ -580,7 +580,7 @@ REAL, DIMENSION(:,:), INTENT(IN)              :: PT     ! Temperature
                                                         ! (Kelvin)
 REAL, DIMENSION(:,:), INTENT(IN)              :: PP     ! Pressure
                                                         ! (Pa)
-!                                                        
+!
 INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL   :: KMASK
 !                                                KMASK = Number of soil moisture layers (DIF option)
 INTEGER,               INTENT(IN), OPTIONAL   :: KL
@@ -607,7 +607,7 @@ IF(PRESENT(KMASK).AND.PRESENT(KL))THEN
   IMASK(:)=KMASK(:)
   INL=KL
 ELSE
-  IMASK(:)=SIZE(PT,2)  
+  IMASK(:)=SIZE(PT,2)
   INL=SIZE(PT,2)
 ENDIF
 !
@@ -615,7 +615,7 @@ ENDIF
 PQSAT(:,:)=XUNDEF
 ZFOES(:,:)=0.0
 !
-!  
+!
 !*       1.    COMPUTE SATURATION VAPOR PRESSURE
 !              ---------------------------------
 !
@@ -644,27 +644,27 @@ END FUNCTION QSATW_2D
 !!
 !!    PURPOSE
 !!    -------
-!       The purpose of this function is to compute the saturation vapor 
+!       The purpose of this function is to compute the saturation vapor
 !     pressure from temperature over saline seawater
-!      
+!
 !
 !!**  METHOD
 !!    ------
 !!       Given temperature T (PT), the saturation vapor pressure es(T)
 !!    (FOES(PT)) is computed by integration of the Clapeyron equation
 !!    from the triple point temperature Tt (XTT) and the saturation vapor 
-!!    pressure of the triple point es(Tt) (XESTT), i.e  
+!!    pressure of the triple point es(Tt) (XESTT), i.e
 !!    The reduction due to salinity is compute with the factor 0.98 (reduction of 2%)
-!!     
+!!
 !!         es(T)= 0.98*EXP( alphaw - betaw /T - gammaw Log(T) )
-!!  
+!!
 !!     with :
-!!       alphaw (XALPW) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt) 
+!!       alphaw (XALPW) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt)
 !!       betaw (XBETAW) = Lv(Tt)/Rv + gammaw Tt
 !!       gammaw (XGAMW) = (Cl -Cpv) /Rv
 !!
 !!      Then, the specific humidity at saturation is deduced.
-!!  
+!!
 !!
 !!    EXTERNAL
 !!    --------
@@ -675,11 +675,11 @@ END FUNCTION QSATW_2D
 !!      Module MODD_CST : comtains physical constants
 !!        XALPW   : Constant for saturation vapor pressure function
 !!        XBETAW  : Constant for saturation vapor pressure function
-!!        XGAMW   : Constant for saturation vapor pressure function  
-!!      
+!!        XGAMW   : Constant for saturation vapor pressure function
+!!
 !!    REFERENCE
 !!    ---------
-!!      Book2 of documentation of Meso-NH 
+!!      Book2 of documentation of Meso-NH
 !!      Zeng, X., Zhao, M., and Dickinson, R. E., 1998 : Intercomparaison of bulk
 !!      aerodynamic algorithm for the computation of sea surface fluxes using
 !!      TOGA COARE and TAO data. Journal of Climate, vol 11, n°10, pp 2628--2644
@@ -691,7 +691,7 @@ END FUNCTION QSATW_2D
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    6/04/2005 
+!!      Original    6/04/2005
 !-------------------------------------------------------------------------------
 !
 !*       0.    DECLARATIONS
@@ -717,7 +717,7 @@ REAL, DIMENSION(SIZE(PT))                   :: PQSAT  ! saturation vapor
 !
 REAL, DIMENSION(SIZE(PT))                   :: ZFOES  ! saturation vapor 
                                                         ! pressure
-                                                        ! (Pascal) 
+                                                        ! (Pascal)
 !
 REAL, DIMENSION(SIZE(PT))                   :: ZWORK1
 REAL                                        :: ZWORK2
@@ -730,7 +730,7 @@ ZFOES (:) = PSAT(PT(:))
 ZFOES (:) = 0.98*ZFOES(:)
 ! vapor pressure reduction of 2% over saline seawater could have a significant 
 ! impact on the computation of surface latent heat flux under strong wind 
-! conditions (Zeng et al, 1998). 
+! conditions (Zeng et al, 1998).
 !
 ZWORK1(:) = ZFOES(:)/PP(:)
 ZWORK2    = XRD/XRV
@@ -757,9 +757,9 @@ END FUNCTION QSATSEAW_1D
 !!
 !!    PURPOSE
 !!    -------
-!       The purpose of this function is to compute the saturation vapor 
+!       The purpose of this function is to compute the saturation vapor
 !     pressure from temperature over saline seawater
-!      
+!
 !
 !!**  METHOD
 !!    ------
@@ -768,7 +768,7 @@ END FUNCTION QSATSEAW_1D
 !!    (1980).
 !!
 !!      Then, the specific humidity at saturation is deduced.
-!!  
+!!
 !!
 !!    EXTERNAL
 !!    --------
@@ -777,7 +777,7 @@ END FUNCTION QSATSEAW_1D
 !!    IMPLICIT ARGUMENTS
 !!    ------------------
 !!      Module MODD_CST : contains physical constants
-!!      
+!!
 !!    REFERENCE
 !!    ---------
 !!      Weiss, R.F., and Price, B.A., 1980 : Nitrous oxide solubility in water
@@ -790,7 +790,7 @@ END FUNCTION QSATSEAW_1D
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    19/03/2014 
+!!      Original    19/03/2014
 !-------------------------------------------------------------------------------
 !
 !*       0.    DECLARATIONS
@@ -858,28 +858,28 @@ END FUNCTION QSATSEAW2_1D
 !!
 !!    PURPOSE
 !!    -------
-!       The purpose of this function is to compute the saturation vapor 
-!     pressure from temperature 
-!      
+!       The purpose of this function is to compute the saturation vapor
+!     pressure from temperature
+!
 !
 !!**  METHOD
 !!    ------
 !!       Given temperature T (PT), the saturation vapor pressure es(T)
 !!    (FOES(PT)) is computed by integration of the Clapeyron equation
 !!    from the triple point temperature Tt (XTT) and the saturation vapor 
-!!    pressure of the triple point es(Tt) (XESTT), i.e  
-!!     
+!!    pressure of the triple point es(Tt) (XESTT), i.e
+!!
 !!         es(T)= EXP( alphaw - betaw /T - gammaw Log(T) )
-!!  
+!!
 !!     with :
-!!       alphaw (XALPW) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt) 
+!!       alphaw (XALPW) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt)
 !!       betaw (XBETAW) = Lv(Tt)/Rv + gammaw Tt
 !!       gammaw (XGAMW) = (Cl -Cpv) /Rv
 !!
 !!      Then, the specific humidity at saturation is deduced.
 !!
 !!      Finally, dqsat / dT  (T) is computed.
-!!  
+!!
 !!
 !!    EXTERNAL
 !!    --------
@@ -890,11 +890,11 @@ END FUNCTION QSATSEAW2_1D
 !!      Module MODD_CST : comtains physical constants
 !!        XALPW   : Constant for saturation vapor pressure function
 !!        XBETAW  : Constant for saturation vapor pressure function
-!!        XGAMW   : Constant for saturation vapor pressure function  
-!!      
+!!        XGAMW   : Constant for saturation vapor pressure function
+!!
 !!    REFERENCE
 !!    ---------
-!!      Book2 of documentation of Meso-NH 
+!!      Book2 of documentation of Meso-NH
 !!
 !!
 !!    AUTHOR
@@ -903,13 +903,13 @@ END FUNCTION QSATSEAW2_1D
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    21/09/98 
+!!      Original    21/09/98
 !-------------------------------------------------------------------------------
 !
 !*       0.    DECLARATIONS
 !              ------------
 !
-USE MODD_CSTS       
+USE MODD_CSTS
 !
 IMPLICIT NONE
 !
@@ -933,9 +933,9 @@ REAL, DIMENSION(SIZE(PT))                   :: PDQSAT ! derivative according
 !
 !*       0.2   Declarations of local variables
 !
-REAL, DIMENSION(SIZE(PT))  :: ZFOES  ! saturation vapor 
+REAL, DIMENSION(SIZE(PT))  :: ZFOES  ! saturation vapor
                                                           ! pressure
-                                                          ! (Pascal) 
+                                                          ! (Pascal)
 !
 REAL                       :: ZWORK1
 REAL, DIMENSION(SIZE(PT))  :: ZWORK2
@@ -975,28 +975,28 @@ END FUNCTION DQSATW_O_DT_1D
 !!
 !!    PURPOSE
 !!    -------
-!       The purpose of this function is to compute the saturation vapor 
-!     pressure from temperature 
-!      
+!       The purpose of this function is to compute the saturation vapor
+!     pressure from temperature
+!
 !
 !!**  METHOD
 !!    ------
 !!       Given temperature T (PT), the saturation vapor pressure es(T)
 !!    (FOES(PT)) is computed by integration of the Clapeyron equation
 !!    from the triple point temperature Tt (XTT) and the saturation vapor 
-!!    pressure of the triple point es(Tt) (XESTT), i.e  
-!!     
+!!    pressure of the triple point es(Tt) (XESTT), i.e
+!!
 !!         es(T)= EXP( alphaw - betaw /T - gammaw Log(T) )
-!!  
+!!
 !!     with :
-!!       alphaw (XALPW) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt) 
+!!       alphaw (XALPW) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt)
 !!       betaw (XBETAW) = Lv(Tt)/Rv + gammaw Tt
 !!       gammaw (XGAMW) = (Cl -Cpv) /Rv
 !!
 !!      Then, the specific humidity at saturation is deduced.
 !!
 !!      Finally, dqsat / dT  (T) is computed.
-!!  
+!!
 !!
 !!    EXTERNAL
 !!    --------
@@ -1007,11 +1007,11 @@ END FUNCTION DQSATW_O_DT_1D
 !!      Module MODD_CST : comtains physical constants
 !!        XALPW   : Constant for saturation vapor pressure function
 !!        XBETAW  : Constant for saturation vapor pressure function
-!!        XGAMW   : Constant for saturation vapor pressure function  
-!!      
+!!        XGAMW   : Constant for saturation vapor pressure function
+!!
 !!    REFERENCE
 !!    ---------
-!!      Book2 of documentation of Meso-NH 
+!!      Book2 of documentation of Meso-NH
 !!
 !!
 !!    AUTHOR
@@ -1020,13 +1020,13 @@ END FUNCTION DQSATW_O_DT_1D
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    21/09/98 
+!!      Original    21/09/98
 !-------------------------------------------------------------------------------
 !
 !*       0.    DECLARATIONS
 !              ------------
 !
-USE MODD_CSTS       
+USE MODD_CSTS
 !
 IMPLICIT NONE
 !
@@ -1052,7 +1052,7 @@ REAL,    DIMENSION(SIZE(PT))                    :: PDQSAT ! derivative according
 !
 REAL, DIMENSION(SIZE(PT))                       :: ZFOES  ! saturation vapor 
                                                           ! pressure
-                                                          ! (Pascal) 
+                                                          ! (Pascal)
 !
 REAL                      :: ZWORK1
 REAL, DIMENSION(SIZE(PT)) :: ZWORK2
@@ -1092,26 +1092,26 @@ END FUNCTION DQSATI_O_DT_1D
 !!
 !!    PURPOSE
 !!    -------
-!       The purpose of this function is to compute the saturation vapor 
-!     pressure from temperature 
-!      
+!       The purpose of this function is to compute the saturation vapor
+!     pressure from temperature
+!
 !
 !!**  METHOD
 !!    ------
 !!       Given temperature T (PT), the saturation vapor pressure es(T)
 !!    (FOES(PT)) is computed by integration of the Clapeyron equation
 !!    from the triple point temperature Tt (XTT) and the saturation vapor 
-!!    pressure of the triple point es(Tt) (XESTT), i.e  
-!!     
+!!    pressure of the triple point es(Tt) (XESTT), i.e
+!!
 !!         es(T)= EXP( alphaw - betaw /T - gammaw Log(T) )
-!!  
+!!
 !!     with :
-!!       alphaw (XALPI) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt) 
+!!       alphaw (XALPI) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt)
 !!       betaw (XBETAI) = Lv(Tt)/Rv + gammaw Tt
 !!       gammaw (XGAMI) = (Cl -Cpv) /Rv
 !!
 !!      Then, the specific humidity at saturation is deduced.
-!!  
+!!
 !!
 !!    EXTERNAL
 !!    --------
@@ -1122,11 +1122,11 @@ END FUNCTION DQSATI_O_DT_1D
 !!      Module MODD_CST : comtains physical constants
 !!        XALPI   : Constant for saturation vapor pressure function
 !!        XBETAI  : Constant for saturation vapor pressure function
-!!        XGAMI   : Constant for saturation vapor pressure function  
-!!      
+!!        XGAMI   : Constant for saturation vapor pressure function
+!!
 !!    REFERENCE
 !!    ---------
-!!      Book2 of documentation of Meso-NH 
+!!      Book2 of documentation of Meso-NH
 !!
 !!
 !!    AUTHOR
@@ -1135,13 +1135,13 @@ END FUNCTION DQSATI_O_DT_1D
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    21/09/98 
+!!      Original    21/09/98
 !-------------------------------------------------------------------------------
 !
 !*       0.    DECLARATIONS
 !              ------------
 !
-USE MODD_CSTS       
+USE MODD_CSTS
 !
 IMPLICIT NONE
 !
@@ -1161,7 +1161,7 @@ REAL, DIMENSION(SIZE(PT))                   :: PQSAT  ! saturation vapor
 !
 REAL, DIMENSION(SIZE(PT))                   :: ZFOES  ! saturation vapor 
                                                         ! pressure
-                                                        ! (Pascal) 
+                                                        ! (Pascal)
 !
 REAL, DIMENSION(SIZE(PT))                   :: ZWORK1
 REAL                                        :: ZWORK2
@@ -1199,26 +1199,26 @@ END FUNCTION QSATI_1D
 !!
 !!    PURPOSE
 !!    -------
-!       The purpose of this function is to compute the saturation vapor 
-!     pressure from temperature 
-!      
+!       The purpose of this function is to compute the saturation vapor
+!     pressure from temperature
+!
 !
 !!**  METHOD
 !!    ------
 !!       Given temperature T (PT), the saturation vapor pressure es(T)
 !!    (FOES(PT)) is computed by integration of the Clapeyron equation
 !!    from the triple point temperature Tt (XTT) and the saturation vapor 
-!!    pressure of the triple point es(Tt) (XESTT), i.e  
-!!     
+!!    pressure of the triple point es(Tt) (XESTT), i.e
+!!
 !!         es(T)= EXP( alphaw - betaw /T - gammaw Log(T) )
-!!  
+!!
 !!     with :
-!!       alphaw (XALPI) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt) 
+!!       alphaw (XALPI) = LOG(es(Tt))+ betaw/Tt + gammaw Log(Tt)
 !!       betaw (XBETAI) = Lv(Tt)/Rv + gammaw Tt
 !!       gammaw (XGAMI) = (Cl -Cpv) /Rv
 !!
 !!      Then, the specific humidity at saturation is deduced.
-!!  
+!!
 !!
 !!    EXTERNAL
 !!    --------
@@ -1229,11 +1229,11 @@ END FUNCTION QSATI_1D
 !!      Module MODD_CST : comtains physical constants
 !!        XALPI   : Constant for saturation vapor pressure function
 !!        XBETAI  : Constant for saturation vapor pressure function
-!!        XGAMI   : Constant for saturation vapor pressure function  
-!!      
+!!        XGAMI   : Constant for saturation vapor pressure function
+!!
 !!    REFERENCE
 !!    ---------
-!!      Book2 of documentation of Meso-NH 
+!!      Book2 of documentation of Meso-NH
 !!
 !!
 !!    AUTHOR
@@ -1242,14 +1242,14 @@ END FUNCTION QSATI_1D
 !!
 !!    MODIFICATIONS
 !!    -------------
-!!      Original    21/09/98 
+!!      Original    21/09/98
 !-------------------------------------------------------------------------------
 !
 !*       0.    DECLARATIONS
 !              ------------
 !
 USE MODD_SNOW_PAR,  ONLY : XUNDEF
-USE MODD_CSTS       
+USE MODD_CSTS
 !
 IMPLICIT NONE
 !
@@ -1260,12 +1260,12 @@ REAL, DIMENSION(:,:), INTENT(IN)            :: PT     ! Temperature
                                                       ! (Kelvin)
 REAL, DIMENSION(:,:), INTENT(IN)            :: PP     ! Pressure
                                                       ! (Pa)
-!                                                        
+!
 INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL   :: KMASK
 !                                                KMASK = Number of soil moisture layers (DIF option)
 INTEGER,               INTENT(IN), OPTIONAL   :: KL
 !                                                KL = Max number of soil moisture layers (DIF option)
-!                                                      
+!
 REAL, DIMENSION(SIZE(PT,1),SIZE(PT,2))      :: PQSAT  ! saturation vapor 
                                                       ! specific humidity
                                                       ! with respect to
@@ -1284,17 +1284,17 @@ INTEGER         :: INL
 !IF (LHOOK) CALL DR_HOOK('MODE_THERMOS:QSATI_2D',0,ZHOOK_HANDLE)
 !
 IF(PRESENT(KMASK))THEN
-  IMASK(:)=KMASK(:)    
+  IMASK(:)=KMASK(:)
   INL=KL
 ELSE
-  IMASK(:)=SIZE(PT,2)  
+  IMASK(:)=SIZE(PT,2)
   INL=SIZE(PT,2)
 ENDIF
 !
 PQSAT(:,:)=XUNDEF
 ZFOES(:,:)=0.0
 !
-!  
+!
 !*       1.    COMPUTE SATURATION VAPOR PRESSURE
 !              ---------------------------------
 !

--- a/src/Land_models/NoahMP/phys/surfex/tridiag_ground_snowcro.F
+++ b/src/Land_models/NoahMP/phys/surfex/tridiag_ground_snowcro.F
@@ -2,7 +2,7 @@
 !SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
 !SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
 !SFX_LIC for details. version 1.
-MODULE MODI_TRIDIAG_GROUND_SNOWCRO 
+MODULE MODI_TRIDIAG_GROUND_SNOWCRO
 !
 INTERFACE TRIDIAG_GROUND_SNOWCRO
 !
@@ -10,9 +10,9 @@ SUBROUTINE TRIDIAG_GROUND_SNOWCRO_1D(PA,PB,PC,PY,PX,KNLVLS_USE,KDIFLOOP)
 REAL,    DIMENSION(:,:), INTENT(IN)  :: PA  ! lower diag. elements of A matrix
 REAL,    DIMENSION(:,:), INTENT(IN)  :: PB  ! main  diag. elements of A matrix
 REAL,    DIMENSION(:,:), INTENT(IN)  :: PC  ! upper diag. elements of A matrix
-REAL,    DIMENSION(:,:), INTENT(IN)  :: PY  ! r.h.s. term   
+REAL,    DIMENSION(:,:), INTENT(IN)  :: PY  ! r.h.s. term
 !
-REAL,    DIMENSION(:,:), INTENT(OUT) :: PX  ! solution of A.X = Y 
+REAL,    DIMENSION(:,:), INTENT(OUT) :: PX  ! solution of A.X = Y
 !
 INTEGER,    DIMENSION(:), INTENT(IN) :: KNLVLS_USE ! number of effective layers 
 !
@@ -23,9 +23,9 @@ SUBROUTINE TRIDIAG_GROUND_SNOWCRO_2D(PA,PB,PC,PY,PX,KNLVLS_USE,KDIFLOOP)
 REAL,    DIMENSION(:,:,:), INTENT(IN)  :: PA  ! lower diag. elements of A matrix
 REAL,    DIMENSION(:,:,:), INTENT(IN)  :: PB  ! main  diag. elements of A matrix
 REAL,    DIMENSION(:,:,:), INTENT(IN)  :: PC  ! upper diag. elements of A matrix
-REAL,    DIMENSION(:,:,:), INTENT(IN)  :: PY  ! r.h.s. term   
+REAL,    DIMENSION(:,:,:), INTENT(IN)  :: PY  ! r.h.s. term
 !
-REAL,    DIMENSION(:,:,:), INTENT(OUT) :: PX  ! solution of A.X = Y 
+REAL,    DIMENSION(:,:,:), INTENT(OUT) :: PX  ! solution of A.X = Y
 !
 INTEGER,    DIMENSION(:,:), INTENT(IN) :: KNLVLS_USE ! number of effective layers 
 !
@@ -57,7 +57,7 @@ END MODULE MODI_TRIDIAG_GROUND_SNOWCRO
 !
 !!**   METHOD
 !!     ------
-!!                      
+!!
 !!        Then, the classical tridiagonal algorithm is used to invert the 
 !!     implicit operator. Its matrix is given by:
 !!
@@ -88,12 +88,12 @@ END MODULE MODI_TRIDIAG_GROUND_SNOWCRO
 !!     AUTHOR
 !!     ------
 !!       V. Masson
-!! 
+!!
 !!     MODIFICATIONS
 !!     -------------
 !!       Original        May 13, 1998
 !!       05/2011: Brun  Special treatment to tackle the variable number
-!!                      of snow layers 
+!!                      of snow layers
 !!                      In case of second call, a shift of 1 snow layer
 !!                      is applied in the control loops.
 !! ---------------------------------------------------------------------
@@ -110,9 +110,9 @@ IMPLICIT NONE
 REAL,    DIMENSION(:,:), INTENT(IN)  :: PA  ! lower diag. elements of A matrix
 REAL,    DIMENSION(:,:), INTENT(IN)  :: PB  ! main  diag. elements of A matrix
 REAL,    DIMENSION(:,:), INTENT(IN)  :: PC  ! upper diag. elements of A matrix
-REAL,    DIMENSION(:,:), INTENT(IN)  :: PY  ! r.h.s. term   
+REAL,    DIMENSION(:,:), INTENT(IN)  :: PY  ! r.h.s. term
 !
-REAL,    DIMENSION(:,:), INTENT(OUT) :: PX  ! solution of A.X = Y 
+REAL,    DIMENSION(:,:), INTENT(OUT) :: PX  ! solution of A.X = Y
 !
 INTEGER,    DIMENSION(:), INTENT(IN) :: KNLVLS_USE ! number of effective layers 
 !
@@ -210,7 +210,7 @@ END SUBROUTINE TRIDIAG_GROUND_SNOWCRO_1D
 !
 !!**   METHOD
 !!     ------
-!!                      
+!!
 !!        Then, the classical tridiagonal algorithm is used to invert the 
 !!     implicit operator. Its matrix is given by:
 !!
@@ -241,12 +241,12 @@ END SUBROUTINE TRIDIAG_GROUND_SNOWCRO_1D
 !!     AUTHOR
 !!     ------
 !!       V. Masson
-!! 
+!!
 !!     MODIFICATIONS
 !!     -------------
 !!       Original        May 13, 1998
 !!       05/2011: Brun  Special treatment to tackle the variable number
-!!                      of snow layers 
+!!                      of snow layers
 !!                      In case of second call, a shift of 1 snow layer
 !!                      is applied in the control loops.
 !! ---------------------------------------------------------------------
@@ -263,9 +263,9 @@ IMPLICIT NONE
 REAL,    DIMENSION(:,:,:), INTENT(IN)  :: PA  ! lower diag. elements of A matrix
 REAL,    DIMENSION(:,:,:), INTENT(IN)  :: PB  ! main  diag. elements of A matrix
 REAL,    DIMENSION(:,:,:), INTENT(IN)  :: PC  ! upper diag. elements of A matrix
-REAL,    DIMENSION(:,:,:), INTENT(IN)  :: PY  ! r.h.s. term   
+REAL,    DIMENSION(:,:,:), INTENT(IN)  :: PY  ! r.h.s. term
 !
-REAL,    DIMENSION(:,:,:), INTENT(OUT) :: PX  ! solution of A.X = Y 
+REAL,    DIMENSION(:,:,:), INTENT(OUT) :: PX  ! solution of A.X = Y
 !
 INTEGER,    DIMENSION(:,:), INTENT(IN) :: KNLVLS_USE ! number of effective layers 
 !

--- a/src/MPP/CPL_WRF.F
+++ b/src/MPP/CPL_WRF.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 !   This is used as a coupler with the WRF model.
@@ -28,7 +28,7 @@ MODULE MODULE_CPL_LAND
 
   integer, public :: HYDRO_COMM_WORLD = MPI_COMM_NULL
   integer my_global_id
- 
+
   integer total_pe_num
   integer global_ix,global_jx
 
@@ -60,12 +60,12 @@ MODULE MODULE_CPL_LAND
       integer ierr
       logical mpi_inited
       integer istart,iend,jstart,jend
-      
+
       integer :: xx, ndim
       integer, dimension(0:1) :: dims, coords
       logical cyclic(0:1), reorder
       data cyclic/.false.,.false./  ! not cyclic
-      data reorder/.false./   
+      data reorder/.false./
 
       CALL mpi_initialized( mpi_inited, ierr )
       if ( .NOT. mpi_inited ) then
@@ -110,20 +110,20 @@ MODULE MODULE_CPL_LAND
 	  dims(1) = dims(1)+1
 	endif
       enddo
-      
+
       ndim = 2
       np_up_down = dims(0)
       np_left_right = dims(1)
 
       call MPI_Cart_create(HYDRO_COMM_WORLD, ndim, dims, &
                           cyclic, reorder, cartGridComm, ierr)
-     
+
       call MPI_CART_GET(cartGridComm, 2, dims, cyclic, coords, ierr)
-     
+
       p_up_down = coords(0)
       p_left_right = coords(1)
 
-      initialized = .false.  ! land model need to be initialized. 
+      initialized = .false.  ! land model need to be initialized.
       return
   END subroutine CPL_LAND_INIT
 
@@ -132,18 +132,18 @@ MODULE MODULE_CPL_LAND
         integer,allocatable,dimension(:,:) :: tmp_info
         integer  ierr, i,size, tag
         integer mpp_status(MPI_STATUS_SIZE)
-        tag  = 9 
+        tag  = 9
         size =  9
 
         if(my_global_id .eq. 0) then
-           do i = 1, total_pe_num-1 
+           do i = 1, total_pe_num-1
              call mpi_recv(node_info(:,i+1),size,MPI_INTEGER,  &
                 i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
            enddo
         else
            call mpi_send(node_info(:,my_global_id+1),size,   &
                MPI_INTEGER,0,tag,HYDRO_COMM_WORLD,ierr)
-        endif 
+        endif
 
         call MPI_barrier( HYDRO_COMM_WORLD ,ierr)
 
@@ -159,16 +159,16 @@ MODULE MODULE_CPL_LAND
      subroutine find_left()
           implicit none
           integer i
-          
+
           node_info(2,my_global_id+1) = -1
 
-          do i = 1, total_pe_num 
+          do i = 1, total_pe_num
                if( (node_info(8,i).eq.node_info(8,my_global_id+1)) .and. &
                    (node_info(9,i).eq.node_info(9,my_global_id+1)) .and. &
                    ((node_info(7,i)+1).eq.node_info(6,my_global_id+1)) ) then
                    node_info(2,my_global_id+1) = i - 1
                    return
-               endif 
+               endif
           end do
      return
      end subroutine find_left
@@ -176,16 +176,16 @@ MODULE MODULE_CPL_LAND
      subroutine find_right()
           implicit none
           integer i
-          
+
           node_info(3,my_global_id+1) = -1
 
-          do i = 1, total_pe_num 
+          do i = 1, total_pe_num
                if( (node_info(8,i).eq.node_info(8,my_global_id+1)) .and. &
                    (node_info(9,i).eq.node_info(9,my_global_id+1)) .and. &
                    ((node_info(6,i)-1).eq.node_info(7,my_global_id+1)) ) then
                    node_info(3,my_global_id+1) = i - 1
                    return
-               endif 
+               endif
           end do
      return
      end subroutine find_right
@@ -193,16 +193,16 @@ MODULE MODULE_CPL_LAND
      subroutine find_up()
           implicit none
           integer i
-          
+
           node_info(4,my_global_id+1) = -1
 
-          do i = 1, total_pe_num 
+          do i = 1, total_pe_num
                if( (node_info(6,i).eq.node_info(6,my_global_id+1)) .and. &
                    (node_info(7,i).eq.node_info(7,my_global_id+1)) .and. &
                    ((node_info(8,i)-1).eq.node_info(9,my_global_id+1)) ) then
                    node_info(4,my_global_id+1) = i - 1
                    return
-               endif 
+               endif
           end do
      return
      end subroutine find_up
@@ -210,16 +210,16 @@ MODULE MODULE_CPL_LAND
      subroutine find_down()
           implicit none
           integer i
-          
+
           node_info(5,my_global_id+1) = -1
 
-          do i = 1, total_pe_num 
+          do i = 1, total_pe_num
                if( (node_info(6,i).eq.node_info(6,my_global_id+1)) .and. &
                    (node_info(7,i).eq.node_info(7,my_global_id+1)) .and. &
                    ((node_info(9,i)+1).eq.node_info(8,my_global_id+1)) ) then
                    node_info(5,my_global_id+1) = i - 1
                    return
-               endif 
+               endif
           end do
      return
      end subroutine find_down

--- a/src/MPP/hashtable.F
+++ b/src/MPP/hashtable.F
@@ -135,7 +135,7 @@ contains
     else
        n = size(keys)
     end if
-    
+
     this%n_buckets = n
     allocate(this%buckets(n))
 
@@ -224,7 +224,7 @@ contains
     if (.not. allocated(this%buckets)) return
 
     do i = 1, size(this%buckets)
-       if (associated(this%buckets(i)%next)) then 
+       if (associated(this%buckets(i)%next)) then
           call this%buckets(i)%next%node_clear()
           deallocate(this%buckets(i)%next)
           if(allocated(this%buckets(i)%kv)) then

--- a/src/OrchestratorLayer/io_manager.f90
+++ b/src/OrchestratorLayer/io_manager.f90
@@ -1,7 +1,7 @@
 module io_manager_base
   use netcdf_layer_base
   implicit none
-  
+
   type :: IOManager_
      logical :: parallel = .false.
      class(NetCDF_layer_),allocatable :: netcdf_layer
@@ -11,7 +11,7 @@ module io_manager_base
   interface IOManager_
      module procedure IOManager_init
   end interface IOManager_
-    
+
 contains
 
   type(IOManager_) function IOManager_init(parallel)
@@ -32,7 +32,7 @@ contains
        allocate(NetCDF_parallel_ :: IOManager_init%netcdf_layer)
        IOManager_init%netcdf_layer%open_file => nf90_open
     end if
-    
+
   end function IOManager_init
-  
+
 end module io_manager_base

--- a/src/OrchestratorLayer/orchestrator.f90
+++ b/src/OrchestratorLayer/orchestrator.f90
@@ -6,7 +6,7 @@ module orchestrator_base
   ! interface orchestrator_
   !    procedure orchestrator_init
   ! end interface orchestrator_
-  
+
   type orchestrator_
 
      !class(FluxAggregator_) :: flux_aggregator
@@ -17,19 +17,19 @@ module orchestrator_base
      !class(SpatialObject_) :: spatial_object
 
    contains
-     
+
      procedure, public, pass(self) :: init => orchestrator_init
 
   end type orchestrator_
 
   type(orchestrator_), save :: orchestrator
-  
+
 contains
 
   !We may want routines to access the various components
 
   subroutine orchestrator_init(self)
-    class (orchestrator_) :: self   
+    class (orchestrator_) :: self
 
     self%config = Configuration_()
 
@@ -37,7 +37,7 @@ contains
     ! Read configuration and decide how to assemble the various components
     ! Assuming IO_Manager_serial_ selected
     self%IO_manager = IOManager_()
-    
+
   end subroutine orchestrator_init
 
 end module orchestrator_base

--- a/src/Rapid_routing/hrldas_RAPID_drv.F90
+++ b/src/Rapid_routing/hrldas_RAPID_drv.F90
@@ -12,7 +12,7 @@ program main_program
 
   do ITIME=1,NTIME
     call hrldas_RAPID_exe(runoff,ii,jj)
-  end do  
+  end do
 ! end loop for calling RAPID programs
-   
-  end 
+
+  end

--- a/src/Rapid_routing/hrldas_RAPID_wrapper.F90
+++ b/src/Rapid_routing/hrldas_RAPID_wrapper.F90
@@ -44,7 +44,7 @@ CONTAINS
 !    use rapid_main , only : rapid_ini
     implicit none
     integer :: ntime
- 
+
     if (rank==0) then
       print *,'RAPID initialized = ',initialized
       if(initialized)  return  !If not first time initialization
@@ -55,7 +55,7 @@ CONTAINS
       call rapid_ini(ntime)
       initialized = .True.
     end if
-    
+
     call PetscLogStageRegister('Read Comp Write',stage,ierr)
     call PetscLogStagePush(stage,ierr)
   end subroutine hrldas_RAPID_ini
@@ -102,11 +102,11 @@ CONTAINS
     end if
 
     call rapid_main(1,runoff,ii,jj,Qout_nc_file)
-    
+
     !--LPR: add to test runoff in RESTART run mode, can remove this later-----------
     !if(cnt_rapid_run == 2) then
     !    write(81,*) runoff
-    !endif    
+    !endif
 
   end subroutine hrldas_RAPID_exe
 
@@ -123,13 +123,13 @@ CONTAINS
           May take a while depending on size of river network ... &
           ... Wait ...'
       call rapid_init
-    end if    
+    end if
 
   end subroutine rapid_ini
 
 
 
-!--------------RAPID coupler: gridded runoff to vector runoff-----------------------  
+!--------------RAPID coupler: gridded runoff to vector runoff-----------------------
   subroutine rapid_runoff_to_inflow(ZM_runoff,ZV_Vlat,cnt_rapid_run)
     implicit none
 
@@ -167,9 +167,9 @@ CONTAINS
         end do
         close(88)
         print *,' LPR CHECK river 30000 ',IV_riv_bas_id(30000),ZV_areakm(30000), &
-                IV_i_index(30000),IV_j_index(30000)        
+                IV_i_index(30000),IV_j_index(30000)
         !---------END OPTION 1----------------------------------
-         
+
         !---------OPTION 2: Area-weighted coupling----------------------
 
         !--------END OPTION 2-----------------------------------
@@ -196,7 +196,7 @@ CONTAINS
       print *, '***** LPR: RAPID coupling successful! **********************'
       print *, '************************************************************'
     end if
-        
+
     !------write to PETSC vector---------------------------
     if (rank==0) then
       print *,' number of river reaches  = ',IS_riv_bas

--- a/src/Rapid_routing/rapid_arrays.F90
+++ b/src/Rapid_routing/rapid_arrays.F90
@@ -4,7 +4,7 @@
 subroutine rapid_arrays
 
 !Purpose:
-!Create arrays from input files that are useful for RAPID. 
+!Create arrays from input files that are useful for RAPID.
 !for all simulations, RAPID can run on a subset of all available river reaches
 !of the domain.
 !Three Fortran vectors are useful here:
@@ -13,44 +13,44 @@ subroutine rapid_arrays
 !   located in Vlat_file using the 1-based ZV_read_riv_tot
 ! - IV_riv_bas_loc1(IS_riv_bas) allows to know where to ad dthe flow values in
 !   the current modeling domain using the 0-based ZV_Qout
-!When human-induced option is activated, the flow entering each given river ID 
-!is read from a file and added to the inflow the corresponding river.  
-!Three Fortran vectors are useful here: 
+!When human-induced option is activated, the flow entering each given river ID
+!is read from a file and added to the inflow the corresponding river.
+!Three Fortran vectors are useful here:
 ! - IV_hum_bas_id(IS_hum_bas) allows to know the IDs of the humand-induced flows
-!   locations into the subbasin 
-! - IV_hum_index(IS_hum_bas) allows to know where the flow values are 
+!   locations into the subbasin
+! - IV_hum_index(IS_hum_bas) allows to know where the flow values are
 !   located in Qhum_file using the 1-based ZV_read_hum_tot
 ! - IV_hum_loc1(IS_hum_bas) allows to know where to add the flow values
 !   in the current modeling domain using the 0-based ZV_Qhum
-!When forcing option is activated, the flow exiting each given river ID is 
-!read from a file and added to the inflow of its downstream river.  
-!Three Fortran vectors are useful here: 
+!When forcing option is activated, the flow exiting each given river ID is
+!read from a file and added to the inflow of its downstream river.
+!Three Fortran vectors are useful here:
 ! - IV_for_bas_id(IS_for_bas) allows to know the IDs of the forcing locations
-!   flowing into the subbasin 
-! - IV_for_index(IS_for_bas) allows to know where the flow values are 
+!   flowing into the subbasin
+! - IV_for_index(IS_for_bas) allows to know where the flow values are
 !   located in Qfor_file using the 1-based ZV_read_for_tot
 ! - IV_for_loc2(IS_for_bas) allows to know where to add the flow values
 !   in the current modeling domain using the 0-based ZV_Qfor
-!When dam option is activated, the flow exiting each given river ID is 
-!obtained from a model and added to the inflow of its downstream river.  
-!Four Fortran vectors are useful here: 
+!When dam option is activated, the flow exiting each given river ID is
+!obtained from a model and added to the inflow of its downstream river.
+!Four Fortran vectors are useful here:
 ! - IV_dam_bas_id(IS_dam_bas) allows to know the IDs of the dam locations
-!   in the subbasin 
-! - IV_dam_index(IS_dam_bas) allows to know where the flow values are 
+!   in the subbasin
+! - IV_dam_index(IS_dam_bas) allows to know where the flow values are
 !   located in dam model array using the 1-based ZV_read_dam_tot
 ! - IV_dam_loc2(IS_dam_bas) allows to know where to add the flow values
 !   in the current modeling domain using the 0-based ZV_Qdam
-! - IV_dam_pos(IS_dam_bas) allows to know where to read the flow values for the 
+! - IV_dam_pos(IS_dam_bas) allows to know where to read the flow values for the
 !   dam model in the current modeling domain using the 0-based ZV_Qdam
-!When RAPID is run in optimization mode, the flow measured at each given river   
-!ID is read from a file and compared to computations.  
-!Three Fortran vectors are useful here: 
-! - IV_obs_bas_id(IS_obs_bas) allows to know the IDs of the observations 
-! - IV_obs_index(IS_obs_bas) allows to know where the flow values are 
+!When RAPID is run in optimization mode, the flow measured at each given river
+!ID is read from a file and compared to computations.
+!Three Fortran vectors are useful here:
+! - IV_obs_bas_id(IS_obs_bas) allows to know the IDs of the observations
+! - IV_obs_index(IS_obs_bas) allows to know where the flow values are
 !   located in Qobs_file using the 1-based ZV_read_obs_tot
 ! - IV_obs_loc1(IS_obs_bas) allows to know where to put the flow values
 !   in the current modeling domain using the 0-based ZV_Qobs
-!Author: 
+!Author:
 !Cedric H. David, 2014-2015.
 
 
@@ -109,30 +109,30 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
-#include "finclude/petsclog.h" 
+#include "finclude/petsclog.h"
 !PETSc log
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 
 
 !*******************************************************************************
-!Relationship between entire domain and study basin 
+!Relationship between entire domain and study basin
 !*******************************************************************************
 
 !-------------------------------------------------------------------------------
@@ -152,7 +152,7 @@ end do
 close(11)
 
 !-------------------------------------------------------------------------------
-!Populate hashtable-like matrices 
+!Populate hashtable-like matrices
 !-------------------------------------------------------------------------------
 call rapid_hsh_mat
 
@@ -176,7 +176,7 @@ do JS_riv_bas=1,IS_riv_bas
      ZS_val=-999
      call MatGetValues(ZM_hsh_tot,                                             &
                        IS_one,rank,                                            &
-                       IS_one,IV_riv_bas_id(JS_riv_bas)-1,                     & 
+                       IS_one,IV_riv_bas_id(JS_riv_bas)-1,                     &
                        ZS_val,ierr)
      CHKERRQ(ierr)
      JS_riv_tot=int(ZS_val)
@@ -189,11 +189,11 @@ do JS_riv_bas=1,IS_riv_bas
                            ' not included in domain' // char(10),ierr)
           stop
      end if
-end do 
-!vector with (Fortran, 1-based) indexes corresponding to reaches of basin 
+end do
+!vector with (Fortran, 1-based) indexes corresponding to reaches of basin
 !within whole network
-!IV_riv_index has two advantages.  1) it is needed in order to read inflow  
-!data (Vlat for ex).  2) It allows to avoid one other nested loop in the 
+!IV_riv_index has two advantages.  1) it is needed in order to read inflow
+!data (Vlat for ex).  2) It allows to avoid one other nested loop in the
 !following, which reduces tremendously the computation time.
 
 !-------------------------------------------------------------------------------
@@ -212,7 +212,7 @@ do JS_up=1, IV_nbup(IV_riv_index(JS_riv_bas2))
      ZS_val=-999
      call MatGetValues(ZM_hsh_bas,                                             &
                        IS_one,rank,                                            &
-                       IS_one,IM_up(IV_riv_index(JS_riv_bas2),JS_up)-1,        & 
+                       IS_one,IM_up(IV_riv_index(JS_riv_bas2),JS_up)-1,        &
                        ZS_val,ierr)
      CHKERRQ(ierr)
      JS_riv_bas=int(ZS_val)
@@ -225,8 +225,8 @@ end do
 !Optional, display IV_riv_loc1, IV_riv_index, and IM_index_up
 !-------------------------------------------------------------------------------
 !if (rank==0) then
-!     print *, IV_riv_loc1 
-!     print *, IV_riv_index 
+!     print *, IV_riv_loc1
+!     print *, IV_riv_index
 !     do JS_riv_bas=1,IS_riv_bas
 !          print *, IM_index_up(JS_riv_bas,:)
 !     end do
@@ -299,14 +299,14 @@ do JS_riv_bas=1,IS_riv_bas
      if (IV_hum_use_id(JS_hum_use)==IV_riv_bas_id(JS_riv_bas)) then
           JS_hum_bas=JS_hum_bas+1
           IV_hum_bas_id(JS_hum_bas)=IV_riv_bas_id(JS_riv_bas)
-     end if 
+     end if
 end do
 end do
 
 end if
 
 !-------------------------------------------------------------------------------
-!Populate IV_hum_index 
+!Populate IV_hum_index
 !-------------------------------------------------------------------------------
 do JS_hum_bas=1,IS_hum_bas
 do JS_hum_tot=1,IS_hum_tot
@@ -323,7 +323,7 @@ do JS_hum_bas=1,IS_hum_bas
 do JS_riv_bas=1,IS_riv_bas
      if (IV_riv_bas_id(JS_riv_bas)==IV_hum_bas_id(JS_hum_bas)) then
           IV_hum_loc1(JS_hum_bas)=JS_riv_bas-1
-     end if 
+     end if
 end do
 end do
 
@@ -338,7 +338,7 @@ if (rank==0 .and. IS_hum_bas>0) then
      print *, '        IV_hum_index    =', IV_hum_index
      print *, '        IV_hum_loc1     =', IV_hum_loc1
 end if
-!Warning about human-induced flows 
+!Warning about human-induced flows
 
 !-------------------------------------------------------------------------------
 !End if human-induced is used
@@ -383,12 +383,12 @@ do JS_for_use=1,IS_for_use
           if (IV_for_use_id(JS_for_use)==IV_riv_tot_id(JS_riv_tot)) then
 
      do JS_riv_bas=1,IS_riv_bas
-          if (IV_down(JS_riv_tot)==IV_riv_bas_id(JS_riv_bas)) then 
+          if (IV_down(JS_riv_tot)==IV_riv_bas_id(JS_riv_bas)) then
                IS_for_bas=IS_for_bas+1
           end if
      end do
 
-          end if 
+          end if
      end do
 end do
 
@@ -420,13 +420,13 @@ do JS_for_use=1,IS_for_use
           if (IV_for_use_id(JS_for_use)==IV_riv_tot_id(JS_riv_tot)) then
 
      do JS_riv_bas=1,IS_riv_bas
-          if (IV_down(JS_riv_tot)==IV_riv_bas_id(JS_riv_bas)) then 
+          if (IV_down(JS_riv_tot)==IV_riv_bas_id(JS_riv_bas)) then
                JS_for_bas=JS_for_bas+1
                IV_for_bas_id(JS_for_bas)=IV_for_use_id(JS_for_use)
           end if
      end do
 
-          end if 
+          end if
      end do
 end do
 
@@ -498,7 +498,7 @@ read(19,*) IV_dam_use_id
 close(19)
 
 !-------------------------------------------------------------------------------
-!Calculate IS_dam_bas 
+!Calculate IS_dam_bas
 !-------------------------------------------------------------------------------
 write(temp_char,'(i10)') IS_dam_tot
 call PetscPrintf(PETSC_COMM_WORLD,'         Total number of dam IDs in ' //    &
@@ -514,7 +514,7 @@ do JS_dam_use=1,IS_dam_use
 do JS_riv_bas=1,IS_riv_bas
      if (IV_dam_use_id(JS_dam_use)==IV_riv_tot_id(IV_riv_index(JS_riv_bas)))then
           IS_dam_bas=IS_dam_bas+1
-     end if 
+     end if
 end do
 end do
 
@@ -547,14 +547,14 @@ do JS_riv_bas=1,IS_riv_bas
      if (IV_dam_use_id(JS_dam_use)==IV_riv_tot_id(IV_riv_index(JS_riv_bas)))then
           JS_dam_bas=JS_dam_bas+1
           IV_dam_bas_id(JS_dam_bas)=IV_riv_tot_id(IV_riv_index(JS_riv_bas))
-     end if 
+     end if
 end do
 end do
 
 end if
 
 !-------------------------------------------------------------------------------
-!Populate IV_dam_index 
+!Populate IV_dam_index
 !-------------------------------------------------------------------------------
 do JS_dam_bas=1,IS_dam_bas
 do JS_dam_tot=1,IS_dam_tot
@@ -574,7 +574,7 @@ do JS_riv_tot=1,IS_riv_tot
 
 if (IV_riv_bas_id(JS_riv_bas)==IV_down(JS_riv_tot)) then
           IV_dam_loc2(JS_dam_bas)=JS_riv_bas-1
-end if 
+end if
           end do
      end if
 end do
@@ -605,7 +605,7 @@ end if
 
 if (rank==0 .and. IS_dam_tot>0) then
      print *, '        IV_dam_pos      =', IV_dam_pos
-end if 
+end if
 !Warning about forcing downstream basins
 
 !-------------------------------------------------------------------------------
@@ -615,7 +615,7 @@ end if
 
 
 !*******************************************************************************
-!If optimization mode is selected 
+!If optimization mode is selected
 !*******************************************************************************
 if (IS_opt_run==2) then
 
@@ -647,7 +647,7 @@ do JS_obs_use=1,IS_obs_use
      do JS_riv_bas=1,IS_riv_bas
           if (IV_obs_use_id(JS_obs_use)==IV_riv_bas_id(JS_riv_bas)) then
                IS_obs_bas=IS_obs_bas+1
-          end if 
+          end if
      end do
 end do
 
@@ -691,18 +691,18 @@ end do
 !Optional - Display vectors
 !-------------------------------------------------------------------------------
 !if (rank==0) then
-!     print *, 'IV_obs_index=', IV_obs_index 
-!     print *, 'IV_obs_loc1  =', IV_obs_loc1 
+!     print *, 'IV_obs_index=', IV_obs_index
+!     print *, 'IV_obs_loc1  =', IV_obs_loc1
 !end if
 
 !-------------------------------------------------------------------------------
-!End if optimization mode is selected 
+!End if optimization mode is selected
 !-------------------------------------------------------------------------------
 end if
 
 
 !*******************************************************************************
-!End 
+!End
 !*******************************************************************************
 call PetscPrintf(PETSC_COMM_WORLD,'Arrays created'//char(10),ierr)
 call PetscPrintf(PETSC_COMM_WORLD,'--------------------------'//char(10),ierr)

--- a/src/Rapid_routing/rapid_close_Qfor_file.F90
+++ b/src/Rapid_routing/rapid_close_Qfor_file.F90
@@ -1,11 +1,11 @@
 !*******************************************************************************
-!Subroutine - rapid_close_Qfor_file 
+!Subroutine - rapid_close_Qfor_file
 !*******************************************************************************
 subroutine rapid_close_Qfor_file
 
 !Purpose:
 !Close Qfor_file from Fortran.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -20,7 +20,7 @@ implicit none
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 
 

--- a/src/Rapid_routing/rapid_close_Qhum_file.F90
+++ b/src/Rapid_routing/rapid_close_Qhum_file.F90
@@ -1,11 +1,11 @@
 !*******************************************************************************
-!Subroutine - rapid_close_Qhum_file 
+!Subroutine - rapid_close_Qhum_file
 !*******************************************************************************
 subroutine rapid_close_Qhum_file
 
 !Purpose:
 !Close Qhum_file from Fortran.
-!Author: 
+!Author:
 !Cedric H. David, 2014-2015.
 
 
@@ -20,7 +20,7 @@ implicit none
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 
 

--- a/src/Rapid_routing/rapid_close_Qobs_file.F90
+++ b/src/Rapid_routing/rapid_close_Qobs_file.F90
@@ -1,11 +1,11 @@
 !*******************************************************************************
-!Subroutine - rapid_close_Qobs_file 
+!Subroutine - rapid_close_Qobs_file
 !*******************************************************************************
 subroutine rapid_close_Qobs_file
 
 !Purpose:
 !Close Qobs_file from Fortran.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -20,7 +20,7 @@ implicit none
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 
 

--- a/src/Rapid_routing/rapid_close_Qout_file.F90
+++ b/src/Rapid_routing/rapid_close_Qout_file.F90
@@ -1,11 +1,11 @@
 !*******************************************************************************
-!Subroutine - rapid_close_Qout_file 
+!Subroutine - rapid_close_Qout_file
 !*******************************************************************************
 subroutine rapid_close_Qout_file
 
 !Purpose:
 !Close Qout_file from Fortran/netCDF.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -21,7 +21,7 @@ implicit none
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 
 

--- a/src/Rapid_routing/rapid_close_Vlat_file.F90
+++ b/src/Rapid_routing/rapid_close_Vlat_file.F90
@@ -1,11 +1,11 @@
 !*******************************************************************************
-!Subroutine - rapid_close_Vlat_file 
+!Subroutine - rapid_close_Vlat_file
 !*******************************************************************************
 subroutine rapid_close_Vlat_file
 
 !Purpose:
 !Close Qobs_file from Fortran/netCDF.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -21,7 +21,7 @@ implicit none
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 
 

--- a/src/Rapid_routing/rapid_create_Qout_file.F90
+++ b/src/Rapid_routing/rapid_create_Qout_file.F90
@@ -1,11 +1,11 @@
 !*******************************************************************************
 !Subroutine - rapid_create_Qout_file
 !*******************************************************************************
-subroutine rapid_create_Qout_file(Qout_file) 
+subroutine rapid_create_Qout_file(Qout_file)
 
 !Purpose:
 !Create Qout_file from Fortran/netCDF.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -28,7 +28,7 @@ implicit none
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 character(len=100), intent(in):: Qout_file
 
@@ -36,7 +36,7 @@ character(len=100), intent(in):: Qout_file
 !*******************************************************************************
 !Open file
 !*******************************************************************************
-if (rank==0) then 
+if (rank==0) then
 
      IS_nc_status=NF90_CREATE(Qout_file,NF90_CLOBBER,IS_nc_id_fil_Qout)
      IS_nc_status=NF90_DEF_DIM(IS_nc_id_fil_Qout,'Time',NF90_UNLIMITED,        &
@@ -58,8 +58,7 @@ end if
 
 
 !*******************************************************************************
-!End 
+!End
 !*******************************************************************************
 
 end subroutine rapid_create_Qout_file
-

--- a/src/Rapid_routing/rapid_create_obj.F90
+++ b/src/Rapid_routing/rapid_create_obj.F90
@@ -1,12 +1,12 @@
 !*******************************************************************************
 !Subroutine - rapid_create_obj
 !*******************************************************************************
-subroutine rapid_create_obj 
+subroutine rapid_create_obj
 
 !Purpose:
-!All PETSc and TAO objects need be created (requirement of both mathematical 
+!All PETSc and TAO objects need be created (requirement of both mathematical
 !libraries).  PETSc and TAO also need be initialized.  This is what's done here.
-!Author: 
+!Author:
 !Cedric H. David, 2008-2015.
 
 
@@ -41,22 +41,22 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
 
 #ifndef NO_TAO
-#include "finclude/taosolver.h" 
+#include "finclude/taosolver.h"
 !TAO solver
 #endif
 
@@ -102,7 +102,7 @@ call MatCreate(PETSC_COMM_WORLD,ZM_Obs,ierr)
 call MatSetSizes(ZM_Obs,PETSC_DECIDE,PETSC_DECIDE,IS_riv_bas,IS_riv_bas,ierr)
 call MatSetFromOptions(ZM_Obs,ierr)
 call MatSetUp(ZM_Obs,ierr)
-!These matrices are all square of size IS_riv_bas.  PETSC_DECIDE allows PETSc 
+!These matrices are all square of size IS_riv_bas.  PETSC_DECIDE allows PETSc
 !to determine the local sizes on its own. MatSetFromOptions allows to use many
 !different options at runtime, such as "-mat_type aijmumps".
 
@@ -182,7 +182,7 @@ call VecSetFromOptions(ZV_p,ierr)
 
 call VecDuplicate(ZV_p,ZV_pnorm,ierr)
 call VecDuplicate(ZV_p,ZV_pfac,ierr)
- 
+
 
 !Vectors and objects useful for PETSc programming-------------------------------
 call VecDuplicate(ZV_k,ZV_one,ierr)
@@ -190,7 +190,7 @@ call VecSet(ZV_one,ZS_one,ierr)
 !this is a vector with ones a each row, used for computations
 
 call VecScatterCreateToZero(ZV_k,vecscat,ZV_SeqZero,ierr)
-!create scatter context from a distributed vector to a sequential vector on the 
+!create scatter context from a distributed vector to a sequential vector on the
 !zeroth processor.  Also creates the vector ZV_SeqZero
 
 
@@ -201,7 +201,7 @@ call TaoInitialize(PETSC_NULL_CHARACTER,ierr)
 
 call TaoCreate(PETSC_COMM_WORLD,tao,ierr)
 call TaoSetType(tao,'tao_nm',ierr)
-!Create TAO App 
+!Create TAO App
 
 call VecDuplicate(ZV_p,ZV_1stIndex,ierr)
 call VecSetValues(ZV_1stIndex,IS_one,0*IS_one,ZS_one,INSERT_VALUES,ierr)

--- a/src/Rapid_routing/rapid_destro_obj.F90
+++ b/src/Rapid_routing/rapid_destro_obj.F90
@@ -1,14 +1,14 @@
 !*******************************************************************************
 !Subroutine - rapid_destro_obj
 !*******************************************************************************
-subroutine rapid_destro_obj 
+subroutine rapid_destro_obj
 
 !Purpose:
-!All PETSc and TAO objects need be destroyed (requirement of both mathematical 
+!All PETSc and TAO objects need be destroyed (requirement of both mathematical
 !libraries).  PETSc and TAO also need be finalized.  This is what's done here
 !Note: only finilized here, need to add destroy of vectors.
-!Author: 
-!Cedric H. David, 2008-2015. 
+!Author:
+!Cedric H. David, 2008-2015.
 
 
 !*******************************************************************************
@@ -42,22 +42,22 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
 
 #ifndef NO_TAO
-#include "finclude/taosolver.h" 
+#include "finclude/taosolver.h"
 !TAO solver
 #endif
 
@@ -144,4 +144,4 @@ call VecScatterDestroy(vecscat,ierr)
 call PetscFinalize(ierr)
 
 
-end subroutine rapid_destro_obj 
+end subroutine rapid_destro_obj

--- a/src/Rapid_routing/rapid_final.F90
+++ b/src/Rapid_routing/rapid_final.F90
@@ -1,12 +1,12 @@
 !*******************************************************************************
-!Subroutine - rapid_final 
+!Subroutine - rapid_final
 !*******************************************************************************
 subroutine rapid_final
 
 !Purpose:
-!This subroutine allows to finalize RAPID for both regular runs and 
-!optimization runs, by performing slightly different tasks depending on what 
-!option is chosen.  
+!This subroutine allows to finalize RAPID for both regular runs and
+!optimization runs, by performing slightly different tasks depending on what
+!option is chosen.
 !Finalization Initialization tasks specific to Option 1
 !     -Output final instantaneous flow
 !     -Output babsmax, QoutRabsmin and QoutRabsmax
@@ -14,9 +14,9 @@ subroutine rapid_final
 !     -N/A
 !Finalization tasks common to all RAPID options:
 !     -Prints some information about the types of objects used during simulation
-!     -Destroy all PETSc and TAO objects 
-!Author: 
-!Cedric H. David, 2012-2015. 
+!     -Destroy all PETSc and TAO objects
+!Author:
+!Cedric H. David, 2012-2015.
 
 
 !*******************************************************************************
@@ -40,20 +40,20 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
-#include "finclude/petsclog.h" 
+#include "finclude/petsclog.h"
 !PETSc log
 
 
@@ -71,7 +71,7 @@ call VecScatterBegin(vecscat,ZV_QoutR,ZV_SeqZero,                              &
 call VecScatterEnd(vecscat,ZV_QoutR,ZV_SeqZero,                                &
                         INSERT_VALUES,SCATTER_FORWARD,ierr)
 call VecGetArrayF90(ZV_SeqZero,ZV_pointer,ierr)
-if (rank==0) then 
+if (rank==0) then
      open(31,file=Qfinal_file)
      do JS_riv_bas=1,IS_riv_bas
           write(31,*) ZV_pointer(JS_riv_bas)
@@ -90,7 +90,7 @@ call VecScatterBegin(vecscat,ZV_babsmax,ZV_SeqZero,                            &
 call VecScatterEnd(vecscat,ZV_babsmax,ZV_SeqZero,                              &
                         INSERT_VALUES,SCATTER_FORWARD,ierr)
 call VecGetArrayF90(ZV_SeqZero,ZV_pointer,ierr)
-if (rank==0) then 
+if (rank==0) then
      open(42,file=babsmax_file)
      do JS_riv_bas=1,IS_riv_bas
           write(42,*) ZV_pointer(JS_riv_bas)
@@ -101,7 +101,7 @@ call VecRestoreArrayF90(ZV_SeqZero,ZV_pointer,ierr)
 end if
 
 !-------------------------------------------------------------------------------
-!Output minimum absolute values of instantaneous flow 
+!Output minimum absolute values of instantaneous flow
 !-------------------------------------------------------------------------------
 if (BS_opt_influence) then
 call VecScatterBegin(vecscat,ZV_QoutRabsmin,ZV_SeqZero,                        &
@@ -109,7 +109,7 @@ call VecScatterBegin(vecscat,ZV_QoutRabsmin,ZV_SeqZero,                        &
 call VecScatterEnd(vecscat,ZV_QoutRabsmin,ZV_SeqZero,                          &
                         INSERT_VALUES,SCATTER_FORWARD,ierr)
 call VecGetArrayF90(ZV_SeqZero,ZV_pointer,ierr)
-if (rank==0) then 
+if (rank==0) then
      open(43,file=QoutRabsmin_file)
      do JS_riv_bas=1,IS_riv_bas
           write(43,*) ZV_pointer(JS_riv_bas)
@@ -120,7 +120,7 @@ call VecRestoreArrayF90(ZV_SeqZero,ZV_pointer,ierr)
 end if
 
 !-------------------------------------------------------------------------------
-!Output maximum absolute values of instantaneous flow 
+!Output maximum absolute values of instantaneous flow
 !-------------------------------------------------------------------------------
 if (BS_opt_influence) then
 call VecScatterBegin(vecscat,ZV_QoutRabsmax,ZV_SeqZero,                        &
@@ -128,7 +128,7 @@ call VecScatterBegin(vecscat,ZV_QoutRabsmax,ZV_SeqZero,                        &
 call VecScatterEnd(vecscat,ZV_QoutRabsmax,ZV_SeqZero,                          &
                         INSERT_VALUES,SCATTER_FORWARD,ierr)
 call VecGetArrayF90(ZV_SeqZero,ZV_pointer,ierr)
-if (rank==0) then 
+if (rank==0) then
      open(44,file=QoutRabsmax_file)
      do JS_riv_bas=1,IS_riv_bas
           write(44,*) ZV_pointer(JS_riv_bas)
@@ -152,13 +152,13 @@ call VecGetType(ZV_k,temp_char,ierr)
 call PetscPrintf(PETSC_COMM_WORLD,'type of vector: '//temp_char//char(10),ierr)
 call MatGetType(ZM_A,temp_char,ierr)
 call PetscPrintf(PETSC_COMM_WORLD,'type of matrix: '//temp_char//char(10),ierr)
-if (IS_opt_routing==1 .or. IS_opt_routing==3) then 
+if (IS_opt_routing==1 .or. IS_opt_routing==3) then
      call KSPGetType(ksp,temp_char,ierr)
 else
      temp_char='No KSP'
 end if
 call PetscPrintf(PETSC_COMM_WORLD,'type of KSP   : '//temp_char//char(10),ierr)
-if (IS_opt_routing==1 .or. IS_opt_routing==3) then 
+if (IS_opt_routing==1 .or. IS_opt_routing==3) then
      call KSPGetPC(ksp,pc,ierr)
      call PCGetType(pc,temp_char,ierr)
 else

--- a/src/Rapid_routing/rapid_get_Qdam.F90
+++ b/src/Rapid_routing/rapid_get_Qdam.F90
@@ -5,7 +5,7 @@ subroutine rapid_get_Qdam
 
 !Purpose:
 !Communicate with a dam subroutine to exchange inflows and outflows.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -27,25 +27,25 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
-#include "finclude/petsclog.h" 
+#include "finclude/petsclog.h"
 !PETSc log
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 
 
@@ -55,20 +55,20 @@ implicit none
 !-------------------------------------------------------------------------------
 !Compute inflow into dams from previous river flow
 !-------------------------------------------------------------------------------
-call MatMult(ZM_Net,ZV_QoutbarR,ZV_QinbarR,ierr)           
+call MatMult(ZM_Net,ZV_QoutbarR,ZV_QinbarR,ierr)
 call VecAXPY(ZV_QinbarR,ZS_one,ZV_Qext,ierr)
 !QinbarR=Net*QoutbarR+Qext
 
 !-------------------------------------------------------------------------------
-!Set values from PETSc vector into Fortran vector 
+!Set values from PETSc vector into Fortran vector
 !-------------------------------------------------------------------------------
-if (rank==0) ZV_Qin_dam_prev=0 
+if (rank==0) ZV_Qin_dam_prev=0
 call VecScatterBegin(vecscat,ZV_QinbarR,ZV_SeqZero,                            &
                      INSERT_VALUES,SCATTER_FORWARD,ierr)
 call VecScatterEnd(vecscat,ZV_QinbarR,ZV_SeqZero,                              &
                         INSERT_VALUES,SCATTER_FORWARD,ierr)
 call VecGetArrayF90(ZV_SeqZero,ZV_pointer,ierr)
-if (rank==0) ZV_Qin_dam_prev=ZV_pointer(IV_dam_pos) 
+if (rank==0) ZV_Qin_dam_prev=ZV_pointer(IV_dam_pos)
 call VecRestoreArrayF90(ZV_SeqZero,ZV_pointer,ierr)
 !Get values from ZV_QinbarR (PETSc) into ZV_Qin_dam_prev (Fortran)
 
@@ -79,20 +79,20 @@ call VecRestoreArrayF90(ZV_SeqZero,ZV_pointer,ierr)
 !-------------------------------------------------------------------------------
 !If dam module does not exist, outflow is computed from this subroutine
 !-------------------------------------------------------------------------------
-if (rank==0) then 
+if (rank==0) then
      ZV_Qout_dam=ZV_Qin_dam_prev
 end if
 
 !-------------------------------------------------------------------------------
 !If dam module does exist, use it
 !-------------------------------------------------------------------------------
-!if (rank==0) then 
+!if (rank==0) then
 !     call dam_linear(ZV_Qin_dam_prev,ZV_Qout_dam_prev,ZV_Qout_dam)
 !end if
 
 
 !*******************************************************************************
-!Optional - Write information in stdout 
+!Optional - Write information in stdout
 !*******************************************************************************
 !if (rank==0) print *, 'Qin_dam_prev  =', ',', ZV_Qin_dam_prev
 !if (rank==0) print *, 'Qin_dam_prev  =', ',', ZV_Qin_dam_prev(1)
@@ -103,7 +103,7 @@ end if
 
 
 !*******************************************************************************
-!Set values from Fortran vector into PETSc vector 
+!Set values from Fortran vector into PETSc vector
 !*******************************************************************************
 if (rank==0) then
      call VecSetValues(ZV_Qdam,IS_dam_bas,IV_dam_loc2,                         &
@@ -111,19 +111,19 @@ if (rank==0) then
 end if
 
 call VecAssemblyBegin(ZV_Qdam,ierr)
-call VecAssemblyEnd(ZV_Qdam,ierr)           
+call VecAssemblyEnd(ZV_Qdam,ierr)
 
 
 !*******************************************************************************
-!Update ZV_Qout_dam_prev - After calling dam_linear to not override init. values 
+!Update ZV_Qout_dam_prev - After calling dam_linear to not override init. values
 !*******************************************************************************
-if (rank==0) then 
+if (rank==0) then
      ZV_Qout_dam_prev=ZV_Qout_dam
 end if
 
 
 !*******************************************************************************
-!End 
+!End
 !*******************************************************************************
 
 end subroutine rapid_get_Qdam

--- a/src/Rapid_routing/rapid_hsh_mat.F90
+++ b/src/Rapid_routing/rapid_hsh_mat.F90
@@ -10,13 +10,13 @@ subroutine rapid_hsh_mat
 ! - IM_hsh_bas contains the index over the basin (JS_riv_bas) corresponding to
 !   each reach ID and is the same for each row
 !The choice of matrices to mimic hashtables is possible because the "keys" (i.e.
-!the reach IDs) are all integers, and the sparse structure allows to keep memory 
+!the reach IDs) are all integers, and the sparse structure allows to keep memory
 !usage minimal because the number of unique reach IDs is far inferior to the
-!maximum integer value of reach ID.  Implementing a C++ hashtable within Fortran 
-!would have required much more intrusive modifications to RAPID. 
-!Thank you to Chris A. Mattmann and to Si Liu who both suggested the use of 
+!maximum integer value of reach ID.  Implementing a C++ hashtable within Fortran
+!would have required much more intrusive modifications to RAPID.
+!Thank you to Chris A. Mattmann and to Si Liu who both suggested the use of
 !hashtables to decrease model setup time.
-!Author: 
+!Author:
 !Cedric H. David, 2015-2015.
 
 
@@ -38,23 +38,23 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 PetscInt, dimension(ncore)  :: IS_nz, IS_dnz, IS_onz
 PetscInt, dimension(IS_riv_tot) :: IV_tot_tmp1, IV_tot_tmp2
@@ -62,12 +62,12 @@ PetscInt, dimension(IS_riv_bas) :: IV_bas_tmp1, IV_bas_tmp2
 
 
 !*******************************************************************************
-!Check that reach IDs are within the allowed range 
+!Check that reach IDs are within the allowed range
 !*******************************************************************************
-write(temp_char2,'(i10)') IS_riv_id_max 
+write(temp_char2,'(i10)') IS_riv_id_max
 
 do JS_riv_tot=1,IS_riv_tot
-     if (IV_riv_tot_id(JS_riv_tot) > IS_riv_id_max) then 
+     if (IV_riv_tot_id(JS_riv_tot) > IS_riv_id_max) then
           write(temp_char,'(i10)') IV_riv_tot_id(JS_riv_tot)
           call PetscPrintf(PETSC_COMM_WORLD,                                   &
                            'ERROR: reach ID' // temp_char // ' in domain' //   &
@@ -75,7 +75,7 @@ do JS_riv_tot=1,IS_riv_tot
                            ' allowed of' // temp_char2 // char(10),ierr)
           stop
      end if
-     if (IV_riv_tot_id(JS_riv_tot) == 0) then 
+     if (IV_riv_tot_id(JS_riv_tot) == 0) then
           write(temp_char,'(i10)') JS_riv_tot
           call PetscPrintf(PETSC_COMM_WORLD,                                   &
                            'ERROR: reach ID located at index'// temp_char//    &
@@ -85,7 +85,7 @@ do JS_riv_tot=1,IS_riv_tot
 end do
 
 do JS_riv_bas=1,IS_riv_bas
-     if (IV_riv_bas_id(JS_riv_bas) > IS_riv_id_max) then 
+     if (IV_riv_bas_id(JS_riv_bas) > IS_riv_id_max) then
           write(temp_char,'(i10)') IV_riv_bas_id(JS_riv_bas)
           call PetscPrintf(PETSC_COMM_WORLD,                                   &
                            'ERROR: reach ID' // temp_char // ' in basin' //    &
@@ -93,7 +93,7 @@ do JS_riv_bas=1,IS_riv_bas
                            ' allowed of' // temp_char2 // char(10),ierr)
           stop
      end if
-     if (IV_riv_bas_id(JS_riv_bas) == 0) then 
+     if (IV_riv_bas_id(JS_riv_bas) == 0) then
           write(temp_char,'(i10)') JS_riv_bas
           call PetscPrintf(PETSC_COMM_WORLD,                                   &
                            'ERROR: reach ID located at index'// temp_char//    &
@@ -116,7 +116,7 @@ IS_dnz=0
 IS_onz=0
 
 IS_nz=IS_riv_tot
-do JS_riv_tot=1,IS_riv_tot 
+do JS_riv_tot=1,IS_riv_tot
      if (IV_riv_tot_id(JS_riv_tot) -1 >= IS_ownfirst .and.                     &
          IV_riv_tot_id(JS_riv_tot) -1 <  IS_ownlast) then
           IS_dnz=IS_dnz+1
@@ -141,7 +141,7 @@ IS_dnz=0
 IS_onz=0
 
 IS_nz=IS_riv_bas
-do JS_riv_bas=1,IS_riv_bas 
+do JS_riv_bas=1,IS_riv_bas
      if (IV_riv_bas_id(JS_riv_bas) -1 >= IS_ownfirst .and.                     &
          IV_riv_bas_id(JS_riv_bas) -1 <  IS_ownlast) then
           IS_dnz=IS_dnz+1

--- a/src/Rapid_routing/rapid_main.F90
+++ b/src/Rapid_routing/rapid_main.F90
@@ -3,9 +3,9 @@
 !*******************************************************************************
 subroutine rapid_main(ITIME,runoff,ii,jj,Qout_nc_file)
 !Purpose:
-!Allows to route water through a river network, and to estimate optimal 
-!parameters using the inverse method 
-!Author: 
+!Allows to route water through a river network, and to estimate optimal
+!parameters using the inverse method
+!Author:
 !Cedric H. David, 2008-2015.
 !Peirong Lin, modified starting from June 2014 to satisfy WRF-Hydro needs
 
@@ -49,24 +49,24 @@ external rapid_phiroutine
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
-#include "finclude/petsclog.h" 
+#include "finclude/petsclog.h"
 !PETSc log
 
 #ifndef NO_TAO
-#include "finclude/taosolver.h" 
+#include "finclude/taosolver.h"
 !TAO solver
 #endif
 
@@ -86,7 +86,7 @@ Qout_file = Qout_nc_file !---LPR: new output filename defined by Wrapper-------
 !call rapid_init
 
 !*******************************************************************************
-!OPTION 1 - use to calculate flows and volumes and generate output data 
+!OPTION 1 - use to calculate flows and volumes and generate output data
 !*******************************************************************************
 if (IS_opt_run==1) then
 
@@ -96,7 +96,7 @@ if (IS_opt_run==1) then
 call rapid_create_Qout_file(Qout_file)
 
 !-------------------------------------------------------------------------------
-!Open files          
+!Open files
 !-------------------------------------------------------------------------------
 call rapid_open_Qout_file(Qout_file)
 !---LPR: IMPORTANT uncomment this sentence because runoff is NOT read from Vlat
@@ -121,7 +121,7 @@ if (BS_opt_dam .and. IS_dam_bas>0) then
 end if
 
 !-------------------------------------------------------------------------------
-!Read, compute and write          
+!Read, compute and write
 !-------------------------------------------------------------------------------
 !---LPR: IMPORTANT uncomment the next two->defined in RAPID initialization stage
 !call PetscLogStageRegister('Read Comp Write',stage,ierr)
@@ -137,57 +137,57 @@ IV_nc_count2=(/IS_riv_bas,1/)
 !do JS_M=1,IS_M
 !do JS_RpM=1,IS_RpM
 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-!Read/set surface and subsurface volumes 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!Read/set surface and subsurface volumes
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !call rapid_read_Vlat_file  !---LPR: do not read Vlat file, but get Vlat from WRF-Hydro
 
 !---LPR: IMPORTANT new subroutine added in the Wrapper-----------------
-call rapid_runoff_to_inflow(ZM_runoff,ZV_Vlat,cnt_rapid_run) 
+call rapid_runoff_to_inflow(ZM_runoff,ZV_Vlat,cnt_rapid_run)
 !---LPR: IMPORTANT new subroutine added in the Wrapper-----------------
 
 call VecCopy(ZV_Vlat,ZV_Qlat,ierr)            !Qlat=Vlat
 call VecScale(ZV_Qlat,1/ZS_TauR,ierr)         !Qlat=Qlat/TauR
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !Read/set upstream forcing
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 if (BS_opt_for .and. IS_for_bas>0                                              &
                    .and. mod((JS_M-1)*IS_RpM+JS_RpM,IS_RpF)==1) then
 
 call rapid_read_Qfor_file
 
-end if 
+end if
 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !Run dam model based on previous values of QoutbarR and Qext to get Qdam
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 if (BS_opt_dam .and. IS_dam_bas>0) then
 
 call rapid_get_Qdam
 
 end if
 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-!Read/set human induced flows 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!Read/set human induced flows
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 if (BS_opt_hum .and. IS_hum_bas>0                                              &
                    .and. mod((JS_M-1)*IS_RpM+JS_RpM,IS_RpH)==1) then
 
 call rapid_read_Qhum_file
 
-end if 
+end if
 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !calculation of Qext
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 call VecCopy(ZV_Qlat,ZV_Qext,ierr)                            !Qext=Qlat
 if (BS_opt_for) call VecAXPY(ZV_Qext,ZS_one,ZV_Qfor,ierr)     !Qext=Qext+1*Qfor
 if (BS_opt_dam) call VecAXPY(ZV_Qext,ZS_one,ZV_Qdam,ierr)     !Qext=Qext+1*Qdam
 if (BS_opt_hum) call VecAXPY(ZV_Qext,ZS_one,ZV_Qhum,ierr)     !Qext=Qext+1*Qhum
 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !Routing procedure
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 call PetscTime(ZS_time1,ierr)
 call rapid_routing(ZV_C1,ZV_C2,ZV_C3,ZV_Qext,                                  &
                    ZV_QoutinitR,ZV_VinitR,                                     &
@@ -195,20 +195,20 @@ call rapid_routing(ZV_C1,ZV_C2,ZV_C3,ZV_Qext,                                  &
 call PetscTime(ZS_time2,ierr)
 ZS_time3=ZS_time3+ZS_time2-ZS_time1
 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !Update variables
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 call VecCopy(ZV_QoutR,ZV_QoutinitR,ierr)
 call VecCopy(ZV_VR,ZV_VinitR,ierr)
-     
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-!write outputs         
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!write outputs
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 call rapid_write_Qout_file
 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-!Update netCDF location         
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!Update netCDF location
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 if (rank==0) IV_nc_start(2)=IV_nc_start(2)+1
 !do not comment out if writing directly from the routing subroutine
 
@@ -231,7 +231,7 @@ call PetscSynchronizedFlush(PETSC_COMM_WORLD,ierr)
 call PetscPrintf(PETSC_COMM_WORLD,'Output data created'//char(10),ierr)
 
 !-------------------------------------------------------------------------------
-!Close files          
+!Close files
 !-------------------------------------------------------------------------------
 call rapid_close_Qout_file
 !---LPR: IMPORTANT uncomment setence below-------
@@ -247,7 +247,7 @@ end if
 
 
 !*******************************************************************************
-!OPTION 2 - Optimization 
+!OPTION 2 - Optimization
 !*******************************************************************************
 if (IS_opt_run==2) then
 #ifndef NO_TAO

--- a/src/Rapid_routing/rapid_net_mat.F90
+++ b/src/Rapid_routing/rapid_net_mat.F90
@@ -4,13 +4,13 @@
 subroutine rapid_net_mat
 
 !Purpose:
-!This creates a sparse network matrix.  "1" is recorded at Net(i,j) if the reach 
+!This creates a sparse network matrix.  "1" is recorded at Net(i,j) if the reach
 !in column j flows into the reach in line i. If some connections are missing
-!between the subbasin and the entire domain, gives warnings.  
-!A transboundary matrix is also created whose elements in the diagonal blocks 
-!are all null and the elements in the off-diagonal blocks are equal to those of 
-!the network matrix. 
-!Author: 
+!between the subbasin and the entire domain, gives warnings.
+!A transboundary matrix is also created whose elements in the diagonal blocks
+!are all null and the elements in the off-diagonal blocks are equal to those of
+!the network matrix.
+!Author:
 !Cedric H. David, 2008-2015.
 
 
@@ -33,16 +33,16 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
@@ -70,21 +70,21 @@ if (IM_index_up(JS_riv_bas2,JS_up)/=0) then
      !Here JS_riv_bas is determined upstream of JS_riv_bas2
      !both IS_riv_bas2 and IS_riv_bas are used here because the location
      !of nonzeros depends on row and column in an parallel matrix
-     
-     IV_nz(JS_riv_bas2)=IV_nz(JS_riv_bas2)+1 
+
+     IV_nz(JS_riv_bas2)=IV_nz(JS_riv_bas2)+1
      !The size of IV_nz is IS_riv_bas, IV_nz is the same across computing cores
 
      if ((JS_riv_bas >=IS_ownfirst+1 .and.  JS_riv_bas< IS_ownlast+1) .and.    &
          (JS_riv_bas2>=IS_ownfirst+1 .and. JS_riv_bas2< IS_ownlast+1)) then
-          IV_dnz(JS_riv_bas2)=IV_dnz(JS_riv_bas2)+1 
+          IV_dnz(JS_riv_bas2)=IV_dnz(JS_riv_bas2)+1
      end if
      if ((JS_riv_bas < IS_ownfirst+1 .or.  JS_riv_bas >=IS_ownlast+1) .and.    &
          (JS_riv_bas2>=IS_ownfirst+1 .and. JS_riv_bas2< IS_ownlast+1)) then
-          IV_onz(JS_riv_bas2)=IV_onz(JS_riv_bas2)+1 
+          IV_onz(JS_riv_bas2)=IV_onz(JS_riv_bas2)+1
      end if
-     !The size of IV_dnz and of IV_onz is IS_riv_bas. The values of IV_dnz and 
-     !IV_onz are not the same across computing cores.  For each core, the  
-     !only the values located in the range (IS_ownfirst+1:IS_ownlast) are 
+     !The size of IV_dnz and of IV_onz is IS_riv_bas. The values of IV_dnz and
+     !IV_onz are not the same across computing cores.  For each core, the
+     !only the values located in the range (IS_ownfirst+1:IS_ownlast) are
      !correct but only these are used in the preallocation below.
 
 end if
@@ -164,9 +164,9 @@ if (IM_index_up(JS_riv_bas2,JS_up)/=0) then
      call MatSetValues(ZM_A  ,IS_one,JS_riv_bas2-1,IS_one,JS_riv_bas-1,        &
                        0*ZS_one,INSERT_VALUES,ierr)
      CHKERRQ(ierr)
-     !zeros (instead of -C1is) are used here on the off-diagonal of ZM_A because 
-     !C1is are not yet computed, because ZM_A will later be populated based on 
-     !ZM_Net, and because ZM_Net may be later modified for forcing or dams. 
+     !zeros (instead of -C1is) are used here on the off-diagonal of ZM_A because
+     !C1is are not yet computed, because ZM_A will later be populated based on
+     !ZM_Net, and because ZM_Net may be later modified for forcing or dams.
      !Also when running RAPID in optimization mode, it is necessary to recreate
      !ZM_A from scratch every time the parameters C1is are updated
 
@@ -214,9 +214,9 @@ if (IM_index_up(JS_riv_bas2,JS_up)/=0) then
      call MatSetValues(ZM_TC1,IS_one,JS_riv_bas2-1,IS_one,JS_riv_bas-1,        &
                        0*ZS_one,INSERT_VALUES,ierr)
      CHKERRQ(ierr)
-     !zeros (instead of C1is) are used here everywhere in ZM_TC1 because 
-     !C1is are not yet computed, because ZM_TC1 will later be populated based on 
-     !ZM_T, and because ZM_T may be later modified for forcing or dams. 
+     !zeros (instead of C1is) are used here everywhere in ZM_TC1 because
+     !C1is are not yet computed, because ZM_TC1 will later be populated based on
+     !ZM_T, and because ZM_T may be later modified for forcing or dams.
      !Also when running RAPID in optimization mode, it is necessary to recreate
      !ZM_TC1 from scratch every time the parameters C1is are updated
 
@@ -242,7 +242,7 @@ do JS_riv_tot=1,IS_riv_tot
      ZS_val=-999
      call MatGetValues(ZM_hsh_bas,                                             &
                        IS_one,rank,                                            &
-                       IS_one,IV_riv_tot_id(JS_riv_tot)-1,                     & 
+                       IS_one,IV_riv_tot_id(JS_riv_tot)-1,                     &
                        ZS_val,ierr)
      CHKERRQ(ierr)
      JS_riv_bas2=int(ZS_val)
@@ -257,7 +257,7 @@ do JS_riv_tot=1,IS_riv_tot
 ZS_val=-999
 call MatGetValues(ZM_hsh_bas,                                                  &
                   IS_one,rank,                                                 &
-                  IS_one,IV_down(JS_riv_tot)-1,                                & 
+                  IS_one,IV_down(JS_riv_tot)-1,                                &
                   ZS_val,ierr)
 CHKERRQ(ierr)
 JS_riv_bas=int(ZS_val)
@@ -280,7 +280,7 @@ do JS_up=1,IV_nbup(JS_riv_tot)
 ZS_val=-999
 call MatGetValues(ZM_hsh_bas,                                                  &
                   IS_one,rank,                                                 &
-                  IS_one,IM_up(JS_riv_tot,JS_up)-1,                            & 
+                  IS_one,IM_up(JS_riv_tot,JS_up)-1,                            &
                   ZS_val,ierr)
 CHKERRQ(ierr)
 JS_riv_bas=int(ZS_val)

--- a/src/Rapid_routing/rapid_net_mat_brk.F90
+++ b/src/Rapid_routing/rapid_net_mat_brk.F90
@@ -5,11 +5,11 @@ subroutine rapid_net_mat_brk
 
 !Purpose:
 !This subroutine modifies the network and transboundary matrices based on a list
-!of river IDs. 
-!The connectivity is broken between each given river ID and its downstream 
+!of river IDs.
+!The connectivity is broken between each given river ID and its downstream
 !river.
-!Author: 
-!Cedric H. David, 2013-2015. 
+!Author:
+!Cedric H. David, 2013-2015.
 
 
 !*******************************************************************************
@@ -32,16 +32,16 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
@@ -55,7 +55,7 @@ if (BS_opt_for) then
 !-------------------------------------------------------------------------------
 !Breaks Net matrix connectivity in case forcing used is inside basin studied
 !-------------------------------------------------------------------------------
-if (IS_for_bas>0) then 
+if (IS_for_bas>0) then
 call PetscPrintf(PETSC_COMM_WORLD,'Modifying network matrix'//char(10),ierr)
 end if
 
@@ -93,7 +93,7 @@ do JS_for_bas=1,IS_for_bas
           !Writes information on connection that was just broken in stdout
 
           end if
-     end do 
+     end do
 
           end if
      end do
@@ -111,7 +111,7 @@ call PetscPrintf(PETSC_COMM_WORLD,'--------------------------'//char(10),ierr)
 !-------------------------------------------------------------------------------
 if (IS_opt_routing==3) then
 
-if (IS_for_bas>0) then 
+if (IS_for_bas>0) then
 call PetscPrintf(PETSC_COMM_WORLD,'Modifying transboundary matrix'//           &
                  char(10),ierr)
 end if
@@ -136,7 +136,7 @@ if ((JS_riv_bas < IS_ownfirst+1 .or.  JS_riv_bas >=IS_ownlast+1) .and.         &
 end if
 
           end if
-     end do 
+     end do
 
           end if
      end do
@@ -164,7 +164,7 @@ if (BS_opt_dam) then
 !-------------------------------------------------------------------------------
 !Breaks matrix connectivity in case dam model is used inside basin studied
 !-------------------------------------------------------------------------------
-if (IS_dam_bas>0) then 
+if (IS_dam_bas>0) then
 call PetscPrintf(PETSC_COMM_WORLD,'Modifying network matrix'//char(10),ierr)
 end if
 
@@ -191,7 +191,7 @@ do JS_dam_bas=1,IS_dam_bas
           end do
           !Breaks connection for traditional Muskingum method
 
-          
+
           write(temp_char,'(i10)') IV_riv_bas_id(JS_riv_bas)
           call PetscPrintf(PETSC_COMM_WORLD,                                   &
                            '         connection broken downstream of reach ID' &
@@ -203,7 +203,7 @@ do JS_dam_bas=1,IS_dam_bas
           !Writes information on connection that was just broken in stdout
 
           end if
-     end do 
+     end do
 
           end if
      end do
@@ -221,7 +221,7 @@ call PetscPrintf(PETSC_COMM_WORLD,'--------------------------'//char(10),ierr)
 !-------------------------------------------------------------------------------
 if (IS_opt_routing==3) then
 
-if (IS_dam_bas>0) then 
+if (IS_dam_bas>0) then
 call PetscPrintf(PETSC_COMM_WORLD,'Modifying transboundary matrix'//           &
                  char(10),ierr)
 end if
@@ -246,7 +246,7 @@ if ((JS_riv_bas < IS_ownfirst+1 .or.  JS_riv_bas >=IS_ownlast+1) .and.         &
 end if
 
           end if
-     end do 
+     end do
 
           end if
      end do

--- a/src/Rapid_routing/rapid_obs_mat.F90
+++ b/src/Rapid_routing/rapid_obs_mat.F90
@@ -4,10 +4,10 @@
 subroutine rapid_obs_mat
 
 !Purpose:
-!Creates a kronecker-type diagonal sparse matrix.  "1" is recorded at the row 
-!and column where observations are available.  
-!Author: 
-!Cedric H. David, 2008-2015. 
+!Creates a kronecker-type diagonal sparse matrix.  "1" is recorded at the row
+!and column where observations are available.
+!Author:
+!Cedric H. David, 2008-2015.
 
 
 !*******************************************************************************
@@ -16,11 +16,11 @@ subroutine rapid_obs_mat
 use rapid_var, only :                                                          &
                    IS_riv_bas,JS_riv_bas,                                      &
                    IS_obs_bas,JS_obs_bas,                                      &
-                   IV_riv_bas_id,IV_obs_tot_id,                                & 
+                   IV_riv_bas_id,IV_obs_tot_id,                                &
                    IV_obs_index,                                               &
                    ZM_Obs,ZS_norm,                                             &
                    ierr,                                                       &
-                   IS_one,ZS_one,temp_char   
+                   IS_one,ZS_one,temp_char
 
 
 implicit none
@@ -29,16 +29,16 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
@@ -51,8 +51,8 @@ call MatSeqAIJSetPreallocation(ZM_Obs,1*IS_one,PETSC_NULL_INTEGER,ierr)
 call MatMPIAIJSetPreallocation(ZM_Obs,1*IS_one,PETSC_NULL_INTEGER,0*IS_one,    &
                                PETSC_NULL_INTEGER,ierr)
 !Very basic preallocation assuming that all reaches have one gage.  Cannot use
-!IV_obs_loc1 for preallocation because it is of size IS_obs_bas and not 
-!IS_riv_bas. To do a better preallocation one needs to count the diagonal 
+!IV_obs_loc1 for preallocation because it is of size IS_obs_bas and not
+!IS_riv_bas. To do a better preallocation one needs to count the diagonal
 !elements in a new vector
 
 !call PetscPrintf(PETSC_COMM_WORLD,'Observation matrix preallocated'//char(10), &
@@ -70,7 +70,7 @@ if (IV_obs_tot_id(IV_obs_index(JS_obs_bas))==IV_riv_bas_id(JS_riv_bas)) then
                             ZS_one,INSERT_VALUES,ierr)
 end if
 
-     enddo 
+     enddo
 enddo
 
 call MatAssemblyBegin(ZM_Obs,MAT_FINAL_ASSEMBLY,ierr)

--- a/src/Rapid_routing/rapid_open_Qfor_file.F90
+++ b/src/Rapid_routing/rapid_open_Qfor_file.F90
@@ -1,11 +1,11 @@
 !*******************************************************************************
 !Subroutine - rapid_open_Qfor
 !*******************************************************************************
-subroutine rapid_open_Qfor_file(Qfor_file) 
+subroutine rapid_open_Qfor_file(Qfor_file)
 
 !Purpose:
 !Open Qfor_file from Fortran.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -24,7 +24,7 @@ implicit none
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 character(len=100), intent(in):: Qfor_file
 
@@ -36,8 +36,7 @@ if (rank==0) open(34,file=Qfor_file,status='old')
 
 
 !*******************************************************************************
-!End 
+!End
 !*******************************************************************************
 
 end subroutine rapid_open_Qfor_file
-

--- a/src/Rapid_routing/rapid_open_Qhum_file.F90
+++ b/src/Rapid_routing/rapid_open_Qhum_file.F90
@@ -1,11 +1,11 @@
 !*******************************************************************************
 !Subroutine - rapid_open_Qhum
 !*******************************************************************************
-subroutine rapid_open_Qhum_file(Qhum_file) 
+subroutine rapid_open_Qhum_file(Qhum_file)
 
 !Purpose:
 !Open Qhum_file from Fortran.
-!Author: 
+!Author:
 !Cedric H. David, 2014-2015.
 
 
@@ -24,7 +24,7 @@ implicit none
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 character(len=100), intent(in):: Qhum_file
 
@@ -36,8 +36,7 @@ if (rank==0) open(36,file=Qhum_file,status='old')
 
 
 !*******************************************************************************
-!End 
+!End
 !*******************************************************************************
 
 end subroutine rapid_open_Qhum_file
-

--- a/src/Rapid_routing/rapid_open_Qobs_file.F90
+++ b/src/Rapid_routing/rapid_open_Qobs_file.F90
@@ -1,11 +1,11 @@
 !*******************************************************************************
 !Subroutine - rapid_open_Qobs
 !*******************************************************************************
-subroutine rapid_open_Qobs_file(Qobs_file) 
+subroutine rapid_open_Qobs_file(Qobs_file)
 
 !Purpose:
 !Open Qobs_file from Fortran.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -24,7 +24,7 @@ implicit none
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 character(len=100), intent(in):: Qobs_file
 
@@ -36,8 +36,7 @@ if (rank==0) open(33,file=Qobs_file,status='old')
 
 
 !*******************************************************************************
-!End 
+!End
 !*******************************************************************************
 
 end subroutine rapid_open_Qobs_file
-

--- a/src/Rapid_routing/rapid_open_Qout_file.F90
+++ b/src/Rapid_routing/rapid_open_Qout_file.F90
@@ -1,11 +1,11 @@
 !*******************************************************************************
 !Subroutine - rapid_open_Qout_file
 !*******************************************************************************
-subroutine rapid_open_Qout_file(Qout_file) 
+subroutine rapid_open_Qout_file(Qout_file)
 
 !Purpose:
 !Open Qout_file from Fortran/netCDF.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -25,7 +25,7 @@ implicit none
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 character(len=100), intent(in):: Qout_file
 
@@ -33,7 +33,7 @@ character(len=100), intent(in):: Qout_file
 !*******************************************************************************
 !Open file
 !*******************************************************************************
-if (rank==0) then 
+if (rank==0) then
      close(99)
      open(99,file=Qout_file,status='old')
      close(99)
@@ -43,8 +43,7 @@ end if
 
 
 !*******************************************************************************
-!End 
+!End
 !*******************************************************************************
 
 end subroutine rapid_open_Qout_file
-

--- a/src/Rapid_routing/rapid_open_Vlat_file.F90
+++ b/src/Rapid_routing/rapid_open_Vlat_file.F90
@@ -1,11 +1,11 @@
 !*******************************************************************************
 !Subroutine - rapid_open_Vlat_file
 !*******************************************************************************
-subroutine rapid_open_Vlat_file(Vlat_file) 
+subroutine rapid_open_Vlat_file(Vlat_file)
 
 !Purpose:
 !Open Vlat_file from Fortran/netCDF.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -25,7 +25,7 @@ implicit none
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 character(len=100), intent(in):: Vlat_file
 
@@ -33,7 +33,7 @@ character(len=100), intent(in):: Vlat_file
 !*******************************************************************************
 !Open file
 !*******************************************************************************
-if (rank==0) then 
+if (rank==0) then
      open(99,file=Vlat_file,status='old')
      close(99)
      IS_nc_status=NF90_OPEN(Vlat_file,NF90_NOWRITE,IS_nc_id_fil_Vlat)
@@ -42,8 +42,7 @@ end if
 
 
 !*******************************************************************************
-!End 
+!End
 !*******************************************************************************
 
 end subroutine rapid_open_Vlat_file
-

--- a/src/Rapid_routing/rapid_phiroutine.F90
+++ b/src/Rapid_routing/rapid_phiroutine.F90
@@ -8,8 +8,8 @@ subroutine rapid_phiroutine(tao,ZV_pnorm,ZS_phi,IS_dummy,ierr)
 !Calculates a cost function phi as a function of model parameters, using means
 !over a given period of time.  The cost function represents the square error
 !between calculated flows and observed flows where observations are available.
-!Author: 
-!Cedric H. David, 2008-2015. 
+!Author:
+!Cedric H. David, 2008-2015.
 
 
 !*******************************************************************************
@@ -42,25 +42,25 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
-#include "finclude/taosolver.h" 
+#include "finclude/taosolver.h"
 !TAO solver
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 Vec, intent(in) :: ZV_pnorm
 TaoSolver, intent(inout)  :: tao
@@ -70,7 +70,7 @@ PetscInt, intent (in) :: IS_dummy
 
 
 !*******************************************************************************
-!Set linear system corresponding to current ZV_pnorm and set initial flowrates  
+!Set linear system corresponding to current ZV_pnorm and set initial flowrates
 !*******************************************************************************
 ZS_phi=0
 !initialize phi to zero
@@ -94,7 +94,7 @@ if (IS_opt_routing==3) call KSPSetType(ksp,KSPPREONLY,ierr)!default=preonly
 
 
 !*******************************************************************************
-!Set initial values to assure subroutine always starts from same conditions 
+!Set initial values to assure subroutine always starts from same conditions
 !*******************************************************************************
 
 !-------------------------------------------------------------------------------
@@ -141,53 +141,53 @@ IV_nc_count=(/IS_riv_tot,1/)
 
 do JS_O=1,IS_O
 
-!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + 
+!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - +
 !calculate mean daily flow
-!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + 
+!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - +
 call VecSet(ZV_QoutbarO,0*ZS_one,ierr)                 !QoutbarO=0
 
 do JS_RpO=1,IS_RpO   !loop needed here since Vlat is more frequent than Qobs
 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-!Read/set surface and subsurface volumes 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!Read/set surface and subsurface volumes
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 call rapid_read_Vlat_file
 
 call VecCopy(ZV_Vlat,ZV_Qlat,ierr)            !Qlat=Vlat
 call VecScale(ZV_Qlat,1/ZS_TauR,ierr)         !Qlat=Qlat/TauR
 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !Read/set upstream forcing
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 if (BS_opt_for .and. IS_for_bas>0                                              &
                    .and. mod((JS_O-1)*IS_RpO+JS_RpO,IS_RpF)==1) then
 
 call rapid_read_Qfor_file
 
-end if 
+end if
 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !Run dam model based on previous values of QoutbarR and Qext to get Qdam
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 if (BS_opt_dam .and. IS_dam_bas>0) then
 
 call rapid_get_Qdam
 
 end if
 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-!Read/set human induced flows 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!Read/set human induced flows
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 if (BS_opt_hum .and. IS_hum_bas>0                                              &
                    .and. mod((JS_O-1)*IS_RpO+JS_RpO,IS_RpH)==1) then
 
 call rapid_read_Qhum_file
 
-end if 
+end if
 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !calculation of Qext
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 call VecCopy(ZV_Qlat,ZV_Qext,ierr)                            !Qext=Qlat
 if (BS_opt_for) call VecAXPY(ZV_Qext,ZS_one,ZV_Qfor,ierr)     !Qext=Qext+1*Qfor
 if (BS_opt_dam) call VecAXPY(ZV_Qext,ZS_one,ZV_Qdam,ierr)     !Qext=Qext+1*Qdam
@@ -208,33 +208,33 @@ call VecCopy(ZV_QoutR,ZV_QoutinitR,ierr)
 call VecAXPY(ZV_QoutbarO,ZS_one/IS_RpO,ZV_QoutbarR,ierr)
 !Qoutbar=QoutbarO+QoutbarR/IS_RpO
 
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-!Update netCDF location         
-!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!Update netCDF location
+!- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 IV_nc_start(2)=IV_nc_start(2)+1
 
 
 enddo                !end of loop to account for forcing more frequent than obs
 
-!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + 
+!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - +
 !Calculate objective function for current day
-!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + 
+!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - +
 call rapid_read_Qobs_file
 
-!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + 
+!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - +
 !Objective function #1 - for current day - square error
-!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + 
+!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - +
 if (IS_opt_phi==1) then
 call VecWAXPY(ZV_temp1,-ZS_one,ZV_Qobs,ZV_QoutbarO,ierr)  !temp1=Qoutbar-Qobs
-call VecScale(ZV_temp1,ZS_phifac,ierr)                    !if phi too big      
+call VecScale(ZV_temp1,ZS_phifac,ierr)                    !if phi too big
 call MatMult(ZM_Obs,ZV_temp1,ZV_temp2,ierr)               !temp2=Obs*temp1
 call VecDot(ZV_temp1,ZV_temp2,ZS_phitemp,ierr)            !phitemp=temp1.temp2
 !result phitemp=(Qoutbar-Qobs)^T*Obs*(Qoutbar-Qobs)
 end if
 
-!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + 
+!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - +
 !Objective function #2 - for current day - square error normalized by avg flow
-!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + 
+!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - +
 if (IS_opt_phi==2) then
 call VecWAXPY(ZV_temp1,-ZS_one,ZV_Qobs,ZV_QoutbarO,ierr)  !temp1=Qoutbar-Qobs
 call VecPointWiseMult(ZV_temp1,ZV_temp1,ZV_Qobsbarrec,ierr)!temp1=temp1.*Qobsbarrec
@@ -243,16 +243,16 @@ call VecDot(ZV_temp1,ZV_temp2,ZS_phitemp,ierr)            !phitemp=temp1.temp2
 !result phitemp=[(Qoutbar-Qobs).*Qobsbarrec]^T*Obs*[(Qoutbar-Qobs).*Qobsbarrec]
 end if
 
-!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + 
+!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - +
 !adds daily objective function to total objective function
-!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + 
+!- + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - +
 ZS_phi=ZS_phi+ZS_phitemp
 !increments phi for each time step during the desired period of optimization
 
 enddo
 
 !-------------------------------------------------------------------------------
-!Close files 
+!Close files
 !-------------------------------------------------------------------------------
 call rapid_close_Vlat_file
 call rapid_close_Qobs_file

--- a/src/Rapid_routing/rapid_read_Qfor_file.F90
+++ b/src/Rapid_routing/rapid_read_Qfor_file.F90
@@ -5,7 +5,7 @@ subroutine rapid_read_Qfor_file
 
 !Purpose:
 !Read Qfor_file from Fortran.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -23,25 +23,25 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
-#include "finclude/petsclog.h" 
+#include "finclude/petsclog.h"
 !PETSc log
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 
 
@@ -57,7 +57,7 @@ if (rank==0) read(34,*) ZV_read_for_tot
 if (rank==0) then
 call VecSetValues(ZV_Qfor,IS_for_bas,IV_for_loc2,                              &
                   ZV_read_for_tot(IV_for_index),INSERT_VALUES,ierr)
-                  !here we only look at the forcing within the basin studied 
+                  !here we only look at the forcing within the basin studied
 end if
 
 !*******************************************************************************
@@ -68,7 +68,7 @@ call VecAssemblyEnd(ZV_Qfor,ierr)
 
 
 !*******************************************************************************
-!End 
+!End
 !*******************************************************************************
 
 end subroutine rapid_read_Qfor_file

--- a/src/Rapid_routing/rapid_read_Qhum_file.F90
+++ b/src/Rapid_routing/rapid_read_Qhum_file.F90
@@ -5,7 +5,7 @@ subroutine rapid_read_Qhum_file
 
 !Purpose:
 !Read Qhum_file from Fortran.
-!Author: 
+!Author:
 !Cedric H. David, 2014-2015.
 
 
@@ -23,25 +23,25 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
-#include "finclude/petsclog.h" 
+#include "finclude/petsclog.h"
 !PETSc log
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 
 
@@ -57,8 +57,8 @@ if (rank==0) read(36,*) ZV_read_hum_tot
 if (rank==0) then
 call VecSetValues(ZV_Qhum,IS_hum_bas,IV_hum_loc1,                              &
                   ZV_read_hum_tot(IV_hum_index),INSERT_VALUES,ierr)
-                  !here we only look at the human-induced flows within the basin 
-                  !studied 
+                  !here we only look at the human-induced flows within the basin
+                  !studied
 end if
 
 !*******************************************************************************
@@ -69,7 +69,7 @@ call VecAssemblyEnd(ZV_Qhum,ierr)
 
 
 !*******************************************************************************
-!End 
+!End
 !*******************************************************************************
 
 end subroutine rapid_read_Qhum_file

--- a/src/Rapid_routing/rapid_read_Qobs_file.F90
+++ b/src/Rapid_routing/rapid_read_Qobs_file.F90
@@ -5,7 +5,7 @@ subroutine rapid_read_Qobs_file
 
 !Purpose:
 !Read Qobs_file from Fortran.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -22,25 +22,25 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
-#include "finclude/petsclog.h" 
+#include "finclude/petsclog.h"
 !PETSc log
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 
 
@@ -69,7 +69,7 @@ call VecAssemblyEnd(ZV_Qobs,ierr)
 
 
 !*******************************************************************************
-!End 
+!End
 !*******************************************************************************
 
 end subroutine rapid_read_Qobs_file

--- a/src/Rapid_routing/rapid_read_Vlat_file.F90
+++ b/src/Rapid_routing/rapid_read_Vlat_file.F90
@@ -5,7 +5,7 @@ subroutine rapid_read_Vlat_file
 
 !Purpose:
 !Read Vlat_file from Fortran.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -25,25 +25,25 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
-#include "finclude/petsclog.h" 
+#include "finclude/petsclog.h"
 !PETSc log
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 
 
@@ -73,7 +73,7 @@ call VecAssemblyEnd(ZV_Vlat,ierr)
 
 
 !*******************************************************************************
-!End 
+!End
 !*******************************************************************************
 
 end subroutine rapid_read_Vlat_file

--- a/src/Rapid_routing/rapid_read_namelist.F90
+++ b/src/Rapid_routing/rapid_read_namelist.F90
@@ -7,8 +7,8 @@ subroutine rapid_read_namelist
 !This subroutine allows to read the RAPID namelist and hence to run the model
 !multiple times without ever have to recompile.  Some information on the options
 !used is also printed in the stdout.
-!Author: 
-!Cedric H. David, 2011-2015. 
+!Author:
+!Cedric H. David, 2011-2015.
 
 
 !*******************************************************************************
@@ -22,7 +22,7 @@ implicit none
 
 
 !*******************************************************************************
-!Read namelist file 
+!Read namelist file
 !*******************************************************************************
 open(88,file=namelist_file,status='old',form='formatted')
 read(88, NL_namelist)
@@ -30,7 +30,7 @@ close(88)
 
 
 !*******************************************************************************
-!Optional prints what was read 
+!Optional prints what was read
 !*******************************************************************************
 !print *, namelist_file
 

--- a/src/Rapid_routing/rapid_routing.F90
+++ b/src/Rapid_routing/rapid_routing.F90
@@ -9,8 +9,8 @@ subroutine rapid_routing(ZV_C1,ZV_C2,ZV_C3,ZV_Qext,                            &
 !Performs flow calculation in each reach of a river network using the Muskingum
 !method (McCarthy 1938).  Also calculates the volume of each reach using a
 !simple first order approximation
-!Author: 
-!Cedric H. David, 2008-2015. 
+!Author:
+!Cedric H. David, 2008-2015.
 
 
 !*******************************************************************************
@@ -40,26 +40,26 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 Vec, intent(in)    :: ZV_C1,ZV_C2,ZV_C3,ZV_Qext,                               &
-                      ZV_QoutinitR,ZV_VinitR 
+                      ZV_QoutinitR,ZV_VinitR
 Vec, intent(out)   :: ZV_QoutR,ZV_QoutbarR
 Vec                :: ZV_VR,ZV_VbarR
 
@@ -79,8 +79,8 @@ call VecGetLocalSize(ZV_QoutR,IS_localsize,ierr)
 !*******************************************************************************
 !Set mean values to zero initialize QoutprevR with QoutinitR
 !*******************************************************************************
-call VecSet(ZV_QoutbarR,0*ZS_one,ierr)                     !Qoutbar=0 
-!call VecSet(ZV_VbarR,0*ZS_one,ierr)                        !Vbar=0 
+call VecSet(ZV_QoutbarR,0*ZS_one,ierr)                     !Qoutbar=0
+!call VecSet(ZV_VbarR,0*ZS_one,ierr)                        !Vbar=0
 !set the means to zero at beginning of iterations over routing time step
 
 call VecCopy(ZV_QoutinitR,ZV_QoutprevR,ierr)               !QoutprevR=QoutinitR
@@ -89,7 +89,7 @@ call VecCopy(ZV_QoutinitR,ZV_QoutprevR,ierr)               !QoutprevR=QoutinitR
 
 
 !*******************************************************************************
-!Temporal loop 
+!Temporal loop
 !*******************************************************************************
 call VecGetArrayF90(ZV_C1,ZV_C1_p,ierr)
 call VecGetArrayF90(ZV_C2,ZV_C2_p,ierr)
@@ -100,10 +100,10 @@ do JS_R=1,IS_R
 !-------------------------------------------------------------------------------
 !Update mean
 !-------------------------------------------------------------------------------
-call VecAXPY(ZV_QoutbarR,ZS_one/IS_R,ZV_QoutprevR,ierr) 
+call VecAXPY(ZV_QoutbarR,ZS_one/IS_R,ZV_QoutprevR,ierr)
 !Qoutbar=Qoutbar+Qoutprev/IS_R
 
-!call VecAXPY(ZV_VbarR,ZS_one/IS_R,ZV_VprevR,ierr)       
+!call VecAXPY(ZV_VbarR,ZS_one/IS_R,ZV_VprevR,ierr)
 !Vbar=Vbar+Vprev/IS_R
 
 !-------------------------------------------------------------------------------
@@ -148,7 +148,7 @@ do JS_riv_bas=1,IS_riv_bas
      ZV_QoutR_p(JS_riv_bas)=ZV_b_p(JS_riv_bas)                                 &
                             +sum(ZV_C1_p(JS_riv_bas)                           &
                                   *ZV_QoutR_p(IM_index_up(JS_riv_bas,1:        &
-                                   IV_nbup(IV_riv_index(JS_riv_bas))))) 
+                                   IV_nbup(IV_riv_index(JS_riv_bas)))))
 end do
 !Taking into account the knowledge of how many upstream locations exist.
 !Similar to exact preallocation of network matrix
@@ -210,7 +210,7 @@ call VecRestoreArrayF90(ZV_QoutRabsmax,ZV_QoutRabsmax_p,ierr)
 end if
 
 !-------------------------------------------------------------------------------
-!Calculation of V (this part can be commented to accelerate parameter 
+!Calculation of V (this part can be commented to accelerate parameter
 !estimation in calibration mode)
 !-------------------------------------------------------------------------------
 !call VecCopy(ZV_QoutR,ZV_VoutR,ierr)                      !Vout=Qout
@@ -233,7 +233,7 @@ end if
 !-------------------------------------------------------------------------------
 call VecCopy(ZV_QoutR,ZV_QoutprevR,ierr)              !Qoutprev=Qout
 !call VecCopy(ZV_VR,ZV_VprevR,ierr)                    !Vprev=V
-!reset previous 
+!reset previous
 
 
 !-------------------------------------------------------------------------------

--- a/src/Rapid_routing/rapid_routing_param.F90
+++ b/src/Rapid_routing/rapid_routing_param.F90
@@ -2,13 +2,13 @@
 !Subroutine - rapid_routing_param
 !*******************************************************************************
 subroutine rapid_routing_param(ZV_k,ZV_x,                                      &
-                               ZV_C1,ZV_C2,ZV_C3,ZM_A) 
+                               ZV_C1,ZV_C2,ZV_C3,ZM_A)
 
 !Purpose:
-!Calculates the Muskingum method (McCarthy 1938) parameters C1, C2 and C3.  
-!Also calculates the matrix A used for linear system solver. 
-!Author: 
-!Cedric H. David, 2010-2015. 
+!Calculates the Muskingum method (McCarthy 1938) parameters C1, C2 and C3.
+!Also calculates the matrix A used for linear system solver.
+!Author:
+!Cedric H. David, 2010-2015.
 
 
 !*******************************************************************************
@@ -26,30 +26,30 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 Vec, intent(in)    :: ZV_k,ZV_x
-Vec, intent(out)   :: ZV_C1,ZV_C2,ZV_C3,ZM_A 
+Vec, intent(out)   :: ZV_C1,ZV_C2,ZV_C3,ZM_A
 
 
 !*******************************************************************************
-!Calculation of the Muskingum method constants (C1,C2,C3) and of the matrix A 
+!Calculation of the Muskingum method constants (C1,C2,C3) and of the matrix A
 !used in the linear system A*Qout=b
 !*******************************************************************************
 call VecCopy(ZV_x,ZV_Cdenom,ierr)
@@ -93,8 +93,7 @@ call MatDiagonalScale(ZM_TC1,ZV_C1,ZV_one,ierr)            !TC1=diag(C1)*TC1
 end if
 
 !*******************************************************************************
-!End 
+!End
 !*******************************************************************************
 
 end subroutine rapid_routing_param
-

--- a/src/Rapid_routing/rapid_set_Qext0.F90
+++ b/src/Rapid_routing/rapid_set_Qext0.F90
@@ -4,17 +4,17 @@
 subroutine rapid_set_Qext0
 
 !Purpose:
-!This subroutine is only useful if a dam model is used and its goal is to 
+!This subroutine is only useful if a dam model is used and its goal is to
 !properly initialize the flow of water into the dams.
-!The inflow of water ZV_Qin_dam_prev from the river network and from outside of 
+!The inflow of water ZV_Qin_dam_prev from the river network and from outside of
 !the river network into the dams is computed based on ZV_QoutbarR and ZV_Qext
-!in the subroutine rapid_get_Qdam.F90. 
-!Therefore, one has to inject the initial value of ZV_Qin_dam_prev (ZV_Qin_dam0) 
-!into either ZV_QoutbarR or ZV_Qext otherwise the initial value will be 
+!in the subroutine rapid_get_Qdam.F90.
+!Therefore, one has to inject the initial value of ZV_Qin_dam_prev (ZV_Qin_dam0)
+!into either ZV_QoutbarR or ZV_Qext otherwise the initial value will be
 !overwritten in rapid_get_Qdam.F90. The latter is used here (through ZV_Qdam)
 !since the modifications made on the network matrix make it difficult to use
 !ZV_Qin_dam_prev without creating a new variable.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -24,7 +24,7 @@ subroutine rapid_set_Qext0
 use rapid_var, only:                                                           &
                    rank,ierr,IS_one,ZS_one,                                    &
                    ZV_Qdam,ZV_Qext,                                            &
-                   IS_dam_tot,JS_dam_tot,IV_dam_pos 
+                   IS_dam_tot,JS_dam_tot,IV_dam_pos
 
 use rapid_var, only:                                                           &
                    ZV_Qin_dam_prev,ZV_Qin_dam0,                                &
@@ -37,20 +37,20 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
-#include "finclude/petsclog.h" 
+#include "finclude/petsclog.h"
 !PETSc log
 
 
@@ -77,7 +77,7 @@ end if
 end if
 
 call VecAssemblyBegin(ZV_Qdam,ierr)
-call VecAssemblyEnd(ZV_Qdam,ierr)      
+call VecAssemblyEnd(ZV_Qdam,ierr)
 !call VecView(ZV_Qdam,PETSC_VIEWER_STDOUT_WORLD,ierr)
 !the values of Qindam0 are set here where the dams are, not downstream of them
 

--- a/src/Rapid_routing/rapid_var.F90
+++ b/src/Rapid_routing/rapid_var.F90
@@ -4,9 +4,9 @@
 module rapid_var
 
 !Purpose:
-!Module where all the variables are defined. 
-!Author: 
-!Cedric H. David, 2008-2015. 
+!Module where all the variables are defined.
+!Author:
+!Cedric H. David, 2008-2015.
 
 
 implicit none
@@ -15,24 +15,24 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and Fortran90-specific vectors 
-#include "finclude/petscmat.h"    
+!vectors, and Fortran90-specific vectors
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
-!#include "finclude/petsclog.h" 
+!#include "finclude/petsclog.h"
 !Profiling log
 
 #ifndef NO_TAO
-#include "finclude/taosolver.h" 
+#include "finclude/taosolver.h"
 !TAO solver
 #endif
 
@@ -43,7 +43,7 @@ implicit none
 logical :: BS_opt_Qinit
 !.false. --> no read initial flow    .true. --> read initial flow
 logical :: BS_opt_Qfinal
-!.false. --> no write final flow     .true. --> write final flow 
+!.false. --> no write final flow     .true. --> write final flow
 logical :: BS_opt_hum
 !.false. --> no human-induced flows  .true. --> human-induced flows
 logical :: BS_opt_for
@@ -80,13 +80,13 @@ character(len=120) :: hum_tot_id_file
 character(len=120) :: hum_use_id_file
 !unit 15 - file with all the IDs of the reaches used
 character(len=120) :: for_tot_id_file
-!unit 16 - file with all the IDs where flows can be used as forcing to their 
-!corresponding downstream reach  
+!unit 16 - file with all the IDs where flows can be used as forcing to their
+!corresponding downstream reach
 character(len=120) :: for_use_id_file
-!unit 17 - file with all the IDs of the reaches used 
+!unit 17 - file with all the IDs of the reaches used
 character(len=120) :: dam_tot_id_file
-!unit 18 - file with all the IDs of the reaches where the dam model runs and 
-!flows to their corresponding downstream reach  
+!unit 18 - file with all the IDs of the reaches where the dam model runs and
+!flows to their corresponding downstream reach
 character(len=120) :: dam_use_id_file
 !unit 19 - file with all the IDs of the reaches used
 
@@ -94,7 +94,7 @@ character(len=120) :: k_file
 !unit 20 - file with values for k (possibly from previous param. estim.)
 character(len=120) :: x_file
 !unit 21 - file with values for x (possibly from previous param. estim.)
-character(len=120) :: kfac_file  
+character(len=120) :: kfac_file
 !unit 22 - file with kfac for all reaches of the domain
 character(len=120) :: xfac_file
 !unit 23 - file with xfac for all reaches of the domain
@@ -102,7 +102,7 @@ character(len=120) :: xfac_file
 character(len=120) :: Qinit_file
 !unit 30 - file where initial flowrates can be stored to run the model with them
 character(len=120) :: Qfinal_file
-!unit 31 - file where final flowrates can be stored at the end of model run 
+!unit 31 - file where final flowrates can be stored at the end of model run
 character(len=120) :: Vlat_file
 
 character(len=120) :: Qobs_file
@@ -113,7 +113,7 @@ character(len=120) :: Qfor_file
 character(len=120) :: Qobsbarrec_file
 !unit 35 - file where the reciprocal (1/xi) of the average obs are stored.
 character(len=120) :: Qhum_file
-!unit 36 - file where human-induced flowrates are stored.  These flows are added 
+!unit 36 - file where human-induced flowrates are stored.  These flows are added
 !upstream.
 
 character(len=120) :: V_file
@@ -122,11 +122,11 @@ character(len=120) :: babsmax_file
 !unit 42 - file where the maximum of the absolute values of the right-hand-side
 !are stored
 character(len=120) :: QoutRabsmin_file
-!unit 43 - file where the minimum of the absolute values of the instantaneous 
-!flows are stored 
+!unit 43 - file where the minimum of the absolute values of the instantaneous
+!flows are stored
 character(len=120) :: QoutRabsmax_file
-!unit 44 - file where the maximum of the absolute values of the instantaneous 
-!flows are stored 
+!unit 44 - file where the maximum of the absolute values of the instantaneous
+!flows are stored
 character(len=120) :: Qout_file
 
 
@@ -140,7 +140,7 @@ PetscScalar :: ZS_dtM
 PetscInt :: IS_M
 !Number of time steps within the main precedure
 PetscInt :: JS_M
-!Index of main procedure 
+!Index of main procedure
 
 PetscScalar :: ZS_TauO
 !Duration of optimization procedure, in seconds
@@ -149,28 +149,28 @@ PetscScalar :: ZS_dtO
 PetscInt :: IS_O
 !Number of time steps within the optimization precedure
 PetscInt :: JS_O
-!Index of optimization procedure 
+!Index of optimization procedure
 
 PetscScalar :: ZS_TauR
 !Duration of river routing procedure, in seconds
-PetscScalar :: ZS_dtR  
-!Time step of river routing procedure, in seconds  
+PetscScalar :: ZS_dtR
+!Time step of river routing procedure, in seconds
 PetscInt :: IS_R
 !Number of time steps within the river routing procedure
 PetscInt :: JS_R
 !Index of river routing procedure
 
 PetscScalar :: ZS_dtF
-!Time step of forcing data, in seconds  
+!Time step of forcing data, in seconds
 PetscScalar :: ZS_dtH
-!Time step of human-induced data, in seconds  
+!Time step of human-induced data, in seconds
 
 PetscInt :: IS_RpO, JS_RpO
 !Number routing procedures needed per optimization time step, and index
 PetscInt :: IS_RpM, JS_RpM
-!Number routing procedures needed per main time step, and index 
+!Number routing procedures needed per main time step, and index
 PetscInt :: IS_RpF
-!Number routing procedures needed per forcing time step 
+!Number routing procedures needed per forcing time step
 PetscInt :: IS_RpH
 !Number routing procedures needed per human-induced time step
 
@@ -188,7 +188,7 @@ PetscInt, dimension(:), allocatable :: IV_riv_tot_id
 PetscInt, dimension(:), allocatable :: IV_down
 !vector of the downstream river reach of each river reach
 PetscInt, dimension(:), allocatable :: IV_nbup
-!vector of the number of direct upstream river reach of each river reach 
+!vector of the number of direct upstream river reach of each river reach
 PetscInt :: IS_max_up
 !maximum number of upstream river reaches for each river reach
 PetscInt, dimension(:,:), allocatable :: IM_up
@@ -199,22 +199,22 @@ PetscInt :: IS_row,IS_col
 !index of rows and columns used to fill up the network matrix
 PetscInt,dimension (:,:), allocatable :: IM_index_up
 !matrix with the index of the upstream river reaches of each river reach
-!index goes from 1 to IS_riv_bas 
+!index goes from 1 to IS_riv_bas
 PetscInt, dimension(:),allocatable :: IV_riv_bas_id
 !unique IDs in riv_bas_id_file, of length IS_riv_bas
 PetscInt, dimension(:), allocatable :: IV_riv_index
 !indexes (Fortran, 1-based) of the reaches in the _riv within the whole network
 !size IS_riv_bas
 PetscInt,dimension(:), allocatable :: IV_riv_loc1
-!vector giving the zero-base index corresponding to the river reaches within 
+!vector giving the zero-base index corresponding to the river reaches within
 !the _riv studied only, to be used in VecSetValues. size IS_riv_bas
 Mat :: ZM_hsh_tot
-!flat matrix with size IS_riv_id_max*ncore that serves a hashtable-like purpose 
-!in which the index over the domain (JS_riv_tot) is stored at the location of 
+!flat matrix with size IS_riv_id_max*ncore that serves a hashtable-like purpose
+!in which the index over the domain (JS_riv_tot) is stored at the location of
 !each reach ID. Each row contains the exact same data.
 Mat :: ZM_hsh_bas
-!flat matrix with size IS_riv_id_max*ncore that serves a hashtable-like purpose 
-!in which the index over the basin (JS_riv_bas) is stored at the location of 
+!flat matrix with size IS_riv_id_max*ncore that serves a hashtable-like purpose
+!in which the index over the basin (JS_riv_bas) is stored at the location of
 !each reach ID. Each row contains the exact same data.
 PetscInt :: IS_riv_id_max=1000000000
 !Maximum value allowed for the unique integer IDs corresponding to each reach
@@ -224,22 +224,22 @@ PetscInt :: IS_riv_id_max=1000000000
 !*******************************************************************************
 PetscInt :: IS_obs_tot, JS_obs_tot
 !total number of reaches that have observations (gaged reaches), corresponds to
-!the number of lines in obs_tot_id_file 
+!the number of lines in obs_tot_id_file
 PetscInt :: IS_obs_use, JS_obs_use
 !Number of gages available in obs_use_id_file
 PetscInt :: IS_obs_bas, JS_obs_bas
-!Number of gages within _riv studied.  Will be calculated based on 
+!Number of gages within _riv studied.  Will be calculated based on
 !obs_tot_id_file, obs_use_id_file and riv_bas_id_file
 PetscInt, dimension(:), allocatable :: IV_obs_tot_id
 !vector where are stored the river ID of each gage available
 PetscInt, dimension(:), allocatable :: IV_obs_use_id
 !vector where are stored the river ID of each gage used in current run
 PetscInt, allocatable, dimension(:) :: IV_obs_index
-!vector where the Fortran 1-based indexes of the gages within the Qobs_file. 
+!vector where the Fortran 1-based indexes of the gages within the Qobs_file.
 !Will be allocated size IS_obs_bas
 PetscInt, allocatable, dimension(:) :: IV_obs_loc1
-!vector where the C (0-based) vector indexes of where gages are. This is 
-!within the _riv only, not all domain. Will be used in VecSet.  Will be 
+!vector where the C (0-based) vector indexes of where gages are. This is
+!within the _riv only, not all domain. Will be used in VecSet.  Will be
 !allocated size IS_obs_bas
 
 
@@ -247,7 +247,7 @@ PetscInt, allocatable, dimension(:) :: IV_obs_loc1
 !Declaration of variables - Human-induced flow variables
 !*******************************************************************************
 PetscInt :: IS_hum_tot, JS_hum_tot
-!total number of reaches where human-induced flow data are available. 
+!total number of reaches where human-induced flow data are available.
 PetscInt :: IS_hum_use, JS_hum_use
 !total number of reaches where human-induced will be used if in sub_riv
 PetscInt :: IS_hum_bas, JS_hum_bas
@@ -260,11 +260,11 @@ PetscInt, dimension(:), allocatable :: IV_hum_use_id
 PetscInt, dimension(:), allocatable :: IV_hum_bas_id
 !IDs of the reaches where human-indeced flow data to be used is in sub_riv
 PetscInt, allocatable, dimension(:) :: IV_hum_index
-!vector where the Fortran 1-based indexes of the human-induced flow data are 
-!stored. This is of size IS_hum_bas and its elements belong to [1,IS_hum_tot]. 
+!vector where the Fortran 1-based indexes of the human-induced flow data are
+!stored. This is of size IS_hum_bas and its elements belong to [1,IS_hum_tot].
 PetscInt, allocatable, dimension(:) :: IV_hum_loc1
-!vector where the C (0-based) vector indexes of where the above human-induced 
-!flow data are going to be applied. This is of size IS_hum_bas and its elements 
+!vector where the C (0-based) vector indexes of where the above human-induced
+!flow data are going to be applied. This is of size IS_hum_bas and its elements
 !belong to [0,IS_riv_bas-1]. Applied on the river ID itself.
 
 
@@ -272,7 +272,7 @@ PetscInt, allocatable, dimension(:) :: IV_hum_loc1
 !Declaration of variables - Forcing flow variables
 !*******************************************************************************
 PetscInt :: IS_for_tot, JS_for_tot
-!total number of reaches where forcing flow data are available. 
+!total number of reaches where forcing flow data are available.
 PetscInt :: IS_for_use, JS_for_use
 !total number of reaches where forcing will be used if in sub_riv
 PetscInt :: IS_for_bas, JS_for_bas
@@ -285,11 +285,11 @@ PetscInt, dimension(:), allocatable :: IV_for_use_id
 PetscInt, dimension(:), allocatable :: IV_for_bas_id
 !IDs of the reaches where forcing flow data to be used is in sub_riv
 PetscInt, allocatable, dimension(:) :: IV_for_index
-!vector where the Fortran 1-based indexes of the forcing flow data are 
-!available. This is of size IS_for_bas and its elements belong to [1,IS_for_tot] 
+!vector where the Fortran 1-based indexes of the forcing flow data are
+!available. This is of size IS_for_bas and its elements belong to [1,IS_for_tot]
 PetscInt, allocatable, dimension(:) :: IV_for_loc2
-!vector where the C (0-based) vector indexes of where the above forcing 
-!flow data are going to be applied. This is of size IS_for_bas and its elements 
+!vector where the C (0-based) vector indexes of where the above forcing
+!flow data are going to be applied. This is of size IS_for_bas and its elements
 !belong to [0,IS_riv_bas-1]. Applied on the river ID downstream.
 
 
@@ -297,12 +297,12 @@ PetscInt, allocatable, dimension(:) :: IV_for_loc2
 !Declaration of variables - dam model flow variables
 !*******************************************************************************
 PetscInt :: IS_dam_tot, JS_dam_tot
-!total number of reaches where dam model flow data are available. 
+!total number of reaches where dam model flow data are available.
 PetscInt :: IS_dam_use, JS_dam_use
 !total number of reaches where dam model will be used if in sub_riv
 PetscInt :: IS_dam_bas, JS_dam_bas
 !number of reaches forced by observations, within _riv. Calculated on the fly
-!from dam_tot_id_file, dam_use_id_file and riv_bas_id_file. 
+!from dam_tot_id_file, dam_use_id_file and riv_bas_id_file.
 PetscInt, dimension(:), allocatable :: IV_dam_tot_id
 !IDs of the reaches where dam model flow data are available
 PetscInt, dimension(:), allocatable :: IV_dam_use_id
@@ -310,22 +310,22 @@ PetscInt, dimension(:), allocatable :: IV_dam_use_id
 PetscInt, dimension(:), allocatable :: IV_dam_bas_id
 !IDs of the reaches where dam model flow data to be used is in sub_riv
 PetscInt, allocatable, dimension(:) :: IV_dam_index
-!vector where the Fortran 1-based indexes of the dam model flow data are 
-!available. This is of size IS_dam_bas and its elements belong to [1,IS_dam_tot] 
+!vector where the Fortran 1-based indexes of the dam model flow data are
+!available. This is of size IS_dam_bas and its elements belong to [1,IS_dam_tot]
 PetscInt, allocatable, dimension(:) :: IV_dam_loc2
 !vector where the C (0-based) vector indexes of where the above dam model
-!flow data are going to be applied. This is of size IS_dam_bas and its elements 
+!flow data are going to be applied. This is of size IS_dam_bas and its elements
 !belong to [0,IS_riv_bas-1]. Applied on the river ID downstream.
 PetscInt, allocatable, dimension(:) :: IV_dam_pos
-!vector where the Fortran 1-based vector indexes of where flows will be given to 
-!the above dam model. This is of size IS_dam_tot and its elements belong to 
-![1,IS_riv_bas] except when a dam ID is outside of basin studied where it is 0. 
+!vector where the Fortran 1-based vector indexes of where flows will be given to
+!the above dam model. This is of size IS_dam_tot and its elements belong to
+![1,IS_riv_bas] except when a dam ID is outside of basin studied where it is 0.
 !Applied on the river ID itself.
 
 PetscScalar, allocatable, dimension(:) :: ZV_Qin_dam,ZV_Qin_dam_prev
 PetscScalar, allocatable, dimension(:) :: ZV_Qout_dam,ZV_Qout_dam_prev
 PetscScalar, allocatable, dimension(:) :: ZV_Qin_dam0,ZV_Qout_dam0
-!Fortran vectors where the inflows and outflows for the dam module are saved. 
+!Fortran vectors where the inflows and outflows for the dam module are saved.
 !These will be allocated to size IS_dam_tot
 
 
@@ -335,7 +335,7 @@ PetscScalar, allocatable, dimension(:) :: ZV_Qin_dam0,ZV_Qout_dam0
 Mat :: ZM_Net
 !Network matrix
 Mat :: ZM_A
-!Matrix used to solve linear system 
+!Matrix used to solve linear system
 Mat :: ZM_T
 !Transboundary matrix
 Mat :: ZM_TC1
@@ -346,9 +346,9 @@ Logical :: BS_logical
 Vec :: ZV_k,ZV_x
 !Muskingum expression constants vectors, k in seconds, x has no dimension
 Vec :: ZV_p, ZV_pnorm,ZV_pfac
-!vector of the problem parameters, p=(k,x).  normalized version and 
+!vector of the problem parameters, p=(k,x).  normalized version and
 !corresponding factors p=pnorm*pfac
-Vec :: ZV_C1,ZV_C2,ZV_C3,ZV_Cdenom 
+Vec :: ZV_C1,ZV_C2,ZV_C3,ZV_Cdenom
 !Muskingum method constants (last is the common denominator, for calculations)
 Vec :: ZV_b,ZV_babsmax,ZV_bhat
 !Used for linear system A*Qout=b
@@ -356,7 +356,7 @@ Vec :: ZV_b,ZV_babsmax,ZV_bhat
 !Input variables (contribution)
 Vec :: ZV_Qext,ZV_Qfor,ZV_Qlat,ZV_Qhum,ZV_Qdam
 !flowrates Qext is the sum of forced and lateral
-Vec :: ZV_Vext,ZV_Vfor,ZV_Vlat 
+Vec :: ZV_Vext,ZV_Vfor,ZV_Vlat
 !volumes (same as above)
 
 !Main only variables
@@ -411,7 +411,7 @@ PetscScalar :: ZS_k,ZS_x
 
 
 !*******************************************************************************
-!Declaration of variables - routing parameters and initial values 
+!Declaration of variables - routing parameters and initial values
 !*******************************************************************************
 PetscScalar :: ZS_V0=10000,ZS_Qout0=0
 !values to be used in the intitial state of V and Qout for river routing
@@ -428,9 +428,9 @@ KSP :: ksp
 PC :: pc
 !preconditioner object
 PetscMPIInt :: rank
-!integer where the number of each processor is stored, 0 will be main processor 
+!integer where the number of each processor is stored, 0 will be main processor
 PetscMPIInt :: ncore
-!integer where the number of cores used is stored 
+!integer where the number of cores used is stored
 VecScatter :: vecscat
 !Allows for scattering and gathering vectors from in parallel environement
 PetscLogEvent :: stage
@@ -439,7 +439,7 @@ PetscLogEvent :: stage
 PetscInt :: IS_ksp_iter, IS_ksp_iter_max
 !integer where the number of iterations in KSP is solved
 PetscInt :: IS_one=1
-!integer of value 1.  to be used in MatSetValues and VecSet. Directly using 
+!integer of value 1.  to be used in MatSetValues and VecSet. Directly using
 !the value 1 in the functions crashes PETSc
 PetscScalar :: ZS_one=1
 !Scalars of values 1 and 0, same remark as above
@@ -448,7 +448,7 @@ PetscScalar :: ZS_val
 Vec :: ZV_one
 !vector with only ones, useful for creation of matrices here
 Vec :: ZV_SeqZero
-!Sequential vector of size IS_riv_bas, allows for gathering data on zeroth 
+!Sequential vector of size IS_riv_bas, allows for gathering data on zeroth
 !precessor before writing in file
 
 PetscScalar,dimension(:), allocatable :: ZV_read_riv_tot
@@ -472,7 +472,7 @@ character(len=10) :: temp_char,temp_char2
 !then use PetscPrintf
 
 PetscInt, dimension(:), allocatable :: IV_nz, IV_dnz, IV_onz
-!number of nonzero elements per row for network matrix.  nz for sequential, dnz 
+!number of nonzero elements per row for network matrix.  nz for sequential, dnz
 !and onz for distributed matrix (diagonal and off-diagonal elements)
 PetscInt :: IS_ownfirst, IS_ownlast
 !Ownership of each processor
@@ -487,7 +487,7 @@ TaoSolver :: tao
 TaoSolverTerminationReason :: reason
 !TAO terminate reason object
 Vec :: ZV_1stIndex, ZV_2ndIndex
-!ZV_1stIndex=[1;0], ZV_2ndIndex=[0,1].  Used with VecDot to extract first and 
+!ZV_1stIndex=[1;0], ZV_2ndIndex=[0,1].  Used with VecDot to extract first and
 !second indexes of the vector of parameter
 #endif
 
@@ -530,7 +530,7 @@ namelist /NL_namelist/                                                         &
                        ZS_TauM,ZS_dtM,ZS_TauO,ZS_dtO,ZS_TauR,ZS_dtR,           &
                        ZS_dtF,ZS_dtH,                                          &
                        ZS_phifac,IS_strt_opt
- 
+
 character(len=120) :: namelist_file
 !unit 88 - Namelist
 

--- a/src/Rapid_routing/rapid_write_Qout_file.F90
+++ b/src/Rapid_routing/rapid_write_Qout_file.F90
@@ -5,7 +5,7 @@ subroutine rapid_write_Qout_file
 
 !Purpose:
 !Write into Qout_file from Fortran/netCDF.
-!Author: 
+!Author:
 !Cedric H. David, 2013-2015.
 
 
@@ -25,25 +25,25 @@ implicit none
 !*******************************************************************************
 !Includes
 !*******************************************************************************
-#include "finclude/petscsys.h"       
+#include "finclude/petscsys.h"
 !base PETSc routines
-#include "finclude/petscvec.h"  
+#include "finclude/petscvec.h"
 #include "finclude/petscvec.h90"
-!vectors, and vectors in Fortran90 
-#include "finclude/petscmat.h"    
+!vectors, and vectors in Fortran90
+#include "finclude/petscmat.h"
 !matrices
-#include "finclude/petscksp.h"    
+#include "finclude/petscksp.h"
 !Krylov subspace methods
-#include "finclude/petscpc.h"     
+#include "finclude/petscpc.h"
 !preconditioners
 #include "finclude/petscviewer.h"
 !viewers (allows writing results in file for example)
-#include "finclude/petsclog.h" 
+#include "finclude/petsclog.h"
 !PETSc log
 
 
 !*******************************************************************************
-!Intent (in/out), and local variables 
+!Intent (in/out), and local variables
 !*******************************************************************************
 
 
@@ -76,7 +76,7 @@ if (rank==0) call VecRestoreArrayF90(ZV_SeqZero,ZV_pointer,ierr)
 
 
 !*******************************************************************************
-!End 
+!End
 !*******************************************************************************
 
 end subroutine rapid_write_Qout_file

--- a/src/Routing/Noah_distr_routing.F
+++ b/src/Routing/Noah_distr_routing.F
@@ -1337,4 +1337,3 @@ subroutine time_seconds(i3)
         time_array(7) + 0.001 * time_array(8)
     return
 end subroutine time_seconds
-

--- a/src/Routing/Overland/module_overland_mass_balance.F
+++ b/src/Routing/Overland/module_overland_mass_balance.F
@@ -11,12 +11,12 @@ implicit none
    ! holds variables used for mass balance
    type overland_mass_balance_struct
       ! mass balance
-      
+
       ! replaced with accumulated_change_in_soil_moisture
       !real(kind=8) :: dsmctot
       ! total difference in soil moisture each timestep
       real(kind=8) :: accumulated_change_in_soil_moisture
-      
+
       ! replaced with pre_soil_mosture_content
       !real(kind=8) :: smctot1     ! NEED VARIABLE INFO
       ! Pre time step soil moisture content accumulator  (mm) TODO verify unit
@@ -29,14 +29,14 @@ implicit none
 
       ! replaced with pre_infiltration_excess
       !real(kind=8) :: suminfxs1  ! NEED VARIABLE INFO
-      
+
       ! Pre time step infiltration excess accumulator    (mm) TODO verify unit
       ! FIX ME -- this variable was declared as real(kind=8) as mis match with parameter specification
       ! in Noah_distributed_routing.F:OverlandRouting matched it with parameter specified as real(kind=4)
       ! this caused an implicit cast to single percision float which was required as the value was then used
       ! in the sum_real mpi call which required single percision. Does this variable need to be a double?
       real :: pre_infiltration_excess
-      
+
       ! replaced with post_infiltration_excess
       !real(kind=8) :: suminfxsrt  ! NEED VARIABLE INFO
       ! Post time step infiltration excess accumulator   (mm) TODO verify unit
@@ -45,7 +45,7 @@ implicit none
       ! this caused an implicit cast to single percision float which was required as the value was then used
       ! in the sum_real mpi call which required single percision. Does this variable need to be a double?
       real :: post_infiltration_excess
-      
+
    contains
         procedure :: init => overland_mass_balance_init
         procedure :: destroy => overland_mass_balance_destroy

--- a/src/Routing/Subsurface/module_subsurface_static_data.F
+++ b/src/Routing/Subsurface/module_subsurface_static_data.F
@@ -2,13 +2,13 @@ module module_subsurface_static_data
     implicit none
 
     type subsurface_static_interface
-    
+
     integer :: ixrt
     integer :: jxrt
     integer :: nsoil
     real :: dt
-    integer :: rt_option 
- 
+    integer :: rt_option
+
     contains
         procedure :: init => subsurface_static_data_init
         procedure :: destroy => subsurface_static_data_destroy

--- a/src/Routing/module_GW_baseflow.F
+++ b/src/Routing/module_GW_baseflow.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_GW_baseflow
@@ -34,7 +34,7 @@ module module_GW_baseflow
 contains
 
 !------------------------------------------------------------------------------
-!DJG   Simple GW Bucket Model 
+!DJG   Simple GW Bucket Model
 !      for NHDPLUS mapping
 !------------------------------------------------------------------------------
 
@@ -51,19 +51,19 @@ contains
         qout_gwsubbas, qin_gwsubbas,      &
         qloss_gwsubbas,                   &
         GWBASESWCRT,   OVRTSWCRT,         &
-        LNLINKSL,                         & 
+        LNLINKSL,                         &
         basns_area,                       &
         nhdBuckMask,   bucket_loss,       &
-        channelBucket_only ) 
+        channelBucket_only )
 
    use module_UDMAP, only: LNUMRSL, LUDRSL
 
    implicit none
-   
+
 !!!Declarations...
    integer, intent(in)                               :: ix,jx,ixrt,jxrt
    integer, intent(in)                               :: numbasns, lnlinksl
-   real, intent(in), dimension(ix,jx)                :: runoff2x_in 
+   real, intent(in), dimension(ix,jx)                :: runoff2x_in
    real, dimension(ixrt,jxrt)                            :: runoff2x , runoff1x
    real, intent(in), dimension(ix,jx)                :: runoff1x_in, area_lsm
    real, intent(in)                                  :: cellArea(ixrt,jxrt),DT
@@ -81,7 +81,7 @@ contains
    integer, intent(in)                               :: OVRTSWCRT
    real, intent(in), dimension(numbasns)             :: basns_area
    integer, intent(in)                               :: channelBucket_only
-   integer, intent(in)                               :: bucket_loss   
+   integer, intent(in)                               :: bucket_loss
 
    real, dimension(numbasns)                         :: net_perc
    integer, dimension(numbasns)                      :: nhdBuckMask
@@ -118,7 +118,7 @@ contains
              do AGGFACXRT=AGGFACTRT-1,0,-1
                IXXRT=I*AGGFACTRT-AGGFACXRT
                JYYRT=J*AGGFACTRT-AGGFACYRT
-#ifdef MPP_LAND  
+#ifdef MPP_LAND
        if(left_id.ge.0) IXXRT=IXXRT+1
        if(down_id.ge.0) JYYRT=JYYRT+1
 !              if(AGGFACTRT .eq. 1) then
@@ -149,7 +149,7 @@ contains
        LQLateral = 0
        do k = 1, LNUMRSL
               ! get from land grid runoff
-               do m = 1, LUDRSL(k)%ncell 
+               do m = 1, LUDRSL(k)%ncell
                    ii =  LUDRSL(k)%cell_i(m)
                    jj =  LUDRSL(k)%cell_j(m)
                    if(ii .gt. 0 .and. jj .gt. 0) then
@@ -181,7 +181,7 @@ contains
          if(channelBucket_only .eq. 0) then
             !! If not using channelBucket_only, save qin_gwsubbas
             qin_gwsubbas(bas) = net_perc(bas)             !units (m^3)
-         else 
+         else
             !! If using channelBucket_only, get net_perc from the passed qin_gwsubbas
             net_perc(bas)     = qin_gwsubbas(bas)         !units (m^3)
          end if
@@ -203,12 +203,12 @@ contains
             !                    if(z_mx(bas) .gt. 5) then
             !                         z_mx(bas) = z_mx(bas) * mm_to_m    ! change from mm to meters
             !                    endif
- 
+
                if (z_gwsubbas(bas).gt.z_mx(bas) * mm_to_m) then  !If/then for bucket overflow case...
 
                     z_gw_spill = z_gwsubbas(bas) - z_mx(bas) * mm_to_m    ! meters
                     z_gwsubbas(bas) = z_mx(bas) * mm_to_m    ! meters
- 
+
                else
                       z_gw_spill = 0.
                end if   ! End if for bucket overflow case...
@@ -220,18 +220,18 @@ contains
 
 
 ! Assume exponential relation between z/zmax and Q...
-!DJG force asymptote to zero to prevent 'overdraft'... 
+!DJG force asymptote to zero to prevent 'overdraft'...
                if(GWBASESWCRT.eq.1) then ! Exponential model
                    qout_gwsubbas(bas) = C(bas)*(exp(ex(bas)*z_gwsubbas(bas)/(z_mx(bas) * mm_to_m))-1) ! q_out (m^3/s)
 
                elseif(GWBASESWCRT.eq.4) then ! Updated exponential model normalized by area
                    qout_gwsubbas(bas) = C(bas)*(basns_area(bas)*sqm_to_sqkm)*(exp(ex(bas)*z_gwsubbas(bas)/(z_mx(bas)*mm_to_m))-1) ! q_out (m^3/s)
-       
+
                end if
 
 !DJG...Calculation of max bucket outlfow that is limited by total quantity in bucket...
                qout_gwsubbas(bas) = MIN(qout_max,qout_gwsubbas(bas))   ! Limit bucket discharge to max. bucket limit   (m^3/s)
-               
+
                if (bucket_loss .eq. 1) then
                     qloss_gwsubbas(bas) = qout_gwsubbas(bas)*loss_fraction(bas)
                     qout_gwsubbas(bas) = qout_gwsubbas(bas)-qloss_gwsubbas(bas) 
@@ -284,13 +284,13 @@ contains
                             qout_gwsubbas,qinflowbase,gw_strm_msk,gwbas_pix_ct,dist,DT,&
                             C,ex,z_mx,GWBASESWCRT,OVRTSWCRT)
    implicit none
-   
+
 !!!Declarations...
    integer, intent(in)                               :: ix,jx,ixrt,jxrt
    integer, intent(in)                               :: numbasns, gnumbasns
    integer, intent(in), dimension(ix,jx)             :: gwsubbasmsk
-   real, intent(in), dimension(ix,jx)                :: runoff2x_in 
-   real, dimension(ix,jx)                            :: runoff2x 
+   real, intent(in), dimension(ix,jx)                :: runoff2x_in
+   real, dimension(ix,jx)                            :: runoff2x
    real, intent(in), dimension(ix,jx)                :: runoff1x_in
    real, dimension(ix,jx)                            :: runoff1x
    real, intent(in)                                  :: basns_area(numbasns),dist(ixrt,jxrt,9),DT
@@ -306,7 +306,7 @@ contains
    integer, intent(in),dimension(ixrt,jxrt)          :: gw_strm_msk, gw_strm_msk_lind
    integer, intent(in)                               :: GWBASESWCRT
    integer, intent(in)                               :: OVRTSWCRT
-   
+
 
    real*8, dimension(numbasns)                      :: sum_perc8, ct_bas8, sum_perc8_surf
    real, dimension(numbasns)                        :: sum_perc, sum_perc_surf
@@ -371,7 +371,7 @@ contains
    sum_perc = sum_perc8
    sum_perc_surf = sum_perc8_surf
    ct_bas = ct_bas8
-   
+
 
 
 
@@ -430,10 +430,10 @@ contains
 
 ! Assume exponential relation between z/zmax and Q...
 !DJG...old...creates non-asymptotic flow...   qout_gwsubbas(bas) = C(bas)*EXP(ex(bas)*z_gwsubbas(bas)/z_mx(bas)) !Exp.model. q_out (m^3/s)
-!DJG force asymptote to zero to prevent 'overdraft'... 
+!DJG force asymptote to zero to prevent 'overdraft'...
 !DJG debug hardwire test...       qout_gwsubbas(bas) = 1*(EXP(7.0*10./100.)-1) !Exp.model. q_out (m^3/s)
      qout_gwsubbas(bas) = C(bas)*(EXP(ex(bas)*z_gwsubbas(bas)/z_mx(bas))-1) !Exp.model. q_out (m^3/s)
-       
+
 !DJG...Calculation of max bucket outlfow that is limited by total quantity in bucket...
      qout_gwsubbas(bas) = MIN(qout_max,qout_gwsubbas(bas))   ! Limit bucket discharge to max. bucket limit
 
@@ -524,20 +524,20 @@ contains
       integer ::    i,j,ixrt,jxrt,numbasns, bas, gnumbasns, k
       integer,dimension(ixrt,jxrt) :: in_gw_strm_msk
       integer,dimension(global_rt_nx,global_rt_ny) :: gw_strm_msk
-      real,dimension(numbasns) :: gwbas_pix_ct 
-      real,dimension(gnumbasns) :: tmp_gwbas_pix_ct 
+      real,dimension(numbasns) :: gwbas_pix_ct
+      real,dimension(gnumbasns) :: tmp_gwbas_pix_ct
       integer(kind=int64), intent(in), dimension(:) :: basnsInd
 
       gw_strm_msk = 0
 
 
-      call write_IO_rt_int(in_gw_strm_msk, gw_strm_msk)    
-    
-      call mpp_land_sync() 
+      call write_IO_rt_int(in_gw_strm_msk, gw_strm_msk)
+
+      call mpp_land_sync()
 
       if(my_id .eq. IO_id) then
 !        tmp_gwbas_pix_ct = 0.0
-!         do bas = 1,gnumbasns  
+!         do bas = 1,gnumbasns
 !         do i=1,global_rt_nx
 !           do j=1,global_rt_ny
 !             if(gw_strm_msk(i,j) .eq. bas) then
@@ -558,7 +558,7 @@ contains
             end do
       end if
 
-      call mpp_land_sync() 
+      call mpp_land_sync()
 
       if(gnumbasns .gt. 0) then
          call mpp_land_bcast_real(gnumbasns,tmp_gwbas_pix_ct)
@@ -577,4 +577,4 @@ contains
 
 
 
-end module module_GW_baseflow   
+end module module_GW_baseflow

--- a/src/Routing/module_HYDRO_io.F
+++ b/src/Routing/module_HYDRO_io.F
@@ -2454,7 +2454,7 @@ endif
        iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
        if (iret /= 0) then
          call hydro_stop("In output_gw_spinup() - Problem nf90_create")
-       endif 
+       endif
 
        iret = nf90_def_dim(ncid, "time", NF90_UNLIMITED, dimid_times)
        iret = nf90_def_dim(ncid, "x", ixrtd, dimid_ix)  !-- make a decimated grid
@@ -3216,12 +3216,12 @@ subroutine sub_output_gw(igrid, split_output_count, ixrt, jxrt, nsoil, &
         iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
         if (iret /= 0) then
            call hydro_stop("In output_chrt() - Problem nf90_create points")
-        endif 
+        endif
 
         iret = nf90_create(trim(output_flnm2), OR(NF90_CLOBBER, NF90_NETCDF4), ncid2) 
         if (iret /= 0) then
            call hydro_stop("In output_chrt() - Problem nf90_create observation")
-        endif 
+        endif
 
        do i=1,nlk
         if(ORDER(i) .ge. order_to_write) then
@@ -4883,7 +4883,7 @@ end subroutine mpp_output_chrt
       iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
       if (iret /= 0) then
          call hydro_stop("In output_lakes() - Problem nf90_create")
-      endif 
+      endif
 
       do i=1,NLAKES
          station_id(i) = i
@@ -5117,7 +5117,7 @@ end subroutine mpp_output_chrt
       iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
       if (iret /= 0) then
          call hydro_stop("In output_lakes() - Problem nf90_create")
-      endif 
+      endif
 
       iret = nf90_def_dim(ncid, "station", nlakes, stationdim)
 
@@ -5332,7 +5332,7 @@ end subroutine mpp_output_chrt
         iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
         if (iret /= 0) then
            call hydro_stop("In output_chrtgrd() - Problem nf90_create")
-        endif 
+        endif
 
         iret = nf90_def_dim(ncid, "time", NF90_UNLIMITED, timedim)
         iret = nf90_def_dim(ncid, "x", ixrt, ixlondim)
@@ -8927,7 +8927,7 @@ end subroutine MPP_READ_CHROUTING_new
         real, dimension(:) :: chlat,chlon
         integer :: iret, nodes, i, ncid, dimid_n, varid
 
-        nodes = size(chlon,1)        
+        nodes = size(chlon,1)
 
        iret = nf90_create("nodeInfor.nc", OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
        iret = nf90_def_dim(ncid, "node", nodes, dimid_n)  !-- make a decimated grid
@@ -9019,7 +9019,7 @@ call get_1d_netcdf_real(ncid, 'MusX',     MUSX,      'read_route_link_netcdf', .
 call get_1d_netcdf_real(ncid, 'Length',   CHANLEN,   'read_route_link_netcdf', .TRUE.)
 call get_1d_netcdf_real(ncid, 'n',        MannN,     'read_route_link_netcdf', .TRUE.)
 call get_1d_netcdf_real(ncid, 'So',       So,        'read_route_link_netcdf', .TRUE.)
-!! impose a minimum as this sometimes fails in the file. 
+!! impose a minimum as this sometimes fails in the file.
 where(So .lt. 0.00001) So=0.00001
 call get_1d_netcdf_real(ncid, 'ChSlp',    ChSSlp,    'read_route_link_netcdf', .TRUE.)
 call get_1d_netcdf_real(ncid, 'BtmWdth',  Bw,        'read_route_link_netcdf', .TRUE.)
@@ -10245,9 +10245,9 @@ end subroutine output_chrt2
       iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
 
       if (iret /= 0) then
-          print*, "Problem nf90_create" 
-          call hydro_stop("output_gw_netcdf") 
-      endif 
+          print*, "Problem nf90_create"
+          call hydro_stop("output_gw_netcdf")
+      endif
 
 !!! Define dimensions
 
@@ -11219,7 +11219,7 @@ use module_mpp_land,only: mpp_land_bcast_int1
 
   if (present(rt)) then
     regrid = rt
-  else 
+  else
     regrid = .false.
   endif
 

--- a/src/Routing/module_HYDRO_utils.F
+++ b/src/Routing/module_HYDRO_utils.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_HYDRO_utils
@@ -32,8 +32,8 @@ module module_HYDRO_utils
 
 
   implicit none
-  logical lr_dist_flag    !land routing distance calculated or not. 
-  
+  logical lr_dist_flag    !land routing distance calculated or not.
+
 contains
 
   integer function get2d_real(var_name,out_buff,ix,jx,fileName)
@@ -44,7 +44,7 @@ contains
     character(len=*), intent(in) :: var_name
     character(len=*), intent(in) :: fileName
     get2d_real = -1
-    
+
     iret = nf_open(trim(fileName), NF_NOWRITE, ncid)
     if (iret .ne. 0) then
 #ifdef HYDRO_D
@@ -68,10 +68,10 @@ contains
     get2d_real =  ivar
   end function get2d_real
 
- 
+
 ! this module create the distance dx, dy and diagnoal for routing
 ! 8 direction as the slop:
-! 1: i,j+1  
+! 1: i,j+1
 ! 2: i+1, j+1
 ! 3: i+1, j
 ! 4: i+1, j-1
@@ -79,10 +79,10 @@ contains
 ! 6: i-1, j-1
 ! 7: i-1, j
 ! 8: i-1, j+1
-   real function get_dy(i,j,v,ix,jx)  
+   real function get_dy(i,j,v,ix,jx)
       ! south north
        integer :: i,j,ix,jx
-       real,dimension(ix,jx,9) :: v 
+       real,dimension(ix,jx,9) :: v
        if( v(i,j,1) .le. 0) then
           get_dy = v(i,j,5)
        else if( v(i,j,5) .le. 0) then
@@ -93,10 +93,10 @@ contains
        return
    end function get_dy
 
-   real function get_dx(i,j,v,ix,jx)   
+   real function get_dx(i,j,v,ix,jx)
       ! east-west
        integer :: i,j, ix,jx
-       real,dimension(ix,jx,9) :: v 
+       real,dimension(ix,jx,9) :: v
        if( v(i,j,3) .le. 0) then
           get_dx = v(i,j,7)
        else if( v(i,j,7) .le. 0) then
@@ -121,11 +121,11 @@ contains
      dlat = lat2 -lat1
      dlon = lon2 -lon1
      a = sin(dlat/2)*sin(dlat/2) + cos(lat1)*cos(lat2)*sin(dlon/2)*sin(dlon/2)
-     b1 = sqrt(a) 
-     b2 = sqrt(1-a)  
+     b1 = sqrt(a)
+     b2 = sqrt(1-a)
      c = 2.0*atan2(b1,b2)
      get_ll_d = R*c
-     return 
+     return
 
    end function get_ll_d
 
@@ -141,7 +141,7 @@ contains
      lon2 = lon2_in * pai/180
      r = 6371*1000
      get_ll_d_tmp = acos(sin(lat1)*sin(lat2)+cos(lat1)*cos(lat2)*cos(lon2-lon1))*r
-     return 
+     return
 
    end function get_ll_d_tmp
 
@@ -156,7 +156,7 @@ contains
       real, dimension(global_rt_nx,global_rt_ny):: latrt, lonrt
       real, dimension(global_rt_nx,global_rt_ny,9):: dist
       if(my_id .eq. IO_id) then
- ! read the lat and lon. 
+ ! read the lat and lon.
          iret =  get2d_real("LONGITUDE",lonrt,global_rt_nx,global_rt_ny,&
                      trim(nlst(did)%GEO_FINEGRID_FLNM ))
          iret =  get2d_real("LATITUDE",latrt,global_rt_nx,global_rt_ny,&
@@ -169,7 +169,7 @@ contains
      end do
 #else
       real, dimension(rt_domain(did)%ixrt,rt_domain(did)%jxrt):: latrt, lonrt
- ! read the lat and lon. 
+ ! read the lat and lon.
          iret =  get2d_real("LONGITUDE",lonrt,rt_domain(did)%ixrt,rt_domain(did)%jxrt,&
                      trim(nlst(did)%GEO_FINEGRID_FLNM ))
          iret =  get2d_real("LATITUDE",latrt,rt_domain(did)%ixrt,rt_domain(did)%jxrt,&
@@ -179,14 +179,14 @@ contains
 
    end subroutine get_rt_dxdy_ll
 
-!  get dx and dy of lat and lon   
+!  get dx and dy of lat and lon
    subroutine get_dist_ll(dist,lat,lon,ix,jx)
       implicit none
-      integer:: ix,jx 
+      integer:: ix,jx
       real, dimension(ix,jx,9):: dist
       real, dimension(ix,jx):: lat, lon
-      integer:: i,j 
-      real x,y 
+      integer:: i,j
+      real x,y
       dist = -1
       do j = 1, jx
         do i = 1, ix
@@ -194,25 +194,25 @@ contains
              get_ll_d(lat(i,j), lat(i,j+1), lon(i,j), lon(i,j+1))
           if(j .lt. jx .and. i .lt. ix) dist(i,j,2) =  &
              get_ll_d(lat(i,j), lat(i+1,j+1), lon(i,j), lon(i+1,j+1))
-          if(i .lt. ix) dist(i,j,3) = &    
+          if(i .lt. ix) dist(i,j,3) = &
              get_ll_d(lat(i,j), lat(i+1,j), lon(i,j), lon(i+1,j))
-          if(j .gt. 1 .and. i .lt. ix) dist(i,j,4) = &    
+          if(j .gt. 1 .and. i .lt. ix) dist(i,j,4) = &
              get_ll_d(lat(i,j), lat(i+1,j-1), lon(i,j), lon(i+1,j-1))
-          if(j .gt. 1 ) dist(i,j,5) = &   
+          if(j .gt. 1 ) dist(i,j,5) = &
              get_ll_d(lat(i,j), lat(i,j-1), lon(i,j), lon(i,j-1))
-          if(j .gt. 1 .and. i .gt. 1) dist(i,j,6) = &   
+          if(j .gt. 1 .and. i .gt. 1) dist(i,j,6) = &
              get_ll_d(lat(i,j), lat(i-1,j-1), lon(i,j), lon(i-1,j-1))
-          if(i .gt. 1) dist(i,j,7) = &   
+          if(i .gt. 1) dist(i,j,7) = &
              get_ll_d(lat(i,j), lat(i-1,j), lon(i,j), lon(i-1,j))
-          if(j .lt. jx .and. i .gt. 1) dist(i,j,8) = &   
+          if(j .lt. jx .and. i .gt. 1) dist(i,j,8) = &
              get_ll_d(lat(i,j), lat(i-1,j+1), lon(i,j), lon(i-1,j+1))
         end do
       end do
-      do j = 1, jx 
+      do j = 1, jx
         do i = 1, ix
             if(j.eq.1) then
                y =  get_ll_d(lat(i,j), lat(i,j+1), lon(i,j), lon(i,j+1))
-            else if(j.eq.jx) then 
+            else if(j.eq.jx) then
                y =  get_ll_d(lat(i,j-1), lat(i,j), lon(i,j-1), lon(i,j))
             else
                y =  get_ll_d(lat(i,j-1), lat(i,j+1), lon(i,j-1), lon(i,j+1))/2.0
@@ -225,7 +225,7 @@ contains
             else
                 x =  get_ll_d(lat(i-1,j), lat(i+1,j), lon(i-1,j), lon(i+1,j))/2.0
             endif
-            dist(i,j,9) = x * y 
+            dist(i,j,9) = x * y
         end do
       end do
 #ifdef HYDRO_D
@@ -236,9 +236,9 @@ contains
 !  get dx and dy of map projected
    subroutine get_dxdy_mp(dist,ix,jx,dx,dy)
       implicit none
-      integer:: ix,jx 
+      integer:: ix,jx
       real :: dx,dy
-      integer:: i,j 
+      integer:: i,j
       real :: v1
       ! out variable
       real, dimension(ix,jx,9)::dist
@@ -246,14 +246,14 @@ contains
       v1 = sqrt(dx*dx + dy*dy)
       do j = 1, jx
         do i = 1, ix
-          if(j .lt. jx) dist(i,j,1) = dy 
-          if(j .lt. jx .and. i .lt. ix) dist(i,j,2) = v1 
-          if(i .lt. ix) dist(i,j,3) = dx 
-          if(j .gt. 1 .and. i .lt. ix) dist(i,j,4) = v1 
-          if(j .gt. 1 ) dist(i,j,5) = dy 
-          if(j .gt. 1 .and. i .gt. 1) dist(i,j,6) = v1 
-          if(i .gt. 1) dist(i,j,7) = dx 
-          if(j .lt. jx .and. i .gt. 1) dist(i,j,8) = v1 
+          if(j .lt. jx) dist(i,j,1) = dy
+          if(j .lt. jx .and. i .lt. ix) dist(i,j,2) = v1
+          if(i .lt. ix) dist(i,j,3) = dx
+          if(j .gt. 1 .and. i .lt. ix) dist(i,j,4) = v1
+          if(j .gt. 1 ) dist(i,j,5) = dy
+          if(j .gt. 1 .and. i .gt. 1) dist(i,j,6) = v1
+          if(i .gt. 1) dist(i,j,7) = dx
+          if(j .lt. jx .and. i .gt. 1) dist(i,j,8) = v1
           dist(i,j,9) = dx * dy
         end do
       end do
@@ -267,16 +267,16 @@ contains
 #ifdef MPP_LAND
      integer ix,jx,ixrt,jxrt, k
      real , dimension(global_nx,global_ny):: latitude,longitude
-     real, dimension(global_nx,global_ny,9):: dist 
+     real, dimension(global_nx,global_ny,9):: dist
      if(nlst(did)%dxrt0 .lt. 0) then
            ! lat and lon grid
-          call write_io_real(rt_domain(did)%lat_lsm,latitude) 
-          call write_io_real(rt_domain(did)%lon_lsm,longitude) 
+          call write_io_real(rt_domain(did)%lat_lsm,latitude)
+          call write_io_real(rt_domain(did)%lon_lsm,longitude)
           if(my_id.eq.IO_id) then
                call get_dist_ll(dist,latitude,longitude,  &
                          global_nx,global_ny)
           endif
-       
+
      else
            ! mapp projected grid.
           if(my_id.eq.IO_id) then
@@ -345,22 +345,22 @@ contains
 !     end do
 !#endif
 !   end subroutine get_dist_crt
-   
+
    subroutine get_basn_area(did)
       implicit none
       integer :: did, ix,jx, k
       real :: basns_area(rt_domain(did)%gnumbasns)
 #ifdef MPP_LAND
-      integer :: mask(global_nx, global_ny) 
-      real :: dist_lsm(global_nx, global_ny,9) 
+      integer :: mask(global_nx, global_ny)
+      real :: dist_lsm(global_nx, global_ny,9)
 #else
       integer :: mask(rt_domain(did)%ix, rt_domain(did)%jx)
-      real :: dist_lsm(rt_domain(did)%ix, rt_domain(did)%jx,9) 
+      real :: dist_lsm(rt_domain(did)%ix, rt_domain(did)%jx,9)
 #endif
 #ifdef MPP_LAND
       ix = global_nx
       jx = global_ny
-      call write_IO_int(rt_domain(did)%GWSUBBASMSK,mask) 
+      call write_IO_int(rt_domain(did)%GWSUBBASMSK,mask)
       do k = 1,  9
          call write_IO_real(rt_domain(did)%dist_lsm(:,:,k),dist_lsm(:,:,k)) 
       end do
@@ -402,7 +402,7 @@ contains
       end do
       do i = 1, numbasns
          if(count(i) .gt. 0) then
-             basns_area(i) = basns_area(i) / count(i) 
+             basns_area(i) = basns_area(i) / count(i)
          end if
       end do
    end subroutine get_area_g
@@ -436,6 +436,6 @@ contains
        call get_area_g8(rt_domain(did)%node_area, rt_domain(did)%CH_NETLNK, &
          rt_domain(did)%NLINKS,rt_domain(did)%ixrt, rt_domain(did)%jxrt, rt_domain(did)%overland%properties%distance_to_neighbor)
    end subroutine get_node_area
-    
+
 
 end module module_HYDRO_utils

--- a/src/Routing/module_UDMAP.F
+++ b/src/Routing/module_UDMAP.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 ! This subrouting includs the data structure and tools used for NHDPlus network mapping.
@@ -27,9 +27,9 @@ module module_UDMAP
        local_endx_rt,local_endy_rt, left_id, right_id, down_id, up_id, mpp_collect_1d_int_mem, &
        IO_id , numprocs
   use module_mpp_land, only: mpp_land_bcast_int, mpp_land_bcast_real8_1d, mpp_land_bcast_int1, mpp_land_bcast_int8
-  
+
   use module_mpp_land, only: sum_int1d, global_rt_nx, global_rt_ny, write_IO_rt_int, MPP_LAND_COM_INTEGER
-  
+
   use MODULE_mpp_ReachLS, only : updatelinkv, ReachLS_write_io, com_write1dInt, &
        com_decomp1dInt, pack_decomp_int, pack_decomp_real8, &
        com_decomp1dint8, pack_decomp_int8, com_write1dInt8
@@ -92,9 +92,9 @@ contains
         integer :: ix_bufid, ii, ixrt,jxrt
         integer, allocatable, dimension(:) :: gbufi,gbufj,bufsize
         real*8 , allocatable, dimension(:) :: gbufw
-        
+
         did = 1
-        call get_dimension(trim(nlst(did)%UDMAP_FILE), ndata, npid) 
+        call get_dimension(trim(nlst(did)%UDMAP_FILE), ndata, npid)
 
 #ifdef MPP_LAND
         gnpid = npid
@@ -110,10 +110,10 @@ contains
            call get_nprocs_map(ixrt,jxrt,gbufi,gbufj,nprocs_map,ndata)
 
         if(my_id .eq. io_id) then
-           lnsizes = 0 
+           lnsizes = 0
            do i =1 , ndata
                if(nprocs_map(i) .gt. 0) then
-                  lnsizes(nprocs_map(i)) = lnsizes(nprocs_map(i)) + 1 
+                  lnsizes(nprocs_map(i)) = lnsizes(nprocs_map(i)) + 1
                endif
            enddo
         endif
@@ -121,8 +121,8 @@ contains
 
      if(my_id .eq. io_id ) then
         kk = 0
-        do i = 1, numprocs 
-           kk = kk + lnsizes(i) 
+        do i = 1, numprocs
+           kk = kk + lnsizes(i)
         end do
      end if
 
@@ -140,14 +140,14 @@ contains
 
       if(lnsizes(my_id+1) .gt. 0)  allocate(bufi(lnsizes(my_id+1) ))
       call pack_decomp_int(gbufi, ndata, nprocs_map, lnsizes, istart,bufi)
-      if(my_id .eq. io_id) then 
+      if(my_id .eq. io_id) then
            if(allocated(gbufi))  deallocate(gbufi)
       endif
 
-      
+
       if(lnsizes(my_id+1) .gt. 0) allocate(bufj(lnsizes(my_id+1) ))
       call pack_decomp_int(gbufj, ndata, nprocs_map, lnsizes, istart,bufj)
-      if(my_id .eq. io_id)  then 
+      if(my_id .eq. io_id)  then
          if(allocated(gbufj)) deallocate(gbufj)
       endif
 
@@ -186,7 +186,7 @@ contains
          type(hash_t) :: hash_table
          integer(kind=int64) :: val,it
          logical :: found
-         
+
          call hash_table%set_all_idx(bufid_tmp, ix_bufid)
          do it = 1, nlinksl
             call hash_table%get(linkid(it), val, found)
@@ -214,21 +214,21 @@ contains
           do k = 1, npid
                do j = 1, bufsize(k)
                  g1bufid(i) = gbufid(k)
-                 i = i + 1 
+                 i = i + 1
                end do
           enddo
           if(allocated(bufsize))  deallocate(bufsize)
       endif
 
 
-      if(my_id .eq. io_id) then 
+      if(my_id .eq. io_id) then
            if(allocated(gbufid)) deallocate(gbufid)
       endif
 
 
       if(lnsizes(my_id+1) .gt. 0) allocate(bufid(lnsizes(my_id+1) ))
       call pack_decomp_int8(g1bufid, ndata, nprocs_map, lnsizes, istart,bufid)
-      if(my_id .eq. io_id) then 
+      if(my_id .eq. io_id) then
             if(allocated(g1bufid)) deallocate(g1bufid)
       endif
 
@@ -239,7 +239,7 @@ contains
       endif
       if(lnsizes(my_id+1) .gt. 0) allocate(bufw(lnsizes(my_id+1) ))
       call pack_decomp_real8(gbufw, ndata, nprocs_map, lnsizes, istart,bufw)
-      if(my_id .eq. io_id) then 
+      if(my_id .eq. io_id) then
           if(allocated(gbufw))     deallocate(gbufw)
       endif
 
@@ -269,12 +269,12 @@ contains
         if(left_id .ge. 0) then
            starti = local_startx_rt  + 1
         else
-           starti = local_startx_rt 
+           starti = local_startx_rt
         endif
         if(down_id .ge. 0) then
            startj = local_starty_rt  + 1
         else
-           startj = local_starty_rt 
+           startj = local_starty_rt
         endif
         if(right_id .ge. 0) then
            endi = local_startx_rt + ix -2
@@ -294,7 +294,7 @@ contains
 #endif
         gridflag = 0
         lndflag = 0
-      
+
 #ifdef MPP_LAND
         k = 0
         do i = 1, lnsize
@@ -309,7 +309,7 @@ contains
                     lndflag(k) = lndflag(k) + 1
                     if(ter_rt_flag .eq. 1) then
                         if(rtmask(bufi(i)-local_startx_rt+1,bufj(i)-local_starty_rt+1) .ge. 0) then
-                             gridflag(k) = gridflag(k) + 1 
+                             gridflag(k) = gridflag(k) + 1
                         endif
                     endif
                  endif
@@ -324,20 +324,20 @@ contains
 
 ! decide how many user defined links on current domain
         kk = k
-        LNUMRSL = 0 
+        LNUMRSL = 0
         do k = 1, lnsize
            if(lndflag(k) .gt. 0) LNUMRSL = LNUMRSL + 1
         enddo
 
 
-        if(LNUMRSL .gt. 0) then 
+        if(LNUMRSL .gt. 0) then
 
                allocate(LUDRSL(LNUMRSL))
                allocate( basns_area(LNUMRSL) )
         else
 ! When MPI is performed,for every subdomain in each process, all the links 
 ! are listed and if there is no link in the subdomain then it is calling 
-! cleanBuf (memory cleaning purposes), this used to print a warning 
+! cleanBuf (memory cleaning purposes), this used to print a warning
 ! that is not necessary for the user to see it, therefore it is been commented out here
 !               write(6,*) "Warning: no routing links found."
                call cleanBuf()
@@ -345,7 +345,7 @@ contains
         endif
 
         kk = 0
-        do k = 1, lnsize 
+        do k = 1, lnsize
            if( bufid(k) .ge. 0 ) then
              if (bufi(k) .ge. starti .and. bufj(k) .ge. startj .and. &
                     bufi(k) .le. endi   .and. bufj(k) .le. endj ) then
@@ -354,7 +354,7 @@ contains
                  else
                        if(bufid(k) .ne. bufid(k-1)) kk = kk + 1
                  endif
-                 LUDRSL(kk)%myid = bufid(k) 
+                 LUDRSL(kk)%myid = bufid(k)
                  LUDRSL(kk)%ngrids = -999
                  if(gridflag(kk) .gt. 0) then
                    LUDRSL(kk)%ngrids = gridflag(kk)
@@ -366,7 +366,7 @@ contains
                    endif
                  endif
 !  define bucket variables
-                 LUDRSL(kk)%ncell = lndflag(kk) 
+                 LUDRSL(kk)%ncell = lndflag(kk)
                  if(.not. allocated(LUDRSL(kk)%cellweight) ) then
                      allocate( LUDRSL(kk)%cellweight(LUDRSL(kk)%ncell))
                      allocate( LUDRSL(kk)%cell_i(LUDRSL(kk)%ncell))
@@ -382,25 +382,25 @@ contains
         kk = 0
         m  = 1
         c  = 1
-        do i = 1, lnsize 
-               if( (bufid(i) .ge. 0)  ) then 
+        do i = 1, lnsize
+               if( (bufid(i) .ge. 0)  ) then
                    if(bufi(i) .ge. starti .and. bufj(i) .ge. startj .and. &
                       bufi(i) .le. endi   .and. bufj(i) .le. endj) then
                       if(kk .eq. 0) then
                          kk = 1
                       else
-                         if(bufid(i) .ne. bufid(i-1)) then 
+                         if(bufid(i) .ne. bufid(i-1)) then
                              kk = kk + 1
                              m  = 1
                              c  = 1
                          endif
                       endif
 
-                      if(LUDRSL(kk)%ngrids .gt. 0) then 
+                      if(LUDRSL(kk)%ngrids .gt. 0) then
                           if(rtmask(bufi(i)-local_startx_rt+1,bufj(i)-local_starty_rt+1) .ge. 0) then
                              LUDRSL(kk)%grid_i(m) = bufi(i) - local_startx_rt+1
                              LUDRSL(kk)%grid_j(m) = bufj(i) - local_starty_rt+1
-                             LUDRSL(kk)%weight(m) = bufw(i) 
+                             LUDRSL(kk)%weight(m) = bufw(i)
                              m  = m  + 1
                           endif
                       endif
@@ -409,7 +409,7 @@ contains
                           LUDRSL(kk)%cell_j(c) = bufj(i) - local_starty_rt+1
                           LUDRSL(kk)%cellWeight(c) = bufw(i)
                           c  = c  + 1
-!! end define bucket variables 
+!! end define bucket variables
                    endif
                 endif
         end do
@@ -419,7 +419,7 @@ contains
 #else
         call hydro_stop("FATAL ERROR in UDMP: Sequential not work.")
 #endif
-   
+
     end subroutine UDMP2LOCAL
 
     subroutine cleanBuf()
@@ -442,22 +442,22 @@ contains
                        trim(fileName)
                   call hydro_stop("In get_dimension() - Problem opening mapping file.")
                endif
-        
+
                iret = nf_inq_dimid(ncid, "polyid", dimid)
-        
+
                if (iret /= 0) then
                   print*, "nf_inq_dimid:  polyid"
                   call hydro_stop("In get_dimension() - nf_inq_dimid:  polyid")
                endif
-           
+
                iret = nf_inq_dimlen(ncid, dimid, npid)
-           
+
                iret = nf_inq_dimid(ncid, "data", dimid)
                if (iret /= 0) then
                           print*, "nf_inq_dimid:  data"
                           call hydro_stop("In get_file_dimension() - nf_inq_dimid:  data")
                endif
-        
+
                iret = nf_inq_dimlen(ncid, dimid, ndata)
                iret = nf_close(ncid)
 #ifdef MPP_LAND
@@ -550,16 +550,16 @@ contains
                 do m = 1, LUDRSL(k)%ncell
                     LUDRSL(k)%cellArea(m) = cell_area(LUDRSL(k)%cell_i(m),LUDRSL(k)%cell_j(m)) 
                 enddo
-           
-            basns_area(k) = 0 
+
+            basns_area(k) = 0
             do m = 1, LUDRSL(k)%ncell
                     basns_area(k) = basns_area(k) + &
                           cell_area(LUDRSL(k)%cell_i(m),LUDRSL(k)%cell_j(m)) * LUDRSL(k)%cellWeight(m) 
             enddo
-            
+
          end do
       end subroutine getUDMP_area
-    
+
       subroutine get_basn_area_nhd(inOut)
          implicit none
          real, dimension(:) :: inOut
@@ -570,12 +570,12 @@ contains
          inOut = basns_area
 #endif
 
-      
+
       end subroutine get_basn_area_nhd
 
       subroutine get_nprocs_map(ix,jx,bufi,bufj,nprocs_map,ndata)
           implicit none
-          integer,dimension(:)  :: bufi, bufj,nprocs_map 
+          integer,dimension(:)  :: bufi, bufj,nprocs_map
 !          integer, allocatable, dimension(:) ::  lbufi,lbufj, lmap
           integer  :: ndata, lsize, ix,jx
           integer, dimension(ix,jx) :: mask
@@ -583,12 +583,12 @@ contains
 
         integer :: i,j,k, starti,startj, endi,endj, ii,jj, npid, kk
 #ifdef MPP_LAND
-           
+
           mask = my_id + 1
           if(my_id .eq. IO_id) allocate(gmask(global_rt_nx, global_rt_ny))
 
           call MPP_LAND_COM_INTEGER(mask,IX,JX,99)
-          call write_IO_rt_int(mask, gmask) 
+          call write_IO_rt_int(mask, gmask)
 
           if(my_id .eq. io_id ) then
              nprocs_map = -999

--- a/src/Routing/module_lsm_forcing.F
+++ b/src/Routing/module_lsm_forcing.F
@@ -3320,4 +3320,3 @@ end module module_lsm_forcing
       real, dimension(ix,jx):: infxsrt,soldrain
       call read_ldasout_seq(olddate,hgrid, indir, dt,ix,jx,infxsrt,soldrain)
     end subroutine read_forc_ldasout_seq
-

--- a/src/Routing/module_reservoir_routing.F
+++ b/src/Routing/module_reservoir_routing.F
@@ -65,7 +65,7 @@ subroutine read_reservoir_obs(domainId)
    diagFlag = 0
 #endif
 
-   ! Sync up processes. 
+   ! Sync up processes.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
       call mpp_land_sync()
@@ -75,7 +75,7 @@ subroutine read_reservoir_obs(domainId)
    ! Check to ensure the namelist option for reading in the reservoir discharge data
    ! has been set to 1. If not, return back to the main calling program.
    if(nlst(domainId)%reservoir_data_ingest .eq. 0) then
-       ! No reservoir realtime data requested. 
+       ! No reservoir realtime data requested.
        return
    endif
 

--- a/src/nudging/module_nudging_utils.F
+++ b/src/nudging/module_nudging_utils.F
@@ -2,20 +2,20 @@
 !  Author(s)/Contact(s):
 !  Abstract:
 !  History Log:
-! 
+!
 !  Usage:
 !  Parameters: <Specify typical arguments passed>
 !  Input Files:
 !        <list file names and briefly describe the data they include>
 !  Output Files:
 !        <list file names and briefly describe the information they include>
-! 
+!
 !  Condition codes:
 !        <list exit condition or error codes returned >
 !        If appropriate, descriptive troubleshooting instructions or
 !        likely causes for failures could be mentioned here with the
 !        appropriate error code
-! 
+!
 !  User controllable options: <if applicable>
 
 module module_nudging_utils
@@ -33,22 +33,22 @@ contains
 
 
 !===================================================================================================
-! Program Names: 
-!   functions: whichPack and whichLoop 
-! Author(s)/Contact(s): 
+! Program Names:
+!   functions: whichPack and whichLoop
+! Author(s)/Contact(s):
 !   James L McCreight <jamesmcc><ucar><edu>
-! Abstract: 
+! Abstract:
 !   Identify indices in a vector which are TRUE, reutrns zero length vector
 !   if there are no matches.
-! History Log: 
+! History Log:
 !   6/04/15 -Created, JLM.
-! Usage: 
-! Parameters:  
+! Usage:
+! Parameters:
 ! Input Files:
-! Output Files: 
-! Condition codes: 
-! User controllable options: None. 
-! Notes: 
+! Output Files:
+! Condition codes:
+! User controllable options: None.
+! Notes:
 !   JLM: Recent catastrophic failure reported for pack on ifort, with work arround.
 !   JLM: https://software.intel.com/en-us/forums/topic/559308#comments
 
@@ -82,7 +82,7 @@ do ii=1,size(theMask)
       which = -9999
       return
    end if
-   if(theMask(ii)) then 
+   if(theMask(ii)) then
       which(nWhich)=ii
       nWhich = nWhich + 1
    endif
@@ -91,22 +91,22 @@ nWhich = nWhich-1
 end subroutine whichLoop
 
 !===================================================================================================
-! Program Names: 
+! Program Names:
 !   function: whUnique
-! Author(s)/Contact(s): 
+! Author(s)/Contact(s):
 !   James L McCreight <jamesmcc><ucar><edu>
-! Abstract: 
+! Abstract:
 !   Identify THE index in a logical vector which is TRUE. Returns
 !   -1 if not unique or none are true.
-! History Log: 
+! History Log:
 !   6/04/15 -Created, JLM.
-! Usage: 
-! Parameters:  
+! Usage:
+! Parameters:
 ! Input Files:
-! Output Files: 
-! Condition codes: 
-! User controllable options: None. 
-! Notes: 
+! Output Files:
+! Condition codes:
+! User controllable options: None.
+! Notes:
 
 function whUnique(theMask, unsafe)
   implicit none
@@ -116,37 +116,37 @@ function whUnique(theMask, unsafe)
   integer, allocatable, dimension(:) :: whUniques
   integer :: i, nMatches
   if(present(unsafe)) then
-     !whUniques=pack( (/ (i, i=1,size(theMask)) /), mask= theMask)     
+     !whUniques=pack( (/ (i, i=1,size(theMask)) /), mask= theMask)
      !whUnique = whUniques(1)
-     whUnique=sum( (/ (i, i=1,size(theMask)) /), mask= theMask)     
-  else 
+     whUnique=sum( (/ (i, i=1,size(theMask)) /), mask= theMask)
+  else
      nMatches = sum( (/ (1, i=1,size(theMask)) /), mask= theMask )
      if (nMatches .gt. 1 .OR. nMatches .eq. 0) then
         whUnique=-1
-     else 
-        whUnique=sum( (/ (i, i=1,size(theMask)) /), mask= theMask)     
+     else
+        whUnique=sum( (/ (i, i=1,size(theMask)) /), mask= theMask)
      end if
   end if
 end function whUnique
 
 
 !===================================================================================================
-! Program Names: 
+! Program Names:
 !   function: whUnique
-! Author(s)/Contact(s): 
+! Author(s)/Contact(s):
 !   James L McCreight <jamesmcc><ucar><edu>
-! Abstract: 
+! Abstract:
 !   Simply returns the first match, no check for uniques. On gfortran this
 !    was the fastest of the bunch even/especially for max indices on huge arrays.
-! History Log: 
+! History Log:
 !   6/04/15 -Created, JLM.
-! Usage: 
-! Parameters:  
+! Usage:
+! Parameters:
 ! Input Files:
-! Output Files: 
-! Condition codes: 
-! User controllable options: None. 
-! Notes: 
+! Output Files:
+! Condition codes:
+! User controllable options: None.
+! Notes:
 
 function whUniLoop(theMask)
   implicit none
@@ -163,21 +163,21 @@ function whUniLoop(theMask)
 end function whUniLoop
 
 !===================================================================================================
-! Program Names: 
+! Program Names:
 !   function: whInLoop
-! Author(s)/Contact(s): 
+! Author(s)/Contact(s):
 !   James L McCreight <jamesmcc><ucar><edu>
-! Abstract: 
+! Abstract:
 !   Identify the indices of elements in a first vector which are present in the 
 !   second vector, returns 0 for no matches. This can be slow, it's a double do/for loop.
-! History Log: 
+! History Log:
 !   6/04/15 -Created, JLM.
-! Usage: 
-! Parameters:  
+! Usage:
+! Parameters:
 ! Input Files:
-! Output Files: 
-! Condition codes: 
-! User controllable options: None. 
+! Output Files:
+! Condition codes:
+! User controllable options: None.
 ! Notes: Can be slow, use with caution.
 
 ! parallelize this? ||||||||||||||||||||||||||||||||||
@@ -222,26 +222,26 @@ end subroutine whichInLoop2
 
 
 !===================================================================================================
-! Program Names: 
+! Program Names:
 !   accum_nudging_time
-! Author(s)/Contact(s): 
+! Author(s)/Contact(s):
 !   James L McCreight <jamesmcc><ucar><edu>
-! Abstract: 
+! Abstract:
 !   Tally up the total cpu or wall time used by nudging.
-! History Log: 
+! History Log:
 !   8/20/15 -Created, JLM.
-! Usage: 
-! Parameters:  
+! Usage:
+! Parameters:
 !   start, end: real times for end-diff timing & accumulation
 !   sectionLabel: prints a message with the timing for the section
 !      print*, 'Ndg: ' // sectionLabel // '(seconds ' // trim(clockType) // ' time):', diff
 !   optional - accum: accumulate this towards the overall time or simply print the above 
 !      message? Do not accum for nested sections of code, but still give the diagnostic.
 ! Input Files:
-! Output Files: 
-! Condition codes: 
-! User controllable options: None. 
-! Notes: 
+! Output Files:
+! Condition codes:
+! User controllable options: None.
+! Notes:
 subroutine accum_nudging_time(start, end, sectionLabel, accum)
 implicit none
 real,              intent(in) :: start, end
@@ -265,28 +265,28 @@ end subroutine accum_nudging_time
 
 
 !===================================================================================================
-! Program Names: 
+! Program Names:
 !   nudging_timer
-! Author(s)/Contact(s): 
+! Author(s)/Contact(s):
 !   James L McCreight <jamesmcc><ucar><edu>
-! Abstract: 
+! Abstract:
 !   Return your choice of cpu time or wall time
-! History Log: 
+! History Log:
 !   8/20/15 -Created, JLM.
-! Usage: 
-! Parameters:  
+! Usage:
+! Parameters:
 ! Input Files:
-! Output Files: 
-! Condition codes: 
-! User controllable options: None. 
-! Notes: 
+! Output Files:
+! Condition codes:
+! User controllable options: None.
+! Notes:
 subroutine nudging_timer(time)
 implicit none
 real, intent(inout) :: time
-integer :: count 
+integer :: count
 if(clockType.eq.'cpu') call cpu_time(time)
 if(clockType.eq.'wall') then
-   call system_clock(count=count) 
+   call system_clock(count=count)
    time=real(count)
 end if
 end subroutine nudging_timer
@@ -294,4 +294,3 @@ end subroutine nudging_timer
 
 !===================================================================================================
 end module module_nudging_utils
-


### PR DESCRIPTION
TYPE: Text Only

KEYWORDS: Whitespace Cleanup

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Removed trailing whitespace using a bash script and Emacs `delete-trailing-whitespace` elisp function. The point of this is to make differences in future PRs easier to recognize if there aren't also whitespace changes littered throughout the files.

TESTS CONDUCTED: none

NOTES:  Used the following Bash script to match .F90 and .f90 files. Also matched .F files.
```
for file in `find . -name "*.[Ff]90"`; do
    echo "$file"; emacs --batch "$file" \
        --eval '(delete-trailing-whitespace)' \
        -f 'save-buffer'
done
```


### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
