### PR TITLE
CMake Build Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,8 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
+cmake_policy(SET CMP0074 NEW)
 
-if (NOT CMAKE_C_COMPILER)
-	set (CMAKE_C_COMPILER "mpicc")
-endif (NOT CMAKE_C_COMPILER)
-if (NOT CMAKE_CXX_COMPILER)
-	set (CMAKE_CXX_COMPILER "mpicxx")
-endif (NOT CMAKE_CXX_COMPILER)
-if (NOT CMAKE_Fortran_COMPILER)
-	set (CMAKE_Fortran_COMPILER "mpif90")
-endif (NOT CMAKE_Fortran_COMPILER)
-
+# set project name and version numbers
 project (WRF_Hydro)
-
-#set version numbers
 set (WRF_Hydro_VERSION_MAJOR 5)
 set (WRF_Hydro_VERSION_MINOR 2)
 set (WRF_Hydro_VERSION_PATCH dev)
@@ -20,12 +10,16 @@ set (National_Water_Model_VERSION_MAJOR 2)
 set (National_Water_Model_VERSION_MINOR 1)
 set (National_Water_Model_VERSION_PATCH dev)
 
-# set cmake to work with fortran
+# set cmake to work with MPI Fortran
 enable_language (Fortran)
+find_package(MPI REQUIRED)
+add_compile_options(${MPI_Fortran_COMPILE_FLAGS})
+include_directories(${MPI_Fortran_INCLUDE_PATH})
+link_directories(${MPI_Fortran_LIBRARIES})
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+set(CMAKE_SKIP_BUILD_RPATH  FALSE)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 
-#try to find the installed MPI library
-#enable if compiler wrappers dont find MPI libraries
-#find_package(MPI REQUIRED)
 
 #message ("-- MPI Include directories: " ${MPI_INCLUDE_PATH} )
 #message ("-- MPI C COMPILER : " ${MPI_C_COMPILER} )
@@ -34,6 +28,7 @@ enable_language (Fortran)
 #message ("-- MPI COMPILE FLAGS : " ${MPI_COMPILE_FLAGS} )
 #message ("-- MPI LINK FLAGS : " ${MPI_LINK_FLAGS} )
 #message ("-- MPI Fortran LINK FLAGS : " ${MPI_Fortran_LINK_FLAGS} )
+#message ("-- MPI Fortran LINK LIBRARIES : " ${MPI_Fortran_LIBRARIES} )
 #message ("-- MPI LIBRARY : " ${MPI_LIBRARY} )
 #message ("-- MPI EXTRA LIBRARY : " ${MPI_EXTRA_LIBRARY} )
 #message ("-- MPI LIBRARIES : " ${MPI_LIBRARIES} )
@@ -42,13 +37,13 @@ enable_language (Fortran)
 # that contains FindNetCDF.cmake
 set (CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/src/cmake-modules)
 
-#try to find the installed NETCDF library
+# try to find the installed NETCDF library
 set (NETCDF_F90 "YES")
 set (NETCDF_F77 "YES")
 find_package(NetCDF REQUIRED)
 message("-- NetCDF Include Dir: ${NETCDF_INCLUDES}")
 
-#set user controled enviorment variables
+# set user controled enviorment variables
 set (HYDRO_LSM $ENV{HYDRO_LSM} CACHE STRING "Name of the Land Surface Model to Use")
 
 # set enviorment variables if they have not been set
@@ -57,7 +52,7 @@ if ("${HYDRO_LSM}" STREQUAL "")
 	message ("-- Setting LSM to: NoahMP")
 endif ("${HYDRO_LSM}" STREQUAL "")
 
-#get the variables defined by setEnvar.sh
+# get the variables defined by setEnvar.sh
 set (WRF_HYDRO $ENV{WRF_HYDRO} CACHE STRING "WRF environment variable. Always set to 1 for WRF-Hydro")
 set (HYDRO_D $ENV{HYDRO_D} CACHE STRING "Print additional debug information in WRF-Hydro")
 set (WRF_HYDRO_RAPID $ENV{WRF_HYDRO_RAPID} CACHE STRING "WRF-Hydro coupling to RAPID routing model 0=off 1=on")
@@ -198,11 +193,14 @@ message("=============================================================")
 if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU.*")
     # set compile flags for gfortran
     message ( "-- Using gfortran")
