### PR TITLE
Enhancement: compiler info added to NetCDF restart output

### DIFF
--- a/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -3037,7 +3037,7 @@ contains
        ixfull, jxfull, ixpar, jxpar, xstartpar, ystartpar,                                    &
        nsoil, nsnow, dx, dy, truelat1, truelat2, mapproj, lat1, lon1, cen_lon,                       &
        iswater, vegtyp, act_level)
-
+    use iso_fortran_env, only : compiler_version
     implicit none
 #include <netcdf.inc>
 
@@ -3122,6 +3122,7 @@ contains
          ierr = nf90_def_dim(ncid, "glacier_levels", act_level, dimid_glacier_layers)
 
     ierr = nf90_put_att(ncid, NF90_GLOBAL, "TITLE", "RESTART FILE FROM HRLDAS "//version)
+    ierr = nf90_put_att(ncid, NF90_GLOBAL, "compiler_version", compiler_version())
     ierr = nf90_put_att(ncid, NF90_GLOBAL, "missing_value", -1.E33)
 
     date19(1:19) = "0000-00-00_00:00:00"

--- a/src/Routing/module_HYDRO_io.F
+++ b/src/Routing/module_HYDRO_io.F
@@ -35,7 +35,7 @@ module module_HYDRO_io
    use netcdf
    use module_hydro_stop, only:HYDRO_stop
    use hashtable
-   use iso_fortran_env, only: int64
+   use iso_fortran_env, only: int64, compiler_version
 
    implicit none
 
@@ -2451,10 +2451,10 @@ endif
 #endif
 
 
-       iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
+       iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
        if (iret /= 0) then
          call hydro_stop("In output_gw_spinup() - Problem nf90_create")
-       endif 
+       endif
 
        iret = nf90_def_dim(ncid, "time", NF90_UNLIMITED, dimid_times)
        iret = nf90_def_dim(ncid, "x", ixrtd, dimid_ix)  !-- make a decimated grid
@@ -2789,7 +2789,7 @@ subroutine sub_output_gw(igrid, split_output_count, ixrt, jxrt, nsoil, &
 #endif
 
 
-       iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
+       iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
        if (iret /= 0) then
          call hydro_stop("In output_gw_spinup() - Problem nf90_create")
        endif
@@ -3213,15 +3213,15 @@ subroutine sub_output_gw(igrid, split_output_count, ixrt, jxrt, nsoil, &
         print*, 'output_flnm = "'//trim(output_flnm)//'"'
 #endif
 
-        iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
+        iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
         if (iret /= 0) then
            call hydro_stop("In output_chrt() - Problem nf90_create points")
-        endif 
+        endif
 
-        iret = nf90_create(trim(output_flnm2), OR(NF90_CLOBBER, NF90_NETCDF4), ncid2) 
+        iret = nf90_create(trim(output_flnm2), OR(NF90_CLOBBER, NF90_NETCDF4), ncid2)
         if (iret /= 0) then
            call hydro_stop("In output_chrt() - Problem nf90_create observation")
-        endif 
+        endif
 
        do i=1,nlk
         if(ORDER(i) .ge. order_to_write) then
@@ -3968,12 +3968,12 @@ end subroutine output_chrt
         print*, 'output_flnm = "'//trim(output_flnm)//'"'
 #endif
 
-       iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
+       iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
        if (iret /= 0) then
            call hydro_stop("In output_chrt() - Problem nf90_create points")
        endif
 
-       iret = nf90_create(trim(output_flnm2), OR(NF90_CLOBBER, NF90_NETCDF4), ncid2) 
+       iret = nf90_create(trim(output_flnm2), OR(NF90_CLOBBER, NF90_NETCDF4), ncid2)
        if (iret /= 0) then
            call hydro_stop("In output_chrt() - Problem nf90_create observation")
        endif
@@ -4880,10 +4880,10 @@ end subroutine mpp_output_chrt
       print*, 'output_flnm = "'//trim(output_flnm)//'"'
 #endif
 
-      iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
+      iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
       if (iret /= 0) then
          call hydro_stop("In output_lakes() - Problem nf90_create")
-      endif 
+      endif
 
       do i=1,NLAKES
          station_id(i) = i
@@ -5114,10 +5114,10 @@ end subroutine mpp_output_chrt
       print*, 'output_flnm = "'//trim(output_flnm)//'"'
 #endif
 
-      iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
+      iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
       if (iret /= 0) then
          call hydro_stop("In output_lakes() - Problem nf90_create")
-      endif 
+      endif
 
       iret = nf90_def_dim(ncid, "station", nlakes, stationdim)
 
@@ -5329,10 +5329,10 @@ end subroutine mpp_output_chrt
 
 
 !--- define dimension
-        iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
+        iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
         if (iret /= 0) then
            call hydro_stop("In output_chrtgrd() - Problem nf90_create")
-        endif 
+        endif
 
         iret = nf90_def_dim(ncid, "time", NF90_UNLIMITED, timedim)
         iret = nf90_def_dim(ncid, "x", ixrt, ixlondim)
@@ -5755,7 +5755,7 @@ end subroutine mpp_output_chrt
      if(IO_id.eq.my_id) &
 #endif
 
-       iret = nf90_create(trim(outFile), OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
+       iret = nf90_create(trim(outFile), OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
 
 #ifdef MPP_LAND
        call mpp_land_bcast_int1(iret)
@@ -6006,6 +6006,7 @@ end subroutine mpp_output_chrt
 !                    nlst(did)%GWBASESWCRT .ne. 0       )
 
    !         put global attribute
+   iret = nf90_put_att(ncid, NF90_GLOBAL, "compiler_version", compiler_version())
    iret = nf90_put_att(ncid, NF90_GLOBAL, "his_out_counts", rt_domain(did)%his_out_counts)
    iret = nf90_put_att(ncid, NF90_GLOBAL, "Restart_Time", nlst(did)%olddate(1:19))
    iret = nf90_put_att(ncid, NF90_GLOBAL, "Since_Date", nlst(did)%sincedate(1:19))
@@ -8927,9 +8928,9 @@ end subroutine MPP_READ_CHROUTING_new
         real, dimension(:) :: chlat,chlon
         integer :: iret, nodes, i, ncid, dimid_n, varid
 
-        nodes = size(chlon,1)        
+        nodes = size(chlon,1)
 
-       iret = nf90_create("nodeInfor.nc", OR(NF90_CLOBBER, NF90_NETCDF4), ncid) 
+       iret = nf90_create("nodeInfor.nc", OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
        iret = nf90_def_dim(ncid, "node", nodes, dimid_n)  !-- make a decimated grid
 !  define the varialbes
        iret = nf90_def_var(ncid, "fromNode", NF90_INT, (/dimid_n/), varid)
@@ -9019,7 +9020,7 @@ call get_1d_netcdf_real(ncid, 'MusX',     MUSX,      'read_route_link_netcdf', .
 call get_1d_netcdf_real(ncid, 'Length',   CHANLEN,   'read_route_link_netcdf', .TRUE.)
 call get_1d_netcdf_real(ncid, 'n',        MannN,     'read_route_link_netcdf', .TRUE.)
 call get_1d_netcdf_real(ncid, 'So',       So,        'read_route_link_netcdf', .TRUE.)
-!! impose a minimum as this sometimes fails in the file. 
+!! impose a minimum as this sometimes fails in the file.
 where(So .lt. 0.00001) So=0.00001
 call get_1d_netcdf_real(ncid, 'ChSlp',    ChSSlp,    'read_route_link_netcdf', .TRUE.)
 call get_1d_netcdf_real(ncid, 'BtmWdth',  Bw,        'read_route_link_netcdf', .TRUE.)
@@ -10245,9 +10246,9 @@ end subroutine output_chrt2
       iret = nf90_create(trim(output_flnm), OR(NF90_CLOBBER, NF90_NETCDF4), ncid)
 
       if (iret /= 0) then
-          print*, "Problem nf90_create" 
-          call hydro_stop("output_gw_netcdf") 
-      endif 
+          print*, "Problem nf90_create"
+          call hydro_stop("output_gw_netcdf")
+      endif
 
 !!! Define dimensions
 
@@ -11219,7 +11220,7 @@ use module_mpp_land,only: mpp_land_bcast_int1
 
   if (present(rt)) then
     regrid = rt
-  else 
+  else
     regrid = .false.
   endif
 

--- a/src/Routing/module_NWM_io.F
+++ b/src/Routing/module_NWM_io.F
@@ -8,8 +8,7 @@ module module_NWM_io
 use module_version, only: get_code_version, get_nwm_version
 use orchestrator_base
 use module_hydro_stop, only: HYDRO_stop
-
-use iso_fortran_env, only: int64
+use iso_fortran_env, only: int64, compiler_version
 
 implicit none
 
@@ -700,6 +699,8 @@ subroutine output_chrt_NWM(domainId)
       ! Write global attributes.
       iret = nf90_put_att(ftn,NF90_GLOBAL,"TITLE",trim(fileMeta%title))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create TITLE attribute')
+      iret = nf90_put_att(ftn,NF90_GLOBAL,"compiler_version",compiler_version())
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to create compiler_version attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"featureType",trim(fileMeta%fType))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create featureType attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"proj4",trim(fileMeta%proj4))
@@ -1421,6 +1422,8 @@ subroutine output_NoahMP_NWM(outDir,iGrid,output_timestep,itime,startdate,date,i
          ! Write global attributes
          iret = nf90_put_att(ftnNoahMP,NF90_GLOBAL,'TITLE',trim(fileMeta%title))
          call nwmCheck(diagFlag,iret,'ERROR: Unable to place TITLE attribute into LDASOUT file.')
+         iret = nf90_put_att(ftnNoahMP,NF90_GLOBAL,"compiler_version",compiler_version())
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create compiler_version attribute')
          iret = nf90_put_att(ftnNoahMP,NF90_GLOBAL,'model_initialization_time',trim(fileMeta%initTime))
          call nwmCheck(diagFlag,iret,'ERROR: Unable to place model init time attribute into LDASOUT file.')
          iret = nf90_put_att(ftnNoahMP,NF90_GLOBAL,'model_output_valid_time',trim(fileMeta%validTime))
@@ -2032,6 +2035,8 @@ subroutine output_rt_NWM(domainId,iGrid)
       ! Write global attributes
       iret = nf90_put_att(ftn,NF90_GLOBAL,'TITLE',trim(fileMeta%title))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create TITLE attribute')
+      iret = nf90_put_att(ftn,NF90_GLOBAL,"compiler_version",compiler_version())
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to create compiler_version attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,'model_initialization_time',trim(fileMeta%initTime))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place model init time attribute into RT_DOMAIN file.')
       iret = nf90_put_att(ftn,NF90_GLOBAL,'model_output_valid_time',trim(fileMeta%validTime))
@@ -2778,6 +2783,8 @@ subroutine output_lakes_NWM(domainId,iGrid)
       ! Write global attributes.
       iret = nf90_put_att(ftn,NF90_GLOBAL,"TITLE",trim(fileMeta%title))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create TITLE attribute')
+      iret = nf90_put_att(ftn,NF90_GLOBAL,"compiler_version",compiler_version())
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to create compiler_version attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"featureType",trim(fileMeta%fType))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create featureType attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"proj4",trim(fileMeta%proj4))
@@ -3357,6 +3364,8 @@ subroutine output_chrtout_grd_NWM(domainId,iGrid)
       ! Write global attributes
       iret = nf90_put_att(ftn,NF90_GLOBAL,'TITLE',trim(fileMeta%title))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create TITLE attribute')
+      iret = nf90_put_att(ftn,NF90_GLOBAL,"compiler_version",compiler_version())
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to create compiler_version attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,'model_initialization_time',trim(fileMeta%initTime))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place model init time attribute into RT_DOMAIN file.')
       iret = nf90_put_att(ftn,NF90_GLOBAL,'model_output_valid_time',trim(fileMeta%validTime))
@@ -3828,6 +3837,8 @@ subroutine output_lsmOut_NWM(domainId)
       ! Write global attributes
       iret = nf90_put_att(ftn,NF90_GLOBAL,'TITLE',trim(fileMeta%title))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place TITLE attribute into LSMOUT file.')
+      iret = nf90_put_att(ftn,NF90_GLOBAL,"compiler_version",compiler_version())
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to create compiler_version attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,'model_initialization_time',trim(fileMeta%initTime))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to place model init time attribute into LSMOUT file.')
       iret = nf90_put_att(ftn,NF90_GLOBAL,'model_output_valid_time',trim(fileMeta%validTime))
@@ -4806,6 +4817,8 @@ subroutine output_chanObs_NWM(domainId)
       ! Write global attributes.
          iret = nf90_put_att(ftn,NF90_GLOBAL,"TITLE",trim(fileMeta%title))
          call nwmCheck(diagFlag,iret,'ERROR: Unable to create TITLE attribute')
+         iret = nf90_put_att(ftn,NF90_GLOBAL,"compiler_version",compiler_version())
+         call nwmCheck(diagFlag,iret,'ERROR: Unable to create compiler_version attribute')
          iret = nf90_put_att(ftn,NF90_GLOBAL,"featureType",trim(fileMeta%fType))
          call nwmCheck(diagFlag,iret,'ERROR: Unable to create featureType attribute')
          iret = nf90_put_att(ftn,NF90_GLOBAL,"proj4",trim(fileMeta%proj4))
@@ -5471,6 +5484,8 @@ subroutine output_gw_NWM(domainId,iGrid)
       ! Write global attributes.
       iret = nf90_put_att(ftn,NF90_GLOBAL,"TITLE",trim(fileMeta%title))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create TITLE attribute')
+      iret = nf90_put_att(ftn,NF90_GLOBAL,"compiler_version",compiler_version())
+      call nwmCheck(diagFlag,iret,'ERROR: Unable to create compiler_version attribute')
       iret = nf90_put_att(ftn,NF90_GLOBAL,"featureType",trim(fileMeta%fType))
       call nwmCheck(diagFlag,iret,'ERROR: Unable to create featureType attribute')
       !iret = nf90_put_att(ftn,NF90_GLOBAL,"proj4",trim(fileMeta%proj4))


### PR DESCRIPTION
TYPE: Enhancement

KEYWORDS: Compiler, Data, NetCDF

SOURCE: Soren Rasmussen, NCAR 

DESCRIPTION OF CHANGES: add compiler info to NetCDF restart file under global attribute `compiler_version`. The compiler info is returned from the intrinsic `compiler_version()`. Examples of output:

`:compiler_version = "GCC version 12.1.0" ;` 

and 

`:compiler_version = "Intel(R) Fortran Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 19.1.1.217 Build 20200306" ;`

TESTS CONDUCTED: Built and tested with Intel and GNU compilers on Croton test case.  

NOTE: the compiler info can be added to other output files if desired. The arguments used to compile the executable can also be retrieved by the `compiler_options()` intrinsic. The only apparent issue with that is the call will return some full path names which seemed like too much info to attach to the restart file.

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