-    set (CMAKE_Fortran_FLAGS "-cpp -O2 -g -w -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -fallow-argument-mismatch")
+    set (CMAKE_Fortran_FLAGS "-cpp -O2 -g -w -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4")
 elseif (CMAKE_Fortran_COMPILER_ID MATCHES "Intel.*")
     # set compile flags for ifort
-    message ( "Using ifort")
+    message ( "-- Using ifort")
     set (CMAKE_Fortran_FLAGS "-fpp -O2 -g -w -ftz -align all -fno-alias -fp-model precise -FR -convert big_endian")
+elseif ((CMAKE_Fortran_COMPILER_ID MATCHES "PGI.*") OR (CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC.*"))
+	message ("-- Using PGI / NVHPC")
+	set (CMAKE_Fortran_FLAGS "-Mpreprocess -O2 -Mfree -byteswapio -Kieee ")
 else (CMAKE_Fortran_COMPILER_ID MATCHES "GNU.*")
     message ("CMAKE_Fortran_COMPILER full path: " ${CMAKE_Fortran_COMPILER})
     message ("Fortran compiler: " ${Fortran_COMPILER_NAME})
@@ -222,6 +220,5 @@ include_directories(AFTER ${PROJECT_BINARY_DIR}/mods)
 include_directories(AFTER ${MPI_INCLUDE_PATH})
 include_directories(AFTER ${NETCDF_INCLUDES})
 include_directories(AFTER ${PROJECT_SOURCE_DIR}/src/Data_Rec)
-
 
 add_subdirectory("src")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 # build the various sup-projects
 add_subdirectory("MPP")
@@ -15,8 +15,8 @@ add_subdirectory("Routing")
 add_subdirectory("HYDRO_drv")
 
 if (WRF_HYDRO_NUDGING STREQUAL "1")
-	add_subdirectory("nudging")
-	add_dependencies(hydro_driver hydro_nudging)
+    add_subdirectory("nudging")
+    add_dependencies(hydro_driver hydro_nudging)
 endif (WRF_HYDRO_NUDGING STREQUAL "1")
 
 if (WRF_HYDRO_NUOPC STREQUAL "1")
@@ -64,67 +64,67 @@ add_dependencies(hydro_data_rec hydro_routing_reservoirs)
 
 
 if (HYDRO_LSM MATCHES "NoahMP")
-	message ("-- Building NoahMP LSM")
-	add_subdirectory("Land_models/NoahMP")
+    message ("-- Building NoahMP LSM")
+    add_subdirectory("Land_models/NoahMP")
 
-	add_subdirectory("CPL/NoahMP_cpl")
-	add_dependencies(hydro_noahmp_cpl hydro_routing)
-	add_dependencies(hydro_noahmp_cpl hydro_mpp )
-	add_dependencies(hydro_noahmp_cpl hydro_driver )
+    add_subdirectory("CPL/NoahMP_cpl")
+    add_dependencies(hydro_noahmp_cpl hydro_routing)
+    add_dependencies(hydro_noahmp_cpl hydro_mpp )
+    add_dependencies(hydro_noahmp_cpl hydro_driver )
 
 
-	add_executable(wrfhydro.exe
-		Land_models/NoahMP/IO_code/main_hrldas_driver.F
-		Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
-		Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
-	)
+    add_executable(wrfhydro.exe
+        Land_models/NoahMP/IO_code/main_hrldas_driver.F
+        Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+        Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+    )
 
-	target_include_directories(wrfhydro.exe BEFORE PUBLIC ${PROJECT_BINARY_DIR}/mods)
+    target_include_directories(wrfhydro.exe BEFORE PUBLIC ${PROJECT_BINARY_DIR}/mods)
 
-	target_link_libraries(wrfhydro.exe hydro_utils)
-	target_link_libraries(wrfhydro.exe hydro_mpp)
-	target_link_libraries(wrfhydro.exe hydro_debug_utils)
-	target_link_libraries(wrfhydro.exe hydro_routing_overland)
-	target_link_libraries(wrfhydro.exe hydro_routing_subsurface)
-	#target_link_libraries(wrfhydro.exe hydro_routing_groundwater)
-	#target_link_libraries(wrfhydro.exe hydro_routing_groundwater_bucket)
-	#target_link_libraries(wrfhydro.exe hydro_routing_groundwater_nhd)
-	#target_link_libraries(wrfhydro.exe hydro_routing_groundwater_simple)
-	target_link_libraries(wrfhydro.exe hydro_data_rec)
-	target_link_libraries(wrfhydro.exe hydro_routing)
-	target_link_libraries(wrfhydro.exe hydro_routing_reservoirs_levelpool)
-	target_link_libraries(wrfhydro.exe hydro_routing_reservoirs_hybrid)
-	target_link_libraries(wrfhydro.exe hydro_routing_reservoirs_rfc)
-	target_link_libraries(wrfhydro.exe hydro_routing_reservoirs)
-	target_link_libraries(wrfhydro.exe hydro_driver)
-	target_link_libraries(wrfhydro.exe noahmp_util)
-	target_link_libraries(wrfhydro.exe noahmp_phys)
-	target_link_libraries(wrfhydro.exe noahmp_data)
-	target_link_libraries(wrfhydro.exe hydro_noahmp_cpl)
-	target_link_libraries(wrfhydro.exe ${NETCDF_LIBRARIES})
+    target_link_libraries(wrfhydro.exe hydro_utils)
+    target_link_libraries(wrfhydro.exe hydro_mpp)
+    target_link_libraries(wrfhydro.exe hydro_debug_utils)
+    target_link_libraries(wrfhydro.exe hydro_routing_overland)
+    target_link_libraries(wrfhydro.exe hydro_routing_subsurface)
+    #target_link_libraries(wrfhydro.exe hydro_routing_groundwater)
+    #target_link_libraries(wrfhydro.exe hydro_routing_groundwater_bucket)
+    #target_link_libraries(wrfhydro.exe hydro_routing_groundwater_nhd)
+    #target_link_libraries(wrfhydro.exe hydro_routing_groundwater_simple)
+    target_link_libraries(wrfhydro.exe hydro_data_rec)
+    target_link_libraries(wrfhydro.exe hydro_routing)
+    target_link_libraries(wrfhydro.exe hydro_routing_reservoirs_levelpool)
+    target_link_libraries(wrfhydro.exe hydro_routing_reservoirs_hybrid)
+    target_link_libraries(wrfhydro.exe hydro_routing_reservoirs_rfc)
+    target_link_libraries(wrfhydro.exe hydro_routing_reservoirs)
+    target_link_libraries(wrfhydro.exe hydro_driver)
+    target_link_libraries(wrfhydro.exe noahmp_util)
+    target_link_libraries(wrfhydro.exe noahmp_phys)
+    target_link_libraries(wrfhydro.exe noahmp_data)
+    target_link_libraries(wrfhydro.exe hydro_noahmp_cpl)
+    target_link_libraries(wrfhydro.exe ${NETCDF_LIBRARIES})
 
-	if (WRF_HYDRO_NUDGING STREQUAL "1")
-		target_link_libraries(wrfhydro.exe hydro_nudging)
- 		add_dependencies(wrfhydro.exe hydro_nudging)
-	endif (WRF_HYDRO_NUDGING STREQUAL "1")
+    if (WRF_HYDRO_NUDGING STREQUAL "1")
+        target_link_libraries(wrfhydro.exe hydro_nudging)
+         add_dependencies(wrfhydro.exe hydro_nudging)
+    endif (WRF_HYDRO_NUDGING STREQUAL "1")
 
-	add_custom_command(TARGET wrfhydro.exe POST_BUILD
-		COMMAND mkdir -p ${CMAKE_BINARY_DIR}/Run
-		COMMAND rm -f ${CMAKE_BINARY_DIR}/Run/*
-		COMMAND cp ${PROJECT_BINARY_DIR}/src/wrfhydro.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro_NoahMP.exe
-		COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/NoahMP/* ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/CHANPARM.TBL ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/hydro.namelist ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/HYDRO.TBL ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${PROJECT_SOURCE_DIR}/src/Land_models/NoahMP/run/*.TBL ${CMAKE_BINARY_DIR}/Run
-		COMMAND ln -s wrf_hydro_NoahMP.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro.exe
-		COMMAND rm ${PROJECT_BINARY_DIR}/src/wrfhydro.exe
-	)
+    add_custom_command(TARGET wrfhydro.exe POST_BUILD
+        COMMAND mkdir -p ${CMAKE_BINARY_DIR}/Run
+        COMMAND rm -f ${CMAKE_BINARY_DIR}/Run/*
+        COMMAND cp ${PROJECT_BINARY_DIR}/src/wrfhydro.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro_NoahMP.exe
+        COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/NoahMP/* ${CMAKE_BINARY_DIR}/Run
+        COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/CHANPARM.TBL ${CMAKE_BINARY_DIR}/Run
+        COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/hydro.namelist ${CMAKE_BINARY_DIR}/Run
+        COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/HYDRO.TBL ${CMAKE_BINARY_DIR}/Run
+        COMMAND cp ${PROJECT_SOURCE_DIR}/src/Land_models/NoahMP/run/*.TBL ${CMAKE_BINARY_DIR}/Run
+        COMMAND ln -s wrf_hydro_NoahMP.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro.exe
+        COMMAND rm ${PROJECT_BINARY_DIR}/src/wrfhydro.exe
+    )
 
 elseif(HYDRO_LSM MATCHES "Noah")
-	message ("-- Building Noah LSM")
-	add_subdirectory("Land_models/Noah")
-	add_subdirectory("CPL/Noah_cpl")
+    message ("-- Building Noah LSM")
+    add_subdirectory("Land_models/Noah")
+    add_subdirectory("CPL/Noah_cpl")
 
         add_dependencies(hydro_noah_cpl hydro_routing)
         add_dependencies(hydro_noah_cpl hydro_mpp )
@@ -149,34 +149,33 @@ elseif(HYDRO_LSM MATCHES "Noah")
         target_link_libraries(wrfhydro.exe hydro_data_rec)
         target_link_libraries(wrfhydro.exe hydro_routing)
         target_link_libraries(wrfhydro.exe hydro_driver)
-	target_link_libraries(wrfhydro.exe hydro_routing_reservoirs_levelpool)
-	target_link_libraries(wrfhydro.exe hydro_routing_reservoirs_hybrid)
-	target_link_libraries(wrfhydro.exe hydro_routing_reservoirs_rfc)
-	target_link_libraries(wrfhydro.exe hydro_routing_reservoirs)
-	target_link_libraries(wrfhydro.exe noah_util)
+        target_link_libraries(wrfhydro.exe hydro_routing_reservoirs_levelpool)
+        target_link_libraries(wrfhydro.exe hydro_routing_reservoirs_hybrid)
+        target_link_libraries(wrfhydro.exe hydro_routing_reservoirs_rfc)
+        target_link_libraries(wrfhydro.exe hydro_routing_reservoirs)
+        target_link_libraries(wrfhydro.exe noah_util)
         target_link_libraries(wrfhydro.exe noah)
         target_link_libraries(wrfhydro.exe hydro_noah_cpl)
-        target_link_libraries(wrfhydro.exe ${NETCDF_LIBRARIES})
+        target_link_libraries(wrfhydro.exe ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES})
 
-	if (WRF_HYDRO_NUDGING STREQUAL "1")
-                target_link_libraries(wrfhydro.exe hydro_nudging)
-                add_dependencies(wrfhydro.exe hydro_nudging)
+        if (WRF_HYDRO_NUDGING STREQUAL "1")
+            target_link_libraries(wrfhydro.exe hydro_nudging)
+            add_dependencies(wrfhydro.exe hydro_nudging)
         endif (WRF_HYDRO_NUDGING STREQUAL "1")
 
         add_custom_command(TARGET wrfhydro.exe POST_BUILD
-		COMMAND mkdir -p ${CMAKE_BINARY_DIR}/Run
-		COMMAND rm -f ${CMAKE_BINARY_DIR}/Run/*
-		COMMAND cp ${PROJECT_BINARY_DIR}/src/wrfhydro.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro_Noah.exe
-		COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/Noah/* ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/CHANPARM.TBL ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/hydro.namelist ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/HYDRO.TBL ${CMAKE_BINARY_DIR}/Run
-		COMMAND cp ${PROJECT_SOURCE_DIR}/src/Land_models/Noah/Run/*.TBL ${CMAKE_BINARY_DIR}/Run
-		COMMAND ln -s wrf_hydro_Noah.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro.exe
-		COMMAND rm ${PROJECT_BINARY_DIR}/src/wrfhydro.exe
+            COMMAND mkdir -p ${CMAKE_BINARY_DIR}/Run
+            COMMAND rm -f ${CMAKE_BINARY_DIR}/Run/*
+            COMMAND cp ${PROJECT_BINARY_DIR}/src/wrfhydro.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro_Noah.exe
+            COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/Noah/* ${CMAKE_BINARY_DIR}/Run
+            COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/CHANPARM.TBL ${CMAKE_BINARY_DIR}/Run
+            COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/hydro.namelist ${CMAKE_BINARY_DIR}/Run
+            COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/HYDRO.TBL ${CMAKE_BINARY_DIR}/Run
+            COMMAND cp ${PROJECT_SOURCE_DIR}/src/Land_models/Noah/Run/*.TBL ${CMAKE_BINARY_DIR}/Run
+            COMMAND ln -s wrf_hydro_Noah.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro.exe
+            COMMAND rm ${PROJECT_BINARY_DIR}/src/wrfhydro.exe
         )
 
-
 else()
-	message ("Unknown land surface model:" ${HYDRO_LSM} )
+    message ("Unknown land surface model:" ${HYDRO_LSM} )
 endif (HYDRO_LSM MATCHES "NoahMP")

--- a/src/CPL/NUOPC_cpl/CMakeLists.txt
+++ b/src/CPL/NUOPC_cpl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 ### Library Prerequisites
 if (NOT TARGET esmf)

--- a/src/CPL/NoahMP_cpl/CMakeLists.txt
+++ b/src/CPL/NoahMP_cpl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(hydro_noahmp_cpl STATIC
 	module_hrldas_HYDRO.F

--- a/src/Data_Rec/CMakeLists.txt
+++ b/src/Data_Rec/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(hydro_data_rec STATIC
 	module_gw_gw2d_data.F

--- a/src/Debug_Utilities/CMakeLists.txt
+++ b/src/Debug_Utilities/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 # build the version static library
 add_library(hydro_debug_utils STATIC

--- a/src/HYDRO_drv/CMakeLists.txt
+++ b/src/HYDRO_drv/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 # build the version static library
 add_library(hydro_driver STATIC

--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 # build the orchestrator static library
 add_library(hydro_netcdf_layer STATIC

--- a/src/Land_models/Noah/CMakeLists.txt
+++ b/src/Land_models/Noah/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_subdirectory("Noah")
 add_subdirectory("Utility_routines")

--- a/src/Land_models/Noah/Noah/CMakeLists.txt
+++ b/src/Land_models/Noah/Noah/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(noah STATIC
 	module_sf_urban.F

--- a/src/Land_models/Noah/Utility_routines/CMakeLists.txt
+++ b/src/Land_models/Noah/Utility_routines/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(noah_util STATIC
 	kwm_string_utilities.F

--- a/src/Land_models/NoahMP/CMakeLists.txt
+++ b/src/Land_models/NoahMP/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_subdirectory("phys")
 add_subdirectory("Utility_routines")

--- a/src/Land_models/NoahMP/Utility_routines/CMakeLists.txt
+++ b/src/Land_models/NoahMP/Utility_routines/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(noahmp_util STATIC
 	kwm_string_utilities.F

--- a/src/Land_models/NoahMP/data_structures/CMakeLists.txt
+++ b/src/Land_models/NoahMP/data_structures/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(noahmp_data STATIC
         forcing.f90

--- a/src/Land_models/NoahMP/phys/CMakeLists.txt
+++ b/src/Land_models/NoahMP/phys/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_subdirectory("surfex")
 

--- a/src/Land_models/NoahMP/phys/surfex/CMakeLists.txt
+++ b/src/Land_models/NoahMP/phys/surfex/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(crocus_surfex STATIC
   ini_csts.F

--- a/src/Land_models/NoahMP/phys/surfex/module_snowcro.F
+++ b/src/Land_models/NoahMP/phys/surfex/module_snowcro.F
@@ -165,6 +165,7 @@ USE MODE_SNOW3L
 ! this module is not used anymore
 ! USE MODI_GREGODSTRATI
 
+use ieee_arithmetic, only: isnan => ieee_is_nan
 
 !
 IMPLICIT NONE

--- a/src/MPP/CMakeLists.txt
+++ b/src/MPP/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(hydro_mpp STATIC
 	CPL_WRF.F
@@ -7,3 +7,5 @@ add_library(hydro_mpp STATIC
 	mpp_land.F          
 	hashtable.F
 )
+
+target_link_libraries(hydro_mpp ${MPI_Fortran_LIBRARIES})

--- a/src/OrchestratorLayer/CMakeLists.txt
+++ b/src/OrchestratorLayer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 # build the orchestrator static library
 add_library(hydro_orchestrator STATIC

--- a/src/Routing/CMakeLists.txt
+++ b/src/Routing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(hydro_routing STATIC
 	module_UDMAP.F

--- a/src/Routing/Overland/CMakeLists.txt
+++ b/src/Routing/Overland/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(hydro_routing_overland STATIC
 	module_overland_control.F  

--- a/src/Routing/Reservoirs/CMakeLists.txt
+++ b/src/Routing/Reservoirs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(hydro_routing_reservoirs STATIC
 	module_reservoir.F

--- a/src/Routing/Reservoirs/Level_Pool/CMakeLists.txt
+++ b/src/Routing/Reservoirs/Level_Pool/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(hydro_routing_reservoirs_levelpool STATIC
 	module_levelpool.F

--- a/src/Routing/Reservoirs/Persistence_Level_Pool_Hybrid/CMakeLists.txt
+++ b/src/Routing/Reservoirs/Persistence_Level_Pool_Hybrid/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(hydro_routing_reservoirs_hybrid STATIC
 	module_persistence_levelpool_hybrid.F

--- a/src/Routing/Reservoirs/RFC_Forecasts/CMakeLists.txt
+++ b/src/Routing/Reservoirs/RFC_Forecasts/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(hydro_routing_reservoirs_rfc STATIC
 	module_rfc_forecasts.F

--- a/src/Routing/Subsurface/CMakeLists.txt
+++ b/src/Routing/Subsurface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 add_library(hydro_routing_subsurface STATIC
 	module_subsurface_input.F  

--- a/src/compile_offline_Noah.sh
+++ b/src/compile_offline_Noah.sh
@@ -43,14 +43,14 @@ make clean ; rm -f Run/wrf_hydro_Noah.exe ; rm -f Run/*TBL ; rm -f Run/*namelist
 
 cat macros LandModel/user_build_options.bak > LandModel/user_build_options
 
-make; make install
+make && make install
 
 
 if [[ $? -eq 0 ]]; then
     echo
     echo '*****************************************************************'
     echo "Make was successful"
-else 
+else
     echo
     echo '*****************************************************************'
     echo "Make NOT successful"

--- a/src/compile_offline_NoahMP.sh
+++ b/src/compile_offline_NoahMP.sh
@@ -26,7 +26,7 @@ if [[ ! -z $env_file ]]; then
 
     echo "configure: Sourcing $env_file for the compile options."
     source $env_file
-    
+
 else
     echo "configure: Using the compile options in the calling environment."
 fi
@@ -51,14 +51,14 @@ ln -sf CPL/NoahMP_cpl LandModel_cpl
 make clean; rm -f Run/wrf_hydro_NoahMP.exe ; rm -f Run/*TBL ; rm -f Run/*namelist*
 
 #for debugging and testing
-#make debug; make install; make test 
-make; make install
+#make debug; make install; make test
+make && make install
 
 if [[ $? -eq 0 ]]; then
     echo
     echo '*****************************************************************'
     echo "Make was successful"
-else 
+else
     echo
     echo '*****************************************************************'
     echo "Make NOT successful"
@@ -79,7 +79,7 @@ else
     # If it's an nwm version (nwm release branch), grab the nwm versions from elsewhere.
     echo 'NWM version: not populating with generic templates'
 fi
-    
+
 
 echo
 echo '*****************************************************************'

--- a/src/nudging/CMakeLists.txt
+++ b/src/nudging/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 # build the version static library
 add_library(hydro_nudging STATIC

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 # read version numbers for wrf_hydro_version and nwm_version from 
 # ../.version and ../.nwm_version


### PR DESCRIPTION
TYPE: bugfix/enhancement

KEYWORDS: CMake, PGI

SOURCE: WRF-Hydro Team @ NCAR

DESCRIPTION OF CHANGES:

* In the classic build system, don't report success if the underlying Make process failed.

* In CMake build system, remove `-fallow-argument-mismatch` from gfortran flags, since this
breaks compatibiilty with older GNU suites (< v10) and not needed anymore with `use netcdf`

* Update the CMake build system to use FIND_MPI() and not override the compiler variables with
static `mpif90` wrapper scripts. This also explicitly links MPI libaries to modules that require
it. 

* Support PGI (> v20) and NVHPC in CMake:
 - added compiler flags from arc/macros.mpp.linux
 - added `use ieee_arithmetic, only: isnan => ieee_is_nan` to CROCUS since PGI doesn't
   suport isnan() intrinsic (this may help on other compilers too)

ISSUES:
```
Fixes #640, #677
```

TESTS CONDUCTED: pending

## Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [X] Closes issues #640 and #677 (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [-] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
