### PR TITLE
Support parallel Make in Legacy build system

### DIFF
--- a/src/CPL/CLM_cpl/Makefile
+++ b/src/CPL/CLM_cpl/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .F
@@ -13,19 +13,20 @@ MODFLAG =       -I./ -I ../../MPP -I ../../mod
 
 OBJS = \
 	module_clm_HYDRO.o \
-	clm_drv_HYDRO.o    
-all:	$(OBJS) 
+	clm_drv_HYDRO.o
 
-.F.o:
+all:	$(OBJS)
+	ar -cr ../../lib/libHYDRO.a $(OBJS)
+
+%.o: %.F
 	@echo ""
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(MODFLAG) -I ../../mod $(CLM_MOD) $(*).F
 	@echo ""
-	ar -r ../../lib/libHYDRO.a $(@)
 
 #
 # Dependencies:
 #
 
 clean:
-	rm -f *.o *.mod *.stb *~ 
+	rm -f *.o *.mod *.stb *~
 	cd ../..; make -f Makefile.comm clean

--- a/src/CPL/CLM_cpl/Makefile
+++ b/src/CPL/CLM_cpl/Makefile
@@ -20,7 +20,7 @@ all:	$(OBJS)
 
 %.o: %.F
 	@echo ""
-	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(MODFLAG) -I ../../mod $(CLM_MOD) $(*).F
+	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(MODFLAG) -I ../../mod $(CLM_MOD) $<
 	@echo ""
 
 #

--- a/src/CPL/CLM_cpl/Makefile
+++ b/src/CPL/CLM_cpl/Makefile
@@ -28,5 +28,5 @@ all:	$(OBJS)
 #
 
 clean:
-	rm -f *.o *.mod *.stb *~
-	cd ../..; make -f Makefile.comm clean
+	rm -f *.o $(MAKE)  *.stb *~
+	cd ../..; $(MAKE) -f Makefile.comm clean

--- a/src/CPL/CLM_cpl/Makefile.cpl
+++ b/src/CPL/CLM_cpl/Makefile.cpl
@@ -1,8 +1,8 @@
-# Makefile 
+# Makefile
 
 all:
-	(cd ../../; make -f Makefile.comm)
-	(make)
+	(cd ../../; $(MAKE) -f Makefile.comm)
+	($(MAKE))
 
 clean:
-	(cd ../../; make -f Makefile.comm clean)
+	(cd ../../; $(MAKE) -f Makefile.comm clean)

--- a/src/CPL/LIS_cpl/Makefile
+++ b/src/CPL/LIS_cpl/Makefile
@@ -5,7 +5,7 @@
 .SUFFIXES: .o .F
 LIS_ROOT = ../../../..
 
-LIS_MOD = -I ../../mod -I$(LIS_ROOT)/make
+LIS_MOD = -I ../../mod -I$(LIS_ROOT)/$(MAKE)
 include $(LIS_ROOT)/make/configure.lis
 include ../../macros
 

--- a/src/CPL/LIS_cpl/Makefile
+++ b/src/CPL/LIS_cpl/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 
 .SUFFIXES:
@@ -14,17 +14,18 @@ MODFLAG =       -I./ -I ../../MPP -I ../../mod
 OBJS = \
 	module_lis_HYDRO.o\
 	lis_drv_HYDRO.o
-all:	$(OBJS) 
 
-.F.o:
+all:	$(OBJS)
+	ar -r ../../lib/libHYDRO.a $(OBJS)
+
+%.o: %.F
 	@echo ""
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(MODFLAG) -I../../mod $(LIS_MOD) -I$(MOD_ESMF) $(*).F
 	@echo ""
-	ar -r ../../lib/libHYDRO.a $(@)
 
 #
 # Dependencies:
 #
 
 clean:
-	rm -f *.o *.mod *.stb *~ 
+	rm -f *.o *.mod *.stb *~

--- a/src/CPL/LIS_cpl/Makefile
+++ b/src/CPL/LIS_cpl/Makefile
@@ -20,7 +20,7 @@ all:	$(OBJS)
 
 %.o: %.F
 	@echo ""
-	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(MODFLAG) -I../../mod $(LIS_MOD) -I$(MOD_ESMF) $(*).F
+	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(MODFLAG) -I../../mod $(LIS_MOD) -I$(MOD_ESMF) $<
 	@echo ""
 
 #

--- a/src/CPL/LIS_cpl/Makefile.cpl
+++ b/src/CPL/LIS_cpl/Makefile.cpl
@@ -1,9 +1,9 @@
-# Makefile 
+# Makefile
 
 all:
-	(cd ../../; make -f Makefile.comm)
+	(cd ../../; $(MAKE) -f Makefile.comm)
 	(make)
 
 clean:
-	(make clean)
-	(cd ../../; make -f Makefile.comm clean)
+	($(MAKE) clean)
+	(cd ../../; $(MAKE) -f Makefile.comm clean)

--- a/src/CPL/NUOPC_cpl/Makefile
+++ b/src/CPL/NUOPC_cpl/Makefile
@@ -173,7 +173,7 @@ build_model:
 	$(call checkdir, $(MODEL_DIR))
 	mkdir -p $(MODEL_LIBDIR)
 	mkdir -p $(MODEL_MODDIR)
-	make -C $(MODEL_DIR) -f $(MODEL_MK)
+	$(MAKE) -C $(MODEL_DIR) -f $(MODEL_MK)
 
 $(MODEL_MODS): build_model
 
@@ -347,7 +347,7 @@ nuopcdistclean: nuopcclean
 	@echo "Cleaning Model build..."
 	@echo ""
 	$(call checkdir, $(MODEL_DIR))
-	make -C $(MODEL_DIR) -f $(MODEL_MK) clean
+	$(MAKE) -C $(MODEL_DIR) -f $(MODEL_MK) clean
 
 # #########
 # Clean Cap

--- a/src/CPL/NoahMP_cpl/Makefile
+++ b/src/CPL/NoahMP_cpl/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .F
@@ -11,15 +11,16 @@ MODFLAG =       -I./ -I ../../MPP -I ../../mod
 
 OBJS = \
 	module_hrldas_HYDRO.o \
-	hrldas_drv_HYDRO.o    
-all:	$(OBJS) 
+	hrldas_drv_HYDRO.o
 
-.F.o:
+all:	$(OBJS)
+	ar -cr ../../lib/libHYDRO.a $(OBJS)
+
+%.o: %.F
 	@echo ""
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) $(*).F
 	@echo ""
-	ar -r ../../lib/libHYDRO.a $(@)
-	cp *.mod ../../mod
+	@cp *.mod ../../mod
 
 #
 # Dependencies:

--- a/src/CPL/NoahMP_cpl/Makefile
+++ b/src/CPL/NoahMP_cpl/Makefile
@@ -18,7 +18,7 @@ all:	$(OBJS)
 
 %.o: %.F
 	@echo ""
-	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) $(*).F
+	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) $<
 	@echo ""
 	@cp *.mod ../../mod
 

--- a/src/CPL/Noah_cpl/Makefile
+++ b/src/CPL/Noah_cpl/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .F
@@ -11,14 +11,15 @@ MODFLAG =       -I./ -I ../../MPP -I ../../mod
 
 OBJS = \
 	module_hrldas_HYDRO.o \
-	hrldas_drv_HYDRO.o    
-all:	$(OBJS) 
+	hrldas_drv_HYDRO.o
 
-.F.o:
+all:	$(OBJS)
+	ar -r ../../lib/libHYDRO.a $(OBJS)
+
+%.o: %.F
 	@echo ""
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(MODFLAG) -I$(NETCDF_INC) $(*).F
 	@echo ""
-	ar -r ../../lib/libHYDRO.a $(@)
 
 #
 # Dependencies:

--- a/src/CPL/Noah_cpl/Makefile
+++ b/src/CPL/Noah_cpl/Makefile
@@ -18,7 +18,7 @@ all:	$(OBJS)
 
 %.o: %.F
 	@echo ""
-	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(MODFLAG) -I$(NETCDF_INC) $(*).F
+	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(MODFLAG) -I$(NETCDF_INC) $<
 	@echo ""
 
 #

--- a/src/CPL/WRF_cpl/Makefile
+++ b/src/CPL/WRF_cpl/Makefile
@@ -19,7 +19,7 @@ all:	$(OBJS)
 
 %.o: %.F
 	@echo ""
-	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(MODFLAG) -I$(WRF_ROOT)/frame -I$(WRF_ROOT)/main -I$(WRF_ROOT)/external/esmf_time_f90 $(*).F
+	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(MODFLAG) -I$(WRF_ROOT)/frame -I$(WRF_ROOT)/main -I$(WRF_ROOT)/external/esmf_time_f90 $<
 	@echo ""
 
 #

--- a/src/CPL/WRF_cpl/Makefile
+++ b/src/CPL/WRF_cpl/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .F
@@ -7,19 +7,20 @@
 
 include ../../macros
 
-MODFLAG =       -I./ -I ../../MPP -I ../../mod 
+MODFLAG =       -I./ -I ../../MPP -I ../../mod
 
 WRF_ROOT = ../../..
 OBJS = \
 	module_wrf_HYDRO.o \
-	wrf_drv_HYDRO.o    
-all:	$(OBJS) 
+	wrf_drv_HYDRO.o
 
-.F.o:
+all:	$(OBJS)
+	ar -r ../../lib/libHYDRO.a $(OBJS)
+
+%.o: %.F
 	@echo ""
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(MODFLAG) -I$(WRF_ROOT)/frame -I$(WRF_ROOT)/main -I$(WRF_ROOT)/external/esmf_time_f90 $(*).F
 	@echo ""
-	ar -r ../../lib/libHYDRO.a $(@)
 
 #
 # Dependencies:

--- a/src/CPL/WRF_cpl/Makefile.cpl
+++ b/src/CPL/WRF_cpl/Makefile.cpl
@@ -1,9 +1,9 @@
-# Makefile 
+# Makefile
 
 all:
-	(cd ../../; make -f Makefile.comm BASIC)
-	(make)
+	(cd ../../; $(MAKE) -f Makefile.comm BASIC)
+	($(MAKE))
 
 clean:
-	(make clean)
-	(cd ../../; make -f Makefile.comm clean)
+	($(MAKE) clean)
+	(cd ../../; $(MAKE) -f Makefile.comm clean)

--- a/src/Data_Rec/Makefile
+++ b/src/Data_Rec/Makefile
@@ -13,13 +13,13 @@ OBJS = \
 	module_gw_gw2d_data.o
 
 all:	$(OBJS)
+	ar -cr ../lib/libHYDRO.a $(OBJS)
 
-.F.o:
+%.o: %.F
 	@echo ""
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I../mod $(*).F
 	@echo ""
-	ar -r ../lib/libHYDRO.a $(@)
-	cp *.mod ../mod
+	@cp *.mod ../mod
 
 # Dependencies:
 #

--- a/src/Data_Rec/Makefile
+++ b/src/Data_Rec/Makefile
@@ -17,7 +17,7 @@ all:	$(OBJS)
 
 %.o: %.F
 	@echo ""
-	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I../mod $(*).F
+	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I../mod $<
 	@echo ""
 	@cp *.mod ../mod
 

--- a/src/Debug_Utilities/Makefile
+++ b/src/Debug_Utilities/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .F
@@ -6,16 +6,16 @@
 include ../macros
 
 OBJS = \
-	debug_dump_variable.o 
+	debug_dump_variable.o
 
-all:	$(OBJS) 
+all:	$(OBJS)
+	ar -r ../lib/libHYDRO.a $(OBJS)
 
-.F.o:
+%.o: %.F
 	@echo ""
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I../mod $(*).F
 	@echo ""
-	ar -r ../lib/libHYDRO.a $(@)
-	cp *.mod ../mod
+	@cp *.mod ../mod
 
 # Dependencies:
 #

--- a/src/Debug_Utilities/Makefile
+++ b/src/Debug_Utilities/Makefile
@@ -13,7 +13,7 @@ all:	$(OBJS)
 
 %.o: %.F
 	@echo ""
-	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I../mod $(*).F
+	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I../mod $<
 	@echo ""
 	@cp *.mod ../mod
 

--- a/src/HYDRO_drv/Makefile
+++ b/src/HYDRO_drv/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .F
@@ -7,20 +7,27 @@ include ../macros
 
 OBJS = \
 	module_HYDRO_drv.o
-all:	$(OBJS) 
 
-.F.o:
+all:	$(OBJS)
+	ar -r ../lib/libHYDRO.a $(OBJS)
+
+%.o: %.F
 	@echo ""
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) -I../mod $(*).F
 	@echo ""
-	ar -r ../lib/libHYDRO.a $(@)
-	cp *.mod ../mod
+	@cp *.mod ../mod
 
 #
 # Dependencies:
 #
-module_HYDRO_drv.o: ../Data_Rec/module_namelist.o ../Data_Rec/module_RT_data.o ../Data_Rec/module_gw_gw2d_data.o \
-        ../Routing/module_GW_baseflow.o ../Routing/module_HYDRO_utils.o ../Routing/module_HYDRO_io.o ../Routing/module_RT.o
+module_HYDRO_drv.o: ../Data_Rec/module_namelist.o \
+                    ../Data_Rec/module_RT_data.o \
+					../Data_Rec/module_gw_gw2d_data.o \
+                    ../Routing/module_GW_baseflow.o \
+					../Routing/module_HYDRO_utils.o \
+					../Routing/module_HYDRO_io.o \
+					../Routing/module_NWM_io.o \
+					../Routing/module_RT.o
 
 clean:
 	rm -f *.o *.mod *.stb *~

--- a/src/HYDRO_drv/Makefile
+++ b/src/HYDRO_drv/Makefile
@@ -13,7 +13,7 @@ all:	$(OBJS)
 
 %.o: %.F
 	@echo ""
-	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) -I../mod $(*).F
+	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) -I../mod $<
 	@echo ""
 	@cp *.mod ../mod
 

--- a/src/IO/Makefile
+++ b/src/IO/Makefile
@@ -13,7 +13,7 @@ all:	$(OBJS)
 
 %.o: %.f90
 	@echo ""
-# $(CPP) $(CPPFLAGS) -I$(NETCDFINC) $(*).F > $(*).f
+# $(CPP) $(CPPFLAGS) -I$(NETCDFINC) $< > $(*).f
 #	$(COMPILER90) -o $(@) $(F90FLAGS) $(MODFLAG) -I../mod $(*).f
 	$(COMPILER90) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) -I../mod $(*).f90
 #	$(RMD) $(*).f

--- a/src/IO/Makefile
+++ b/src/IO/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .f90
@@ -7,17 +7,18 @@ include ../macros
 
 OBJS = \
 	netcdf_layer.o
-all:	$(OBJS)
 
-.f90.o:
+all:	$(OBJS)
+	ar -r ../lib/libHYDRO.a $(OBJS)
+
+%.o: %.f90
 	@echo ""
 # $(CPP) $(CPPFLAGS) -I$(NETCDFINC) $(*).F > $(*).f
 #	$(COMPILER90) -o $(@) $(F90FLAGS) $(MODFLAG) -I../mod $(*).f
 	$(COMPILER90) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) -I../mod $(*).f90
 #	$(RMD) $(*).f
 	@echo ""
-	ar -r ../lib/libHYDRO.a $(@)
-	cp *.mod ../mod
+	@cp *.mod ../mod
 
 #
 # Dependencies:

--- a/src/Land_models/Noah/GRAPHICS/HORIZ/Makefile
+++ b/src/Land_models/Noah/GRAPHICS/HORIZ/Makefile
@@ -34,7 +34,7 @@ all:	$(CMD)
 
 %.o: %.F
 	@echo ""
-	$(F90) $(CPPINVOKE) $(CPPFLAGS) -c -I$(NETCDF)/include $(FFLAGS) $(MODDIR) $(*).F
+	$(F90) $(CPPINVOKE) $(CPPFLAGS) -c -I$(NETCDF)/include $(FFLAGS) $(MODDIR) $<
 
 $(CMD):	$(OBJS)
 	$(F90) -o $(@) -I$(NETCDF)/include $(FFLAGS) $(OBJS) \

--- a/src/Land_models/Noah/GRAPHICS/HORIZ/Makefile
+++ b/src/Land_models/Noah/GRAPHICS/HORIZ/Makefile
@@ -27,7 +27,7 @@ CMD=	plt2d.exe
 
 
 # Lines from here on down should not need to be changed.  They are the
-# actual rules which make uses to build $(CMD).
+# actual rules which $(MAKE) uses to build $(CMD).
 #
 
 all:	$(CMD)

--- a/src/Land_models/Noah/GRAPHICS/HORIZ/Makefile
+++ b/src/Land_models/Noah/GRAPHICS/HORIZ/Makefile
@@ -1,5 +1,5 @@
 SHELL=/bin/sh
-.SUFFIXES:	
+.SUFFIXES:
 .SUFFIXES:	.F .o .exe
 OBJS=	module_plot2d_graphics.o \
 	module_2ddata.o \
@@ -14,8 +14,8 @@ OBJS=	module_plot2d_graphics.o \
 #FFLAGS=-free
 
 F90=	pgf90
-FFLAGS=-Mfree 
-LIBS2 = -L${PGI}/linux86/5.2/lib -lpgftnrtl -lpgc 
+FFLAGS=-Mfree
+LIBS2 = -L${PGI}/linux86/5.2/lib -lpgftnrtl -lpgc
 
 RM = 	rm -f
 NCARGLIBS=	-L/usr/local/ncarg/lib -L/usr/X11R6/lib \
@@ -32,7 +32,7 @@ CMD=	plt2d.exe
 
 all:	$(CMD)
 
-.F.o:
+%.o: %.F
 	@echo ""
 	$(F90) $(CPPINVOKE) $(CPPFLAGS) -c -I$(NETCDF)/include $(FFLAGS) $(MODDIR) $(*).F
 

--- a/src/Land_models/Noah/GRAPHICS/TIME_SERIES/Makefile
+++ b/src/Land_models/Noah/GRAPHICS/TIME_SERIES/Makefile
@@ -25,7 +25,7 @@ CMD=	pltts.exe
 
 
 # Lines from here on down should not need to be changed.  They are the
-# actual rules which make uses to build $(CMD).
+# actual rules which $(MAKE) uses to build $(CMD).
 #
 
 all:	$(CMD)

--- a/src/Land_models/Noah/GRAPHICS/TIME_SERIES/Makefile
+++ b/src/Land_models/Noah/GRAPHICS/TIME_SERIES/Makefile
@@ -1,5 +1,5 @@
 SHELL=/bin/sh
-.SUFFIXES:	
+.SUFFIXES:
 .SUFFIXES:	.F .o .exe
 OBJS=	module_plotts_graphics.o \
 	module_ptdata.o \
@@ -30,13 +30,13 @@ CMD=	pltts.exe
 
 all:	$(CMD)
 
-.F.o:
+%.o: %.F
 	@echo ""
 	$(F90) $(CPPINVOKE) $(CPPFLAGS) -c -I$(NETCDF)/include $(FFLAGS) $(MODDIR) $(*).F
 
 $(CMD):	$(OBJS)
 	$(F90) -o $(@) -I$(NETCDF)/include $(FFLAGS) $(OBJS) \
-	-L$(NETCDF)/lib -lnetcdf $(NCARGLIBS) 
+	-L$(NETCDF)/lib -lnetcdf $(NCARGLIBS)
 
 clean:
 	$(RM) *.o *~ *.exe *.mod

--- a/src/Land_models/Noah/GRAPHICS/TIME_SERIES/Makefile
+++ b/src/Land_models/Noah/GRAPHICS/TIME_SERIES/Makefile
@@ -32,7 +32,7 @@ all:	$(CMD)
 
 %.o: %.F
 	@echo ""
-	$(F90) $(CPPINVOKE) $(CPPFLAGS) -c -I$(NETCDF)/include $(FFLAGS) $(MODDIR) $(*).F
+	$(F90) $(CPPINVOKE) $(CPPFLAGS) -c -I$(NETCDF)/include $(FFLAGS) $(MODDIR) $<
 
 $(CMD):	$(OBJS)
 	$(F90) -o $(@) -I$(NETCDF)/include $(FFLAGS) $(OBJS) \

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/Makefile
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/Makefile
@@ -20,7 +20,7 @@ lib/libsmda.a:
 
 %.o: %.F
 	@echo ""
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(FREESOURCE) $(F90FLAGS) -c $(NETCDFMOD) -I./lib $(MODFLAG)./lib $(*).F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(FREESOURCE) $(F90FLAGS) -c $(NETCDFMOD) -I./lib $(MODFLAG)./lib $<
 
 $(CMD):	lib/libsmda.a $(OBJS)
 	(cd lib; $(MAKE))

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/Makefile
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/Makefile
@@ -9,27 +9,27 @@ OBJS=	consolidate_grib.o
 CMD=	consolidate_grib.exe
 
 default:
-	(cd lib; make)
-	(make -f Makefile all)
+	(cd lib; $(MAKE))
+	($(MAKE) -f Makefile all)
 
 all:	lib/libsmda.a $(CMD)
-	(cd lib; make)
+	(cd lib; $(MAKE))
 
 lib/libsmda.a:
-	(cd lib; make)
+	(cd lib; $(MAKE))
 
 %.o: %.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(FREESOURCE) $(F90FLAGS) -c $(NETCDFMOD) -I./lib $(MODFLAG)./lib $(*).F
 
 $(CMD):	lib/libsmda.a $(OBJS)
-	(cd lib; make)
+	(cd lib; $(MAKE))
 	$(COMPILERF90) -o $(@) -I./lib $(F90FLAGS) $(MODFLAG)./lib $(OBJS) \
 		-L./lib -lsmda $(NETCDFLIB) $(HDF5LIB) $(BZIP2_LIB) $(LIBJASPER)
 
 clean:
 	$(RM) *.o *~ *.exe *.mod
-	(cd lib; make clean)
+	(cd lib; $(MAKE) clean)
 #
 
 

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/Makefile
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/Makefile
@@ -1,5 +1,5 @@
 SHELL=/bin/sh
-.SUFFIXES:	
+.SUFFIXES:
 .SUFFIXES:	.F .c .o .exe
 
 include ../user_build_options
@@ -18,7 +18,7 @@ all:	lib/libsmda.a $(CMD)
 lib/libsmda.a:
 	(cd lib; make)
 
-.F.o:
+%.o: %.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(FREESOURCE) $(F90FLAGS) -c $(NETCDFMOD) -I./lib $(MODFLAG)./lib $(*).F
 

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/Makefile
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/Makefile
@@ -50,7 +50,7 @@ decode_jpeg2000.o:	decode_jpeg2000.c
 
 %.o: %.F
 	@echo ""
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(GRIBCODE_OPT) $(BZIP_CPP) -c $(FREESOURCE) $(F90FLAGS) $(NETCDFMOD) $(*).F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(GRIBCODE_OPT) $(BZIP_CPP) -c $(FREESOURCE) $(F90FLAGS) $(NETCDFMOD) $<
 
 .c.o:
 	$(CC) -c $(BZIP_CPP) $(<)

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/Makefile
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/lib/Makefile
@@ -1,5 +1,5 @@
 SHELL=/bin/sh
-.SUFFIXES:	
+.SUFFIXES:
 .SUFFIXES:	.F .c .o
 
 include ../../user_build_options
@@ -26,7 +26,7 @@ OBJS=	module_grib2.o \
 	module_grib.o \
 	module_grib_common.o \
 	module_wrfinputfile.o \
-	module_geo_em.o 
+	module_geo_em.o
 
 CMD=	libsmda.a
 
@@ -48,7 +48,7 @@ io_f.o:	io_f.c
 decode_jpeg2000.o:	decode_jpeg2000.c
 	$(CC) -c $(INCJASPER) $(<)
 
-.F.o:
+%.o: %.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(GRIBCODE_OPT) $(BZIP_CPP) -c $(FREESOURCE) $(F90FLAGS) $(NETCDFMOD) $(*).F
 

--- a/src/Land_models/Noah/HRLDAS_COLLECT_DATA/run/Makefile
+++ b/src/Land_models/Noah/HRLDAS_COLLECT_DATA/run/Makefile
@@ -1,5 +1,5 @@
 all:
-	( cd ..; make )
+	( cd ..; $(MAKE) )
 
 clean:
-	( cd ..; make clean )
+	( cd ..; $(MAKE) clean )

--- a/src/Land_models/Noah/IO_code/Makefile
+++ b/src/Land_models/Noah/IO_code/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .F
@@ -24,7 +24,7 @@ module_hrldas_netcdf_io.o: module_hrldas_netcdf_io.F
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS)  -o $(@) -c $(F90FLAGS) $(FREESOURCE) $(MODFLAG)../Utility_routines $(NETCDFMOD)  $(*).F
 	@echo ""
 
-.F.o:
+%.o: %.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(FREESOURCE) $(*).F
 	@echo ""

--- a/src/Land_models/Noah/IO_code/Makefile
+++ b/src/Land_models/Noah/IO_code/Makefile
@@ -16,17 +16,17 @@ all:	$(OBJS)
 Noah_hrldas_driver.o: Noah_hrldas_driver.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(FREESOURCE) $(MODFLAG). \
-	$(MODFLAG)../Noah $(MODFLAG)../Utility_routines -I../../../MPP $(NETCDFMOD) $(*).F
+	$(MODFLAG)../Noah $(MODFLAG)../Utility_routines -I../../../MPP $(NETCDFMOD) $<
 	@echo ""
 
 module_hrldas_netcdf_io.o: module_hrldas_netcdf_io.F
 	@echo ""
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS)  -o $(@) -c $(F90FLAGS) $(FREESOURCE) $(MODFLAG)../Utility_routines $(NETCDFMOD)  $(*).F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS)  -o $(@) -c $(F90FLAGS) $(FREESOURCE) $(MODFLAG)../Utility_routines $(NETCDFMOD)  $<
 	@echo ""
 
 %.o: %.F
 	@echo ""
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(FREESOURCE) $(*).F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(FREESOURCE) $<
 	@echo ""
 
 

--- a/src/Land_models/Noah/Makefile
+++ b/src/Land_models/Noah/Makefile
@@ -1,33 +1,33 @@
 
 all: user_build_options
-	(cd Utility_routines;		make)
-	(cd Noah;			make)
-	(cd IO_code;			make)
-	(cd Run;			make -f Makefile)
-#	(cd HRLDAS_COLLECT_DATA;	make)
+	(cd Utility_routines;		$(MAKE))
+	(cd Noah;			$(MAKE))
+	(cd IO_code;			$(MAKE))
+	(cd Run;			$(MAKE) -f Makefile)
+#	(cd HRLDAS_COLLECT_DATA;	$(MAKE))
 
 clean:
-	(cd Utility_routines;		make clean)
-	(cd Noah;			make clean)
-	(cd IO_code;			make clean)
-	(cd Run;			make -f Makefile clean)
-	(cd HRLDAS_COLLECT_DATA;	make clean)
+	(cd Utility_routines;		$(MAKE) clean)
+	(cd Noah;			$(MAKE) clean)
+	(cd IO_code;			$(MAKE) clean)
+	(cd Run;			$(MAKE) -f Makefile clean)
+	(cd HRLDAS_COLLECT_DATA;	$(MAKE) clean)
 
 test: all
 	(cd TEST; ../HRLDAS_COLLECT_DATA/consolidate_grib.exe )
 	(cd TEST; ../Run/Noah_hrldas_beta )
 
 #all: check user_build_options
-#	(cd Utility_routines;	make)
-#	(cd Noah;		make)
-#	(cd IO_code;		make)
-#	(cd Run;		make)
+#	(cd Utility_routines;	$(MAKE))
+#	(cd Noah;		$(MAKE))
+#	(cd IO_code;		$(MAKE))
+#	(cd Run;		$(MAKE))
 #
 #clean:
-#	(cd Utility_routines;	make clean)
-#	(cd Noah;		make clean)
-#	(cd IO_code;		make clean)
-#	(cd Run;		make clean)
+#	(cd Utility_routines;	$(MAKE) clean)
+#	(cd Noah;		$(MAKE) clean)
+#	(cd IO_code;		$(MAKE) clean)
+#	(cd Run;		$(MAKE) clean)
 #
 #include user_build_options
 #

--- a/src/Land_models/Noah/Noah/Makefile
+++ b/src/Land_models/Noah/Noah/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .F
@@ -13,7 +13,7 @@ CPPHRLDAS = -D_HRLDAS_OFFLINE_
 
 all:	$(OBJS)
 
-.F.o:
+%.o: %.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(MODFLAG). $(MODFLAG)../Utility_routines $(F90FLAGS) $(FREESOURCE) $(*).F
 	@echo ""

--- a/src/Land_models/Noah/Noah/Makefile
+++ b/src/Land_models/Noah/Noah/Makefile
@@ -15,7 +15,7 @@ all:	$(OBJS)
 
 %.o: %.F
 	@echo ""
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(MODFLAG). $(MODFLAG)../Utility_routines $(F90FLAGS) $(FREESOURCE) $(*).F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(MODFLAG). $(MODFLAG)../Utility_routines $(F90FLAGS) $(FREESOURCE) $<
 	@echo ""
 
 #

--- a/src/Land_models/Noah/Utility_programs/Makefile
+++ b/src/Land_models/Noah/Utility_programs/Makefile
@@ -31,7 +31,7 @@ arguments_module.o:
 
 %.o: %.F
 	@echo ""
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(FREESOURCE) $(F90FLAGS) -c $(NETCDFMOD) $(MODFLAG). $(*).F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(FREESOURCE) $(F90FLAGS) -c $(NETCDFMOD) $(MODFLAG). $<
 
 
 hrldas_extract_point: hrldas_extract_point.o

--- a/src/Land_models/Noah/Utility_programs/Makefile
+++ b/src/Land_models/Noah/Utility_programs/Makefile
@@ -13,7 +13,7 @@ include ../user_build_options
 CMD=	hrldas_extract_point gribextract gribedition gribbyte modify_wrfinput geth_newdate
 
 all: $(CMD)
-	( cd gcip_sw_to_grib; make )
+	( cd gcip_sw_to_grib; $(MAKE) )
 
 #
 # Compile the module_date_utilities from the Utility_routines directory
@@ -65,9 +65,9 @@ hrldas_extract_point.o:	lccone.o
 
 clean:
 	$(RM) *.o *~ $(CMD) *.mod
-	( cd gcip_sw_to_grib; make clean )
+	( cd gcip_sw_to_grib; $(MAKE) clean )
 neat:
 	$(RM) *.o *~ *.mod
-	( cd gcip_sw_to_grib; make neat )
+	( cd gcip_sw_to_grib; $(MAKE) neat )
 #
 

--- a/src/Land_models/Noah/Utility_programs/Makefile
+++ b/src/Land_models/Noah/Utility_programs/Makefile
@@ -1,5 +1,5 @@
 SHELL=/bin/sh
-.SUFFIXES:	
+.SUFFIXES:
 .SUFFIXES:	.F .c .o .exe
 
 include ../user_build_options
@@ -29,7 +29,7 @@ arguments_module.o:
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(FREESOURCE) $(F90FLAGS) -c ../HRLDAS_COLLECT_DATA/lib/$(*).F
 
-.F.o:
+%.o: %.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(FREESOURCE) $(F90FLAGS) -c $(NETCDFMOD) $(MODFLAG). $(*).F
 

--- a/src/Land_models/Noah/Utility_programs/gcip_sw_to_grib/Makefile
+++ b/src/Land_models/Noah/Utility_programs/gcip_sw_to_grib/Makefile
@@ -37,7 +37,7 @@ module_date_utilities.o:	../../Utility_routines/module_date_utilities.F
 	$(COMPILERF90) -c $(F90FLAGS) $(FREESOURCE) $(<)
 
 %.o: %.F
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(FREESOURCE) $(F90FLAGS) -c $(*).F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(FREESOURCE) $(F90FLAGS) -c $<
 
 
 neat:

--- a/src/Land_models/Noah/Utility_programs/gcip_sw_to_grib/Makefile
+++ b/src/Land_models/Noah/Utility_programs/gcip_sw_to_grib/Makefile
@@ -36,8 +36,8 @@ swap4f.o:	../../HRLDAS_COLLECT_DATA/lib/swap4f.F
 module_date_utilities.o:	../../Utility_routines/module_date_utilities.F
 	$(COMPILERF90) -c $(F90FLAGS) $(FREESOURCE) $(<)
 
-.F.o:
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(FREESOURCE) $(F90FLAGS) -c $(*).F 
+%.o: %.F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(FREESOURCE) $(F90FLAGS) -c $(*).F
 
 
 neat:

--- a/src/Land_models/Noah/Utility_routines/Makefile
+++ b/src/Land_models/Noah/Utility_routines/Makefile
@@ -19,7 +19,7 @@ all:	$(OBJS)
 
 %.o: %.F
 	@echo ""
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS)  -o $(@) -c $(F90FLAGS) $(FREESOURCE) $(*).F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS)  -o $(@) -c $(F90FLAGS) $(FREESOURCE) $<
 	@echo ""
 
 #

--- a/src/Land_models/Noah/Utility_routines/Makefile
+++ b/src/Land_models/Noah/Utility_routines/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .F
@@ -17,7 +17,7 @@ CPPHRLDAS = -D_HRLDAS_OFFLINE_
 
 all:	$(OBJS)
 
-.F.o:
+%.o: %.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS)  -o $(@) -c $(F90FLAGS) $(FREESOURCE) $(*).F
 	@echo ""

--- a/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/Makefile
+++ b/src/Land_models/Noah/VERIFICATION/Fluxes_statistics/Makefile
@@ -23,14 +23,14 @@ INCLUDES= -I. -I$(NETCDF)/include
 LIBS=	-L$(NETCDF)/lib -lnetcdf \
 	-L$(NCARG_ROOT)/lib -lncarg -lncarg_gks -lncarg_c \
 	-L/usr/X11R6/lib -lX11 \
-	-L/usr/lib/gcc/i386-redhat-linux/3.4.6 -lg2c 
+	-L/usr/lib/gcc/i386-redhat-linux/3.4.6 -lg2c
 
 all: $(CMD)
 
 $(CMD): $(OBJS)
 	$(F90) $(FFLAGS) -o $(CMD) $(INCLUDES) $(OBJS) $(LIBS)
 
-.F.o:
+%.o: %.F
 	$(F90) $(FFLAGS) $(INCLUDES) -c $(<)
 
 clean:

--- a/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/Makefile
+++ b/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/Makefile
@@ -1,5 +1,5 @@
 SHELL=/bin/sh
-.SUFFIXES:	
+.SUFFIXES:
 .SUFFIXES:	.c .o .F
 OBJS=	rdmet.o \
 	rdsom_mem.o \
@@ -26,7 +26,7 @@ FINCLUDES=	-I. -I$(NETCDF)/include
 LIBS=	-L$(NETCDF)/lib -lnetcdf -L$(BZDIR) -lbz2 \
 	-L$(NCARG_ROOT)/lib -lncarg -lncarg_gks -lncarg_c \
 	-L/usr/X11R6/lib -lX11 \
-	-L/usr/lib/gcc/i386-redhat-linux/3.4.6 -lg2c 
+	-L/usr/lib/gcc/i386-redhat-linux/3.4.6 -lg2c
 
 RM = 	rm -f
 CMD=	okmeso_statistics.exe
@@ -39,7 +39,7 @@ all:	$(CMD)
 $(CMD):	$(OBJS)
 	$(FC) -o $(CMD) $(OBJS) $(LIBS)
 
-.F.o:
+%.o: %.F
 	$(FC) -c $(FINCLUDES) $(FFLAGS) $(<)
 
 .c.o:

--- a/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/Makefile
+++ b/src/Land_models/Noah/VERIFICATION/OKMeso_statistics/Makefile
@@ -32,7 +32,7 @@ RM = 	rm -f
 CMD=	okmeso_statistics.exe
 
 # Lines from here on down should not need to be changed.  They are the
-# actual rules which make uses to build $(CMD).
+# actual rules which $(MAKE) uses to build $(CMD).
 #
 all:	$(CMD)
 

--- a/src/Land_models/NoahMP/HRLDAS_forcing/Makefile
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/Makefile
@@ -9,27 +9,27 @@ OBJS=	create_forcing.o
 CMD=	create_forcing.exe
 
 default:
-	(cd lib; make)
-	(make -f Makefile all)
+	(cd lib; $(MAKE))
+	($(MAKE) -f Makefile all)
 
 all:	lib/libsmda.a $(CMD)
-	(cd lib; make)
+	(cd lib; $(MAKE))
 
 lib/libsmda.a:
-	(cd lib; make)
+	(cd lib; $(MAKE))
 
 %.o: %.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPP_NETCDF4_COMPRESS) $(FREESOURCE) $(F90FLAGS) $(LDFLAGS) -c $(NETCDFMOD) -I./lib -I./lib $(*).F
 
 $(CMD):	lib/libsmda.a $(OBJS)
-	(cd lib; make)
+	(cd lib; $(MAKE))
 	$(COMPILERF90) -o $(@) -I./lib $(F90FLAGS) $(LDFLAGS) -I./lib $(OBJS) \
 		-L./lib -lsmda $(NETCDFLIB) $(BZIP2_LIB) $(LIBJASPER)
 
 clean:
 	$(RM) *.o *~ *.exe *.mod
-	(cd lib; make clean)
+	(cd lib; $(MAKE) clean)
 #
 
 

--- a/src/Land_models/NoahMP/HRLDAS_forcing/Makefile
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/Makefile
@@ -20,7 +20,7 @@ lib/libsmda.a:
 
 %.o: %.F
 	@echo ""
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPP_NETCDF4_COMPRESS) $(FREESOURCE) $(F90FLAGS) $(LDFLAGS) -c $(NETCDFMOD) -I./lib -I./lib $(*).F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPP_NETCDF4_COMPRESS) $(FREESOURCE) $(F90FLAGS) $(LDFLAGS) -c $(NETCDFMOD) -I./lib -I./lib $<
 
 $(CMD):	lib/libsmda.a $(OBJS)
 	(cd lib; $(MAKE))

--- a/src/Land_models/NoahMP/HRLDAS_forcing/Makefile
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/Makefile
@@ -1,5 +1,5 @@
  SHELL=/bin/sh
-.SUFFIXES:	
+.SUFFIXES:
 .SUFFIXES:	.F .c .o .exe
 
 include ../user_build_options
@@ -18,7 +18,7 @@ all:	lib/libsmda.a $(CMD)
 lib/libsmda.a:
 	(cd lib; make)
 
-.F.o:
+%.o: %.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPP_NETCDF4_COMPRESS) $(FREESOURCE) $(F90FLAGS) $(LDFLAGS) -c $(NETCDFMOD) -I./lib -I./lib $(*).F
 

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/Makefile
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/Makefile
@@ -1,5 +1,5 @@
 SHELL=/bin/sh
-.SUFFIXES:	
+.SUFFIXES:
 .SUFFIXES:	.F .c .o
 
 include ../../user_build_options
@@ -25,7 +25,7 @@ OBJS=	module_grib2.o \
 	module_grib1.o \
 	module_grib.o \
 	module_grib_common.o \
-	module_geo_em.o 
+	module_geo_em.o
 
 CMD=	libsmda.a
 
@@ -47,7 +47,7 @@ io_f.o:	io_f.c
 decode_jpeg2000.o:	decode_jpeg2000.c
 	$(CC) -c $(INCJASPER) $(<)
 
-.F.o:
+%.o: %.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(GRIBCODE_OPT) $(BZIP_CPP) -c $(FREESOURCE) $(F90FLAGS) $(LDFLAGS) $(NETCDFMOD) $(*).F
 

--- a/src/Land_models/NoahMP/HRLDAS_forcing/lib/Makefile
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/lib/Makefile
@@ -49,7 +49,7 @@ decode_jpeg2000.o:	decode_jpeg2000.c
 
 %.o: %.F
 	@echo ""
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(GRIBCODE_OPT) $(BZIP_CPP) -c $(FREESOURCE) $(F90FLAGS) $(LDFLAGS) $(NETCDFMOD) $(*).F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(GRIBCODE_OPT) $(BZIP_CPP) -c $(FREESOURCE) $(F90FLAGS) $(LDFLAGS) $(NETCDFMOD) $<
 
 .c.o:
 	$(CC) -c $(BZIP_CPP) $(<)

--- a/src/Land_models/NoahMP/HRLDAS_forcing/run/Makefile
+++ b/src/Land_models/NoahMP/HRLDAS_forcing/run/Makefile
@@ -1,5 +1,5 @@
 all:
-	( cd ..; make )
+	( cd ..; $(MAKE) )
 
 clean:
-	( cd ..; make clean )
+	( cd ..; $(MAKE) clean )

--- a/src/Land_models/NoahMP/IO_code/Makefile
+++ b/src/Land_models/NoahMP/IO_code/Makefile
@@ -17,34 +17,34 @@ all:	$(OBJS_NoahMP) $(OBJS)
 
 NoahMP : $(OBJS_NoahMP) $(OBJS)
 
-module_NoahMP_hrldas_driver.o: ../../../HYDRO_drv/module_HYDRO_drv.o \
+module_NoahMP_hrldas_driver.o: module_NoahMP_hrldas_driver.F \
+							   ../../../HYDRO_drv/module_HYDRO_drv.o \
 							   ../../../Data_Rec/module_namelist.o \
-							   ../../../Data_Rec/module_RT_data.o \
-							   module_NoahMP_hrldas_driver.F
+							   ../../../Data_Rec/module_RT_data.o
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(FREESOURCE) $(MODFLAG) -I. \
-	-I../phys -I../phys/surfex -I../Utility_routines -I../../../mod $(NETCDFMOD) $(*).F
+	-I../phys -I../phys/surfex -I../Utility_routines -I../../../mod $(NETCDFMOD) $<
 	@echo ""
 
-main_hrldas_driver.o: ../../../OrchestratorLayer/orchestrator.o \
+main_hrldas_driver.o: main_hrldas_driver.F \
+                      ../../../OrchestratorLayer/orchestrator.o \
                       ../data_structures/state.o \
-					  ../phys/surfex/modd_csts.o \
-					  main_hrldas_driver.F
+					  ../phys/surfex/modd_csts.o
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(LDFLAGS) $(FREESOURCE) -I ../MPP -I. \
-	-I../phys -I../phys/surfex -I../Utility_routines -I../../../mod -I../../../MPP -I../data_structures $(NETCDFMOD) $(*).F
+	-I../phys -I../phys/surfex -I../Utility_routines -I../../../mod -I../../../MPP -I../data_structures $(NETCDFMOD) $<
 #	$(COMPILERF90) -o $(@) -c $(F90FLAGS) $(FREESOURCE) -I ../MPP -I. \
 #	-I../phys -I../Utility_routines $(NETCDFMOD) $(*).f90
 	@echo ""
 
 module_hrldas_netcdf_io.o: module_hrldas_netcdf_io.F
 	@echo ""
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(FREESOURCE) -I ../MPP -I ../../../mod -I../Utility_routines $(MODFLAG) $(NETCDFMOD) $(*).F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(FREESOURCE) -I ../MPP -I ../../../mod -I../Utility_routines $(MODFLAG) $(NETCDFMOD) $<
 	@echo ""
 
 %.o: %.F
 	@echo ""
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(FREESOURCE) $(*).F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(FREESOURCE) $<
 	@echo ""
 
 #

--- a/src/Land_models/NoahMP/IO_code/Makefile
+++ b/src/Land_models/NoahMP/IO_code/Makefile
@@ -17,13 +17,19 @@ all:	$(OBJS_NoahMP) $(OBJS)
 
 NoahMP : $(OBJS_NoahMP) $(OBJS)
 
-module_NoahMP_hrldas_driver.o: module_NoahMP_hrldas_driver.F ../../../HYDRO_drv/module_HYDRO_drv.o ../../../Data_Rec/module_namelist.o ../../../Data_Rec/module_RT_data.o
+module_NoahMP_hrldas_driver.o: ../../../HYDRO_drv/module_HYDRO_drv.o \
+							   ../../../Data_Rec/module_namelist.o \
+							   ../../../Data_Rec/module_RT_data.o \
+							   module_NoahMP_hrldas_driver.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(FREESOURCE) $(MODFLAG) -I. \
 	-I../phys -I../phys/surfex -I../Utility_routines -I../../../mod $(NETCDFMOD) $(*).F
 	@echo ""
 
-main_hrldas_driver.o: ../../../OrchestratorLayer/orchestrator.o main_hrldas_driver.F
+main_hrldas_driver.o: ../../../OrchestratorLayer/orchestrator.o \
+                      ../data_structures/state.o \
+					  ../phys/surfex/modd_csts.o \
+					  main_hrldas_driver.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(LDFLAGS) $(FREESOURCE) -I ../MPP -I. \
 	-I../phys -I../phys/surfex -I../Utility_routines -I../../../mod -I../../../MPP -I../data_structures $(NETCDFMOD) $(*).F
@@ -36,7 +42,7 @@ module_hrldas_netcdf_io.o: module_hrldas_netcdf_io.F
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(FREESOURCE) -I ../MPP -I ../../../mod -I../Utility_routines $(MODFLAG) $(NETCDFMOD) $(*).F
 	@echo ""
 
-.F.o:
+%.o: %.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(FREESOURCE) $(*).F
 	@echo ""

--- a/src/Land_models/NoahMP/Makefile
+++ b/src/Land_models/NoahMP/Makefile
@@ -1,22 +1,22 @@
 
 all: user_build_options
-	(cd Utility_routines;		make)
-	(cd phys;			make)
-	(cd data_structures;		make)
-	(cd IO_code;			make)
-	(cd run;			make)
+	(cd Utility_routines;		$(MAKE))
+	(cd phys;			$(MAKE))
+	(cd data_structures;		$(MAKE))
+	(cd IO_code;			$(MAKE))
+	(cd run;			$(MAKE))
 
 clean:
-	(cd Utility_routines;		make clean)
-	(cd phys;			make clean)
-	(cd data_structures;		make clean)
-	(cd IO_code;			make clean)
-	(cd run;			make clean)
+	(cd Utility_routines;		$(MAKE) clean)
+	(cd phys;			$(MAKE) clean)
+	(cd data_structures;		$(MAKE) clean)
+	(cd IO_code;			$(MAKE) clean)
+	(cd run;			$(MAKE) clean)
 
 ### explicitly point to other land model options
 NoahMP: user_build_options
-	(cd Utility_routines;		make)
-	(cd phys;			make)
-	(cd data_structures;		make)
-	(cd IO_code;			make NoahMP MOD_OPT="-DNoahMP")
-	(cd run;			make -f Makefile NoahMP)
+	(cd Utility_routines;		$(MAKE))
+	(cd phys;			$(MAKE))
+	(cd data_structures;		$(MAKE))
+	(cd IO_code;			$(MAKE) NoahMP MOD_OPT="-DNoahMP")
+	(cd run;			$(MAKE) -f Makefile NoahMP)

--- a/src/Land_models/NoahMP/Utility_routines/Makefile
+++ b/src/Land_models/NoahMP/Utility_routines/Makefile
@@ -16,7 +16,7 @@ CPPHRLDAS = -D_HRLDAS_OFFLINE_
 
 all:	$(OBJS)
 
-.F.o:
+%.o: %.F
 	@echo ""
 	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(LDFLAGS) $(MODFLAG) $(FREESOURCE) $(*).F
 	@echo ""

--- a/src/Land_models/NoahMP/Utility_routines/Makefile
+++ b/src/Land_models/NoahMP/Utility_routines/Makefile
@@ -18,7 +18,7 @@ all:	$(OBJS)
 
 %.o: %.F
 	@echo ""
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(LDFLAGS) $(MODFLAG) $(FREESOURCE) $(*).F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c $(F90FLAGS) $(LDFLAGS) $(MODFLAG) $(FREESOURCE) $<
 	@echo ""
 
 #

--- a/src/Land_models/NoahMP/data_structures/Makefile
+++ b/src/Land_models/NoahMP/data_structures/Makefile
@@ -16,7 +16,7 @@ all:	$(OBJS)
 
 #module_RT.o: module_RT.F
 #	@echo ""
-#	$(CPP) $(CPPFLAGS) $(*).F > $(*).f
+#	$(CPP) $(CPPFLAGS) $< > $(*).f
 #	$(COMPILER90) -o $(@) $(F90FLAGS) $(MODFLAG)  $(*).f
 #	$(RMD) $(*).f
 #	@echo ""
@@ -25,7 +25,7 @@ all:	$(OBJS)
 %.o: %.f90
 	@echo "Data structures Makefile:"
 #	$(COMPILER90) -o $(@) $(F90FLAGS) $(MODFLAG) $(*).f
-	$(COMPILER90) $(CPPINVOKE) -o $(@) $(FPPFLAGS) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) -I../../../OrchestratorLayer $(*).f90
+	$(COMPILER90) $(CPPINVOKE) -o $(@) $(FPPFLAGS) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) -I../../../OrchestratorLayer $<
 #	$(RMD) $(*).f
 	@echo ""
 	@cp *.mod ../../../mod

--- a/src/Land_models/NoahMP/data_structures/Makefile
+++ b/src/Land_models/NoahMP/data_structures/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .f90
@@ -12,6 +12,7 @@ OBJS = \
 	geometry.o
 
 all:	$(OBJS)
+	ar -cr ../../../lib/libHYDRO.a $(OBJS)
 
 #module_RT.o: module_RT.F
 #	@echo ""
@@ -19,16 +20,15 @@ all:	$(OBJS)
 #	$(COMPILER90) -o $(@) $(F90FLAGS) $(MODFLAG)  $(*).f
 #	$(RMD) $(*).f
 #	@echo ""
-#	cp *.mod ../mod
+#	@cp *.mod ../mod
 
-.f90.o:
+%.o: %.f90
 	@echo "Data structures Makefile:"
 #	$(COMPILER90) -o $(@) $(F90FLAGS) $(MODFLAG) $(*).f
 	$(COMPILER90) $(CPPINVOKE) -o $(@) $(FPPFLAGS) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) -I../../../OrchestratorLayer $(*).f90
 #	$(RMD) $(*).f
 	@echo ""
-	ar -r ../../../lib/libHYDRO.a $(@)
-	cp *.mod ../../../mod
+	@cp *.mod ../../../mod
 
 #
 # Dependencies:
@@ -37,5 +37,5 @@ all:	$(OBJS)
 
 # orchestrator.o: ig.o
 
-clean:	
+clean:
 	rm -f *.o *.mod *.stb *~ *.f

--- a/src/Land_models/NoahMP/hydro/Makefile.hydro
+++ b/src/Land_models/NoahMP/hydro/Makefile.hydro
@@ -1,22 +1,22 @@
 
 all: user_build_options
-	(cd Utility_routines;		make)
-	(cd phys;			make)
-	(cd data_structures;		make)
-	(cd IO_code;			make)
-	(cd run;			make)
+	(cd Utility_routines;		$(MAKE))
+	(cd phys;			$(MAKE))
+	(cd data_structures;		$(MAKE))
+	(cd IO_code;			$(MAKE))
+	(cd run;			$(MAKE))
 
 clean:
-	(cd Utility_routines;		make clean)
-	(cd phys;			make clean)
-	(cd data_structures;		make clean)
-	(cd IO_code;			make clean)
-	(cd run;			make clean)
+	(cd Utility_routines;		$(MAKE) clean)
+	(cd phys;			$(MAKE) clean)
+	(cd data_structures;		$(MAKE) clean)
+	(cd IO_code;			$(MAKE) clean)
+	(cd run;			$(MAKE) clean)
 
 ### explicitly point to other land model options
 NoahMP: user_build_options
-	(cd Utility_routines;		make)
-	(cd phys;			make)
-	(cd data_structures;		make)
-	(cd IO_code;			make NoahMP MOD_OPT="-DNoahMP")
-	(cd run;			make -f Makefile NoahMP)
+	(cd Utility_routines;		$(MAKE))
+	(cd phys;			$(MAKE))
+	(cd data_structures;		$(MAKE))
+	(cd IO_code;			$(MAKE) NoahMP MOD_OPT="-DNoahMP")
+	(cd run;			$(MAKE) -f Makefile NoahMP)

--- a/src/Land_models/NoahMP/hydro/Makefile_run
+++ b/src/Land_models/NoahMP/hydro/Makefile_run
@@ -14,11 +14,11 @@ PHDF5_INC=-I ${TACC_HDF5_INC}
 RAPID_MACRO = ${TAO_FORTRAN_LIB} ${TAO_LIB} ${PETSC_LIB}
 RAPID_LIB =  -lrapid
 else
-RAPID_MACRO = 
-RAPID_LIB =  
+RAPID_MACRO =
+RAPID_LIB =
 endif
 
-OBJS_NoahMP = ../IO_code/module_NoahMP_hrldas_driver.o 
+OBJS_NoahMP = ../IO_code/module_NoahMP_hrldas_driver.o
 
 OBJS = \
 	../IO_code/main_hrldas_driver.o \
@@ -39,7 +39,7 @@ all:	$(CMD)
 hrldas.exe: $(OBJS)
 	@echo ""
 	echo "${TAO_FORTRAN_LIB} ${TAO_LIB} ${PETSC_LIB} ${PHDF5_INC} -Wl,-rpath,${TACC_HDF5_LIB} -L${TACC_HDF5_LIB} -lhdf5 -lz"
-# We have to include the modules built in ../IO_code 
+# We have to include the modules built in ../IO_code
 	$(COMPILERF90) -o $(@) -I../IO_code -I../phys $(OBJS) $(OBJS_NoahMP) $(HYDRO_LIB) $(RAPID_LIB) $(NETCDFLIB) $(RAPID_MACRO) $(LDFLAGS) $(LIBS)
 
 	@echo ""

--- a/src/Land_models/NoahMP/phys/Makefile
+++ b/src/Land_models/NoahMP/phys/Makefile
@@ -4,8 +4,6 @@ include ../user_build_options
 
 SRCS := $(wildcard *.F)
 OBJS := $(SRCS:%.F=%.o)
-SUR_SRCS := $(wildcard surfex/*.F)
-SUR_OBJS := $(SUR_SRCS:%.F=%.o)
 CPPHRLDAS = -D_HRLDAS_OFFLINE_
 
 # Check whether or not to build Crocus
@@ -13,33 +11,26 @@ ifndef BUILD_CROCUS
 BUILD_CROCUS:=1
 endif
 ifeq ($(BUILD_CROCUS), 1)
-        SUR_OBJS := $(filter-out ../surfex/module_snowcro_intercept.o, $(SUR_OBJS))
+        SUR_OBJS := surfex/module_snowcro.o surfex/ini_csts.o
 else
-        SUR_OBJS := $(filter-out ../surfex/module_snowcro.o, $(SUR_OBJS))
+        SUR_OBJS := surfex/module_snowcro_intercept.o
 endif
 
 all: $(OBJS)
 
 %.o:%.F
 	@echo ""
-	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c -I../Utility_routines -Isurfex $(F90FLAGS) $(LDFLAGS) $(FREESOURCE) $(*).F
+	$(COMPILERF90) $(CPPINVOKE) $(CPPFLAGS) $(CPPHRLDAS) -o $(@) -c -I../Utility_routines -Isurfex $(F90FLAGS) $(LDFLAGS) $(FREESOURCE) $<
 	@echo ""
 
 surfex/%.o:
-	$(MAKE) --directory=surfex/
+	$(MAKE) --directory=surfex/ $(@F)
 
 #
 # Dependencies:
 #
 module_sf_noahmpdrv.o:	module_sf_noahmplsm.o module_sf_noahmp_glacier.o module_sf_noahmp_groundwater.o $(SUR_OBJS)
 module_sf_noahmp_groundwater.o: module_sf_noahmplsm.o
-
-surfex/ini_csts.o: surfex/modd_csts.o
-surfex/mode_thermos.o: surfex/modd_snow_par.o
-surfex/mode_surf_coefs.o: surfex/mode_thermos.o
-surfex/mode_snow3l.o: surfex/modd_snow_par.o
-surfex/module_snowcro.o: surfex/mode_surf_coefs.o surfex/tridiag_ground_snowcro.o
-
 
 #
 # This command cleans up object (etc) files:

--- a/src/Land_models/NoahMP/phys/Makefile
+++ b/src/Land_models/NoahMP/phys/Makefile
@@ -34,6 +34,13 @@ surfex/%.o:
 module_sf_noahmpdrv.o:	module_sf_noahmplsm.o module_sf_noahmp_glacier.o module_sf_noahmp_groundwater.o $(SUR_OBJS)
 module_sf_noahmp_groundwater.o: module_sf_noahmplsm.o
 
+surfex/ini_csts.o: surfex/modd_csts.o
+surfex/mode_thermos.o: surfex/modd_snow_par.o
+surfex/mode_surf_coefs.o: surfex/mode_thermos.o
+surfex/mode_snow3l.o: surfex/modd_snow_par.o
+surfex/module_snowcro.o: surfex/mode_surf_coefs.o surfex/tridiag_ground_snowcro.o
+
+
 #
 # This command cleans up object (etc) files:
 #

--- a/src/Land_models/NoahMP/phys/surfex/Makefile
+++ b/src/Land_models/NoahMP/phys/surfex/Makefile
@@ -18,10 +18,10 @@ all: $(OBJS)
 #
 # Dependencies:
 #
+ini_csts.o: modd_csts.o
 mode_snow3l.o: modd_snow_par.o modd_csts.o modd_snow_metamo.o
 mode_thermos.o: modd_csts.o modd_snow_par.o
 mode_surf_coefs.o: modd_surf_atm.o mode_thermos.o
-ini_csts.o: modd_csts.o
 module_snowcro.o: mode_snow3l.o modd_snow_par.o modd_csts.o modd_snow_metamo.o modd_surf_atm.o \
 	mode_thermos.o mode_surf_coefs.o tridiag_ground_snowcro.o
 module_snowcro_intercept.o:

--- a/src/Land_models/NoahMP/run/Makefile
+++ b/src/Land_models/NoahMP/run/Makefile
@@ -42,6 +42,18 @@ OBJS := \
 	../phys/surfex/modd_surf_atm.o\
 	../phys/surfex/modd_snow_metamo.o
 
+# we don't need to link these specifically (they come from libhydro.a) but we
+# need to wait for them to be done so that libhydro.a is fully-built
+HYDRO_OBJS := \
+	../../../Routing/module_HYDRO_utils.o \
+	../../../Routing/Noah_distr_routing.o \
+	../../../Routing/Noah_distr_routing_overland.o \
+	../../../Routing/Noah_distr_routing_subsurface.o \
+	../../../Routing/module_channel_routing.o \
+	../../../Routing/module_noah_chan_param_init_rt.o \
+	../../../Routing/module_NWM_io.o \
+	../../../Routing/module_UDMAP.o
+
 # Check whether or not to build Crocus
 ifndef BUILD_CROCUS
 BUILD_CROCUS:=1
@@ -56,7 +68,7 @@ CMD = hrldas.exe
 all:	$(CMD)
 
 ### default we create the exe based on NoahMP
-hrldas.exe: $(OBJS)
+hrldas.exe: $(OBJS) $(HYDRO_OBJS)
 	@echo ""
 	echo "${TAO_FORTRAN_LIB} ${TAO_LIB} ${PETSC_LIB} ${PHDF5_INC} -Wl,-rpath,${TACC_HDF5_LIB} -L${TACC_HDF5_LIB} -lhdf5 -lz"
 # We have to include the modules built in ../IO_code

--- a/src/MPP/Makefile
+++ b/src/MPP/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .F
@@ -14,33 +14,33 @@ hashtable.o: hashtable.F
 	$(RMD) $(*).o $(*).mod $(*).stb *~
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $(*).F
 	cp hashtable.mod ../mod
-	ar -r ../lib/libHYDRO.a $(@)
-
-mpp_land.o: mpp_land.F
-	@echo ""
-	$(RMD) $(*).o $(*).mod $(*).stb *~
-	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $(*).F
-	ar -r ../lib/libHYDRO.a $(@)
+	ar -cr ../lib/libHYDRO.a $(@)
 
 CPL_WRF.o: CPL_WRF.F
 	@echo ""
 	$(RMD) $(*).o $(*).mod $(*).stb *~
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) $(*).F
-        
-	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $(*).F
-	ar -r ../lib/libHYDRO.a $(@)
 
-module_mpp_ReachLS.o: module_mpp_ReachLS.F
+	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $(*).F
+	ar -cr ../lib/libHYDRO.a $(@)
+
+mpp_land.o: mpp_land.F CPL_WRF.o
 	@echo ""
 	$(RMD) $(*).o $(*).mod $(*).stb *~
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $(*).F
-	ar -r ../lib/libHYDRO.a $(@)
+	ar -cr ../lib/libHYDRO.a $(@)
 
-module_mpp_GWBUCKET.o: module_mpp_GWBUCKET.F
+module_mpp_ReachLS.o: module_mpp_ReachLS.F mpp_land.o
 	@echo ""
 	$(RMD) $(*).o $(*).mod $(*).stb *~
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $(*).F
-	ar -r ../lib/libHYDRO.a $(@)
+	ar -cr ../lib/libHYDRO.a $(@)
+
+module_mpp_GWBUCKET.o: module_mpp_GWBUCKET.F mpp_land.o CPL_WRF.o
+	@echo ""
+	$(RMD) $(*).o $(*).mod $(*).stb *~
+	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $(*).F
+	ar -cr ../lib/libHYDRO.a $(@)
 
 clean:
 	$(RMD) *.o *.mod *.stb *~

--- a/src/MPP/Makefile
+++ b/src/MPP/Makefile
@@ -12,34 +12,34 @@ all:	$(OBJS)
 hashtable.o: hashtable.F
 	@echo ""
 	$(RMD) $(*).o $(*).mod $(*).stb *~
-	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $(*).F
+	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $<
 	cp hashtable.mod ../mod
 	ar -cr ../lib/libHYDRO.a $(@)
 
 CPL_WRF.o: CPL_WRF.F
 	@echo ""
 	$(RMD) $(*).o $(*).mod $(*).stb *~
-	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) $(*).F
+	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -I$(NETCDFINC) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) $<
 
-	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $(*).F
+	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $<
 	ar -cr ../lib/libHYDRO.a $(@)
 
 mpp_land.o: mpp_land.F CPL_WRF.o
 	@echo ""
 	$(RMD) $(*).o $(*).mod $(*).stb *~
-	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $(*).F
+	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $<
 	ar -cr ../lib/libHYDRO.a $(@)
 
 module_mpp_ReachLS.o: module_mpp_ReachLS.F mpp_land.o
 	@echo ""
 	$(RMD) $(*).o $(*).mod $(*).stb *~
-	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $(*).F
+	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $<
 	ar -cr ../lib/libHYDRO.a $(@)
 
 module_mpp_GWBUCKET.o: module_mpp_GWBUCKET.F mpp_land.o CPL_WRF.o
 	@echo ""
 	$(RMD) $(*).o $(*).mod $(*).stb *~
-	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $(*).F
+	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) -c $<
 	ar -cr ../lib/libHYDRO.a $(@)
 
 clean:

--- a/src/MPP/Makefile.NoahMP
+++ b/src/MPP/Makefile.NoahMP
@@ -1,21 +1,21 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .F
 
 include ../user_build_options
 
-OBJS =  CPL_WRF.o mpp_land.o 
+OBJS =  CPL_WRF.o mpp_land.o
 
 all:	$(OBJS)
 mpp_land.o: mpp_land.F
 	@echo ""
-	rm -f $(*).o $(*).mod 
-	$(COMPILERF90) $(F90FLAGS) $(FREESOURCE) -c $(*).F
+	rm -f $(*).o $(*).mod
+	$(COMPILERF90) $(F90FLAGS) $(FREESOURCE) -c $<
 
 CPL_WRF.o: CPL_WRF.F
 	@echo ""
-	rm -f $(*).o $(*).mod 
-	$(COMPILERF90) $(F90FLAGS) $(FREESOURCE) -c $(*).F
+	rm -f $(*).o $(*).mod
+	$(COMPILERF90) $(F90FLAGS) $(FREESOURCE) -c $<
 clean:
-	rm -f  *.o *.mod 
+	rm -f  *.o *.mod

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ $(CMD):
 		(mkdir Run);\
 	fi
 	(rm -f Run/wrf_hydro.exe   )
-	(make -f Makefile.comm BASIC)
+	(make -f Makefile.comm)
 	@if [ -d "LandModel_cpl" ]; then \
 	(cd LandModel_cpl; make) \
 	fi
@@ -31,7 +31,7 @@ debug::
 debug:: $(CMD)
 
 install:
-	-rm -f ./Run/wrf_hydro.exe; \
+	rm -f ./Run/wrf_hydro.exe; \
 	mv LandModel/run/hrldas.exe  ./Run/wrf_hydro.exe
 test:
 	@echo "No libraries or utilities are built, skip testing."

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,19 +10,19 @@ $(CMD):
 		(mkdir Run);\
 	fi
 	(rm -f Run/wrf_hydro.exe   )
-	(make -f Makefile.comm)
+	($(MAKE) -f Makefile.comm)
 	@if [ -d "LandModel_cpl" ]; then \
-	(cd LandModel_cpl; make) \
+	(cd LandModel_cpl; $(MAKE)) \
 	fi
 	if [ $(WRF_HYDRO_RAPID) -eq 1 ]; then \
 		(cd lib;rm -f librapid.a); \
 	fi
 	if [ $(WRF_HYDRO_RAPID) -eq 1 ]; then \
-		(cd Rapid_routing; make -f makefile.cpl rapid); \
+		(cd Rapid_routing; $(MAKE) -f makefile.cpl rapid); \
 	fi
 
 	@if [ -d "LandModel" ]; then \
-	(cd LandModel; make ) \
+	(cd LandModel; $(MAKE) ) \
 	fi
 
 debug::
@@ -37,13 +37,13 @@ test:
 	@echo "No libraries or utilities are built, skip testing."
 clean:
 	@if [ -d "LandModel_cpl" ]; then \
-	(cd LandModel_cpl; make clean) \
+	(cd LandModel_cpl; $(MAKE) clean) \
 	fi
-	(make -f Makefile.comm clean)
+	($(MAKE) -f Makefile.comm clean)
 	@if [ -d "LandModel" ]; then \
-	(cd LandModel; make clean) \
+	(cd LandModel; $(MAKE) clean) \
 	fi
 	if [ $(WRF_HYDRO_RAPID) -eq 1 ]; then \
-		(cd Rapid_routing; make -f makefile.cpl clean); \
+		(cd Rapid_routing; $(MAKE) -f makefile.cpl clean); \
 	fi
 	(rm -f */*.mod */*.o lib/*.a Run/wrf_hydro.exe)

--- a/src/OrchestratorLayer/Makefile
+++ b/src/OrchestratorLayer/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .f90
@@ -11,6 +11,7 @@ OBJS = \
 	io_manager.o
 
 all:	$(OBJS)
+	ar -cr ../lib/libHYDRO.a $(OBJS)
 
 #module_RT.o: module_RT.F
 #	@echo ""
@@ -18,16 +19,15 @@ all:	$(OBJS)
 #	$(COMPILER90) -o $(@) $(F90FLAGS) $(MODFLAG)  $(*).f
 #	$(RMD) $(*).f
 #	@echo ""
-#	cp *.mod ../mod
+#	@cp *.mod ../mod
 
-.f90.o:
+%.o: %.f90
 	@echo "Orchestrator Makefile:"
 #	$(COMPILER90) -o $(@) $(F90FLAGS) $(MODFLAG) $(*).f
 	$(COMPILER90) $(CPPINVOKE) -o $(@) $(CPPFLAGS) $(FPPFLAGS) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) $(*).f90
 #	$(RMD) $(*).f
 	@echo ""
-	ar -r ../lib/libHYDRO.a $(@)
-	cp *.mod ../mod
+	@cp *.mod ../mod
 
 #
 # Dependencies:
@@ -36,5 +36,5 @@ io_manager.o: ../IO/netcdf_layer.o
 
 orchestrator.o: io_manager.o config.o
 
-clean:	
+clean:
 	rm -f *.o *.mod *.stb *~ *.f

--- a/src/OrchestratorLayer/Makefile
+++ b/src/OrchestratorLayer/Makefile
@@ -15,7 +15,7 @@ all:	$(OBJS)
 
 #module_RT.o: module_RT.F
 #	@echo ""
-#	$(CPP) $(CPPFLAGS) $(*).F > $(*).f
+#	$(CPP) $(CPPFLAGS) $< > $(*).f
 #	$(COMPILER90) -o $(@) $(F90FLAGS) $(MODFLAG)  $(*).f
 #	$(RMD) $(*).f
 #	@echo ""
@@ -24,7 +24,7 @@ all:	$(OBJS)
 %.o: %.f90
 	@echo "Orchestrator Makefile:"
 #	$(COMPILER90) -o $(@) $(F90FLAGS) $(MODFLAG) $(*).f
-	$(COMPILER90) $(CPPINVOKE) -o $(@) $(CPPFLAGS) $(FPPFLAGS) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) $(*).f90
+	$(COMPILER90) $(CPPINVOKE) -o $(@) $(CPPFLAGS) $(FPPFLAGS) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) $<
 #	$(RMD) $(*).f
 	@echo ""
 	@cp *.mod ../mod

--- a/src/Routing/Makefile
+++ b/src/Routing/Makefile
@@ -17,29 +17,28 @@ OBJS = \
 	Noah_distr_routing.o \
 	Noah_distr_routing_overland.o \
 	Noah_distr_routing_subsurface.o \
+    module_reservoir_routing.o \
 	module_channel_routing.o \
 	module_lsm_forcing.o \
 	module_date_utilities_rt.o \
 	module_NWM_io_dict.o \
-	module_NWM_io.o \
-        module_reservoir_routing.o
+	module_NWM_io.o
+
+ifeq ($(WRF_HYDRO_NUDGING),-DWRF_HYDRO_NUDGING)
+    OBJS += ../nudging/module_date_utils_nudging.o \
+            ../nudging/module_nudging_io.o \
+            ../nudging/module_nudging_utils.o \
+            ../nudging/module_stream_nudging.o
+endif
 
 all:	$(OBJS)
+	ar -cr ../lib/libHYDRO.a $(OBJS)
 
-#module_RT.o: module_RT.F
-#	@echo ""
-#	$(CPP) $(CPPFLAGS) $(*).F > $(*).f
-#	$(COMPILER90) -o $(@) $(F90FLAGS) $(MODFLAG)  $(*).f
-#	$(RMD) $(*).f
-#	@echo ""
-#	cp *.mod ../mod
-
-.F.o:
-	@echo "Routing Makefile:"
+%.o: %.F
+	@echo ""
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) $(*).F
 	@echo ""
-	ar -r ../lib/libHYDRO.a $(@)
-	cp *.mod ../mod
+	@cp *.mod ../mod
 
 #
 # Dependencies:
@@ -47,56 +46,61 @@ all:	$(OBJS)
 module_gw_gw2d.o: ../Data_Rec/module_gw_gw2d_data.o module_HYDRO_io.o
 
 ifneq ($(WRF_HYDRO_NUDGING),-DWRF_HYDRO_NUDGING)
-module_HYDRO_io.o:  module_HYDRO_utils.o \
-	            module_date_utilities_rt.o \
-                    ../Data_Rec/module_namelist.o \
-	 	    ../Data_Rec/module_RT_data.o
+module_HYDRO_io.o: module_HYDRO_utils.o \
+                   module_date_utilities_rt.o \
+                   ../Data_Rec/module_namelist.o \
+                   ../Data_Rec/module_RT_data.o
 else
-module_HYDRO_io.o:  module_HYDRO_utils.o \
-	            module_date_utilities_rt.o \
-		    ../nudging/module_date_utils_nudging.o \
-	            ../nudging/module_nudging_io.o \
-                    ../Data_Rec/module_namelist.o \
-	 	    ../Data_Rec/module_RT_data.o
+module_HYDRO_io.o: module_HYDRO_utils.o \
+                   module_date_utilities_rt.o \
+                   ../nudging/module_date_utils_nudging.o \
+                   ../nudging/module_nudging_io.o \
+                   ../Data_Rec/module_namelist.o \
+                   ../Data_Rec/module_RT_data.o
 endif
 
-module_NWM_io_dict: ../Data_Rec/module_namelist.o ../utils/module_version.o
+Noah_distr_routing_overland.o: Noah_distr_routing.o
 
-module_NWM_io: module_HYDRO_utils.o \
-               module_NWM_io_dict.o \
-               module_HYDRO_io.o \
-               module_date_utilities_rt.o \
-	       ../OrchestratorLayer/orchestrator.o \
-               ../Data_Rec/module_namelist.o \
-               ../Data_Rec/module_RT_data.o \
-	       ../utils/module_version.o
+module_reservoir_routing.o: ../Data_Rec/module_namelist.o module_HYDRO_io.o
 
-module_reservoir_routing: ../Data_Rec/module_namelist.o
+module_NWM_io_dict.o: ../Data_Rec/module_namelist.o ../utils/module_version.o
+
+module_NWM_io.o: module_HYDRO_io.o \
+                 module_HYDRO_utils.o \
+                 module_NWM_io_dict.o \
+                 module_date_utilities_rt.o \
+	             ../OrchestratorLayer/orchestrator.o \
+                 ../Data_Rec/module_namelist.o \
+                 ../Data_Rec/module_RT_data.o \
+     	         ../utils/module_version.o
 
 module_HYDRO_utils.o: ../Data_Rec/module_namelist.o ../Data_Rec/module_RT_data.o
 
 module_lsm_forcing.o: module_HYDRO_io.o
 
+module_GW_baseflow.o: module_UDMAP.o
+
 ifneq ($(WRF_HYDRO_NUDGING),-DWRF_HYDRO_NUDGING)
 module_RT.o: module_GW_baseflow.o \
-	     module_HYDRO_utils.o \
-             module_HYDRO_io.o \
-             module_noah_chan_param_init_rt.o \
-	     module_UDMAP.o \
-	     ../Data_Rec/module_namelist.o \
-	     ../Data_Rec/module_RT_data.o \
-	     ../Data_Rec/module_gw_gw2d_data.o
+	    module_HYDRO_utils.o \
+        module_HYDRO_io.o \
+        module_noah_chan_param_init_rt.o \
+	    module_UDMAP.o \
+	    ../Data_Rec/module_namelist.o \
+	    ../Data_Rec/module_RT_data.o \
+	    ../Data_Rec/module_gw_gw2d_data.o
 else
 module_RT.o: module_GW_baseflow.o \
-	     module_HYDRO_utils.o \
+	         module_HYDRO_utils.o \
              module_HYDRO_io.o \
              module_noah_chan_param_init_rt.o \
-	     module_UDMAP.o \
-	     ../Data_Rec/module_namelist.o \
-	     ../Data_Rec/module_RT_data.o \
-	     ../Data_Rec/module_gw_gw2d_data.o \
+	         module_UDMAP.o \
+	         ../Data_Rec/module_namelist.o \
+	         ../Data_Rec/module_RT_data.o \
+	         ../Data_Rec/module_gw_gw2d_data.o \
              ../nudging/module_date_utils_nudging.o \
              ../nudging/module_nudging_io.o
+../nudging/module_stream_nudging.o: ../nudging/module_nudging_io.o
 endif
 
 module_UDMAP.o: ../Data_Rec/module_namelist.o ../Data_Rec/module_RT_data.o
@@ -104,10 +108,10 @@ module_UDMAP.o: ../Data_Rec/module_namelist.o ../Data_Rec/module_RT_data.o
 ifneq ($(WRF_HYDRO_NUDGING),-DWRF_HYDRO_NUDGING)
 module_channel_routing.o: module_UDMAP.o
 else
-module_channel_routing.o: module_UDMAP.o\
-			  ../nudging/module_date_utils_nudging.o \
-		          ../nudging/module_nudging_utils.o \
-			  ../nudging/module_stream_nudging.o
+module_channel_routing.o: module_UDMAP.o \
+                          ../nudging/module_date_utils_nudging.o \
+                          ../nudging/module_nudging_utils.o \
+                          ../nudging/module_stream_nudging.o
 endif
 
 clean:

--- a/src/Routing/Makefile
+++ b/src/Routing/Makefile
@@ -36,7 +36,7 @@ all:	$(OBJS)
 
 %.o: %.F
 	@echo ""
-	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) $(*).F
+	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) $<
 	@echo ""
 	@cp *.mod ../mod
 

--- a/src/Routing/Overland/Makefile
+++ b/src/Routing/Overland/Makefile
@@ -17,19 +17,19 @@ FLFLAGS=
 all: mod
 
 mod:
-	#Build each sub module then build the module that depends on all sub modules	
+	#Build each sub module then build the module that depends on all sub modules
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) $(F90FLAGS) $(LDFLAGS) $(MODFLAGS) -I$(NETCDFINC) module_overland_control.F
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) $(F90FLAGS) $(LDFLAGS) $(MODFLAGS) -I$(NETCDFINC) module_overland_streams_and_lakes.F
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) $(F90FLAGS) $(LDFLAGS) $(MODFLAGS) -I$(NETCDFINC) module_overland_routing_properties.F
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) $(F90FLAGS) $(LDFLAGS) $(MODFLAGS) -I$(NETCDFINC) module_overland_mass_balance.F
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) $(F90FLAGS) $(LDFLAGS) $(MODFLAGS) -I$(NETCDFINC) module_overland.F
-	ar -r ../../lib/libHYDRO.a module_overland_control.o
-	ar -r ../../lib/libHYDRO.a module_overland_streams_and_lakes.o
-	ar -r ../../lib/libHYDRO.a module_overland_routing_properties.o
-	ar -r ../../lib/libHYDRO.a module_overland_mass_balance.o
-	ar -r ../../lib/libHYDRO.a module_overland.o
+	ar -cr ../../lib/libHYDRO.a module_overland_control.o \
+                                module_overland_streams_and_lakes.o \
+                                module_overland_routing_properties.o \
+                                module_overland_mass_balance.o \
+                                module_overland.o
 
-	cp *.mod ../../mod
+	@cp *.mod ../../mod
 test:
 	$(COMPILER90) $(FFLAGS) overland_tests.F
 	$(COMPILER90) -o overland_tests \
@@ -40,6 +40,6 @@ test:
 		module_overland.o \
 		overland_tests.o
 clean:
-	rm -f *.o 
+	rm -f *.o
 	rm -f *.mod
 	rm -f overland_tests

--- a/src/Routing/Reservoirs/Level_Pool/Makefile
+++ b/src/Routing/Reservoirs/Level_Pool/Makefile
@@ -16,12 +16,12 @@ mod:
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_levelpool_state.F
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_levelpool.F
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_levelpool_tests.F
-	ar -r ../../../lib/libHYDRO.a module_levelpool_properties.o
-	ar -r ../../../lib/libHYDRO.a module_levelpool_state.o
-	ar -r ../../../lib/libHYDRO.a module_levelpool.o
-	ar -r ../../../lib/libHYDRO.a module_levelpool_tests.o
+	ar -cr ../../../lib/libHYDRO.a module_levelpool_properties.o \
+	                               module_levelpool_state.o \
+	                               module_levelpool.o \
+	                               module_levelpool_tests.o
 
-	cp *.mod ../../../mod
+	@cp *.mod ../../../mod
 
 clean:
 	rm -f *.o

--- a/src/Routing/Reservoirs/Makefile
+++ b/src/Routing/Reservoirs/Makefile
@@ -11,10 +11,10 @@ MODFLAG := $(MODFLAG) -I ../../mod
 all: mod
 
 ../../MPP/mpp_land.mod:
-		make -C ../../MPP
+		$(MAKE) -C ../../MPP
 
 ../../utils/module_hydro_stop.mod:
-		make -C ../../utils
+		$(MAKE) -C ../../utils
 
 mod: ../../MPP/module_mpp_land.mod ../../utils/module_hydro_stop.mod
 	#Build each sub module then build the module that depends on all sub modules
@@ -31,9 +31,9 @@ mod: ../../MPP/module_mpp_land.mod ../../utils/module_hydro_stop.mod
 	@cp *.mod ../../mod
 
 	#Build the modules
-	make -C Level_Pool
-	make -C Persistence_Level_Pool_Hybrid
-	make -C RFC_Forecasts
+	$(MAKE) -C Level_Pool
+	$(MAKE) -C Persistence_Level_Pool_Hybrid
+	$(MAKE) -C RFC_Forecasts
 
 
 test: ../../MPP/module_mpp_land.mod ../../utils/module_hydro_stop.mod
@@ -43,9 +43,9 @@ test: ../../MPP/module_mpp_land.mod ../../utils/module_hydro_stop.mod
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_reservoir_read_rfc_time_series_data.F
 
 
-	make -C Level_Pool
-	make -C Persistence_Level_Pool_Hybrid
-	make -C RFC_Forecasts
+	$(MAKE) -C Level_Pool
+	$(MAKE) -C Persistence_Level_Pool_Hybrid
+	$(MAKE) -C RFC_Forecasts
 
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) reservoir_tests.F
 
@@ -78,6 +78,6 @@ clean:
 	rm -f *.mod
 	rm -f reservoir_tests
 
-	make -C Level_Pool clean
-	make -C Persistence_Level_Pool_Hybrid clean
-	make -C RFC_Forecasts clean
+	$(MAKE) -C Level_Pool clean
+	$(MAKE) -C Persistence_Level_Pool_Hybrid clean
+	$(MAKE) -C RFC_Forecasts clean

--- a/src/Routing/Reservoirs/Makefile
+++ b/src/Routing/Reservoirs/Makefile
@@ -23,12 +23,12 @@ mod: ../../MPP/module_mpp_land.mod ../../utils/module_hydro_stop.mod
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_reservoir_read_timeslice_data.F
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_reservoir_read_rfc_time_series_data.F
 
-	ar -r ../../lib/libHYDRO.a module_reservoir_utilities.o
-	ar -r ../../lib/libHYDRO.a module_reservoir.o
-	ar -r ../../lib/libHYDRO.a module_reservoir_read_timeslice_data.o
-	ar -r ../../lib/libHYDRO.a module_reservoir_read_rfc_time_series_data.o
+	ar -cr ../../lib/libHYDRO.a module_reservoir_utilities.o \
+	                            module_reservoir.o \
+	                            module_reservoir_read_timeslice_data.o \
+	                            module_reservoir_read_rfc_time_series_data.o
 
-	cp *.mod ../../mod
+	@cp *.mod ../../mod
 
 	#Build the modules
 	make -C Level_Pool

--- a/src/Routing/Reservoirs/Persistence_Level_Pool_Hybrid/Makefile
+++ b/src/Routing/Reservoirs/Persistence_Level_Pool_Hybrid/Makefile
@@ -16,12 +16,12 @@ mod:
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_persistence_levelpool_hybrid_state.F
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_persistence_levelpool_hybrid.F
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_persistence_levelpool_hybrid_tests.F
-	ar -r ../../../lib/libHYDRO.a module_persistence_levelpool_hybrid_properties.o
-	ar -r ../../../lib/libHYDRO.a module_persistence_levelpool_hybrid_state.o
-	ar -r ../../../lib/libHYDRO.a module_persistence_levelpool_hybrid.o
-	ar -r ../../../lib/libHYDRO.a module_persistence_levelpool_hybrid_tests.o
+	ar -cr ../../../lib/libHYDRO.a module_persistence_levelpool_hybrid_properties.o \
+	                               module_persistence_levelpool_hybrid_state.o \
+	                               module_persistence_levelpool_hybrid.o \
+	                               module_persistence_levelpool_hybrid_tests.o
 
-	cp *.mod ../../../mod
+	@cp *.mod ../../../mod
 
 clean:
 	rm -f *.o

--- a/src/Routing/Reservoirs/RFC_Forecasts/Makefile
+++ b/src/Routing/Reservoirs/RFC_Forecasts/Makefile
@@ -16,12 +16,12 @@ mod:
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_rfc_forecasts_state.F
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_rfc_forecasts.F
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_rfc_forecasts_tests.F
-	ar -r ../../../lib/libHYDRO.a module_rfc_forecasts_properties.o
-	ar -r ../../../lib/libHYDRO.a module_rfc_forecasts_state.o
-	ar -r ../../../lib/libHYDRO.a module_rfc_forecasts.o
-	ar -r ../../../lib/libHYDRO.a module_rfc_forecasts_tests.o
+	ar -cr ../../../lib/libHYDRO.a module_rfc_forecasts_properties.o \
+	                               module_rfc_forecasts_state.o \
+	                               module_rfc_forecasts.o \
+	                               module_rfc_forecasts_tests.o
 
-	cp *.mod ../../../mod
+	@cp *.mod ../../../mod
 
 clean:
 	rm -f *.o

--- a/src/Routing/Subsurface/Makefile
+++ b/src/Routing/Subsurface/Makefile
@@ -27,15 +27,15 @@ mod:
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_subsurface_static_data.F
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_subsurface_output.F
 	$(COMPILER90) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) module_subsurface_input.F
-	ar -r ../../lib/libHYDRO.a module_subsurface_grid_transform.o
-	ar -r ../../lib/libHYDRO.a module_subsurface_properties.o
-	ar -r ../../lib/libHYDRO.a module_subsurface_state.o
-	ar -r ../../lib/libHYDRO.a module_subsurface.o
-	ar -r ../../lib/libHYDRO.a module_subsurface_static_data.o
-	ar -r ../../lib/libHYDRO.a module_subsurface_output.o
-	ar -r ../../lib/libHYDRO.a module_subsurface_input.o
+	ar -cr ../../lib/libHYDRO.a module_subsurface_grid_transform.o \
+	                            module_subsurface_properties.o \
+	                            module_subsurface_state.o \
+	                            module_subsurface.o \
+	                            module_subsurface_static_data.o \
+	                            module_subsurface_output.o \
+	                            module_subsurface_input.o
 
-	cp *.mod ../../mod
+	@cp *.mod ../../mod
 test:
 	$(COMPILER90) $(F90FLAGS) $(MODFLAG) subsurface_tests.F
 	$(COMPILER90) -o subsurface_tests \

--- a/src/arc/Makefile.Noah
+++ b/src/arc/Makefile.Noah
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 CMD = Run/wrf_hydro.exe
 
 all: $(CMD)
@@ -8,23 +8,23 @@ $(CMD):
 		(mkdir Run);\
 	fi
 	(rm -f Run/wrf_hydro.exe   )
-	(make -f Makefile.comm BASIC)
+	($(MAKE) -f Makefile.comm BASIC)
 	@if [ -d "LandModel_cpl" ]; then \
-	(cd LandModel_cpl; make) \
+	(cd LandModel_cpl; $(MAKE)) \
 	fi
 	if [ $(WRF_HYDRO_RAPID) -eq 1 ]; then \
 		(cd lib;rm -f librapid.a); \
 	fi
 	if [ $(WRF_HYDRO_RAPID) -eq 1 ]; then \
-		(cd Rapid_routing; make -f makefile.cpl rapid); \
+		(cd Rapid_routing; $(MAKE) -f makefile.cpl rapid); \
 	fi
 
 	@if [ -d "LandModel" ]; then \
-	(cd LandModel; make ) \
+	(cd LandModel; $(MAKE) ) \
 	fi
 
-debug:: 
-	@echo 'F90FLAGS := $$(DEBUGFLAGS) $$(F90FLAGS)' >> ./macros 
+debug::
+	@echo 'F90FLAGS := $$(DEBUGFLAGS) $$(F90FLAGS)' >> ./macros
 	@echo 'F90FLAGS := $$(DEBUGFLAGS) $$(F90FLAGS)' >> ./LandModel/user_build_options
 debug:: $(CMD)
 
@@ -32,16 +32,16 @@ install:
 	-rm -f ./Run/wrf_hydro.exe; \
 	mv ./Run/Noah_hrldas_beta ./Run/wrf_hydro.exe
 test:
-	@echo "No libraries or utilities are built, skip testing." 
+	@echo "No libraries or utilities are built, skip testing."
 clean:
 	@if [ -d "LandModel_cpl" ]; then \
-	(cd LandModel_cpl; make clean) \
+	(cd LandModel_cpl; $(MAKE) clean) \
 	fi
-	(make -f Makefile.comm clean)
+	($(MAKE) -f Makefile.comm clean)
 	@if [ -d "LandModel" ]; then \
-	(cd LandModel; make clean) \
+	(cd LandModel; $(MAKE) clean) \
 	fi
 	if [ $(WRF_HYDRO_RAPID) -eq 1 ]; then \
-		(cd Rapid_routing; make -f makefile.cpl clean); \
+		(cd Rapid_routing; $(MAKE) -f makefile.cpl clean); \
 	fi
 	(rm -f */*.mod */*.o lib/*.a Run/wrf_hydro.exe)

--- a/src/arc/Makefile.NoahMP
+++ b/src/arc/Makefile.NoahMP
@@ -10,7 +10,7 @@ $(CMD):
 		(mkdir Run);\
 	fi
 	(rm -f Run/wrf_hydro.exe   )
-	(make -f Makefile.comm BASIC)
+	(make -f Makefile.comm)
 	@if [ -d "LandModel_cpl" ]; then \
 	(cd LandModel_cpl; make) \
 	fi
@@ -31,7 +31,7 @@ debug::
 debug:: $(CMD)
 
 install:
-	-rm -f ./Run/wrf_hydro.exe; \
+	rm -f ./Run/wrf_hydro.exe; \
 	mv LandModel/run/hrldas.exe  ./Run/wrf_hydro.exe
 test:
 	@echo "No libraries or utilities are built, skip testing."

--- a/src/arc/Makefile.NoahMP
+++ b/src/arc/Makefile.NoahMP
@@ -10,19 +10,19 @@ $(CMD):
 		(mkdir Run);\
 	fi
 	(rm -f Run/wrf_hydro.exe   )
-	(make -f Makefile.comm)
+	($(MAKE) -f Makefile.comm)
 	@if [ -d "LandModel_cpl" ]; then \
-	(cd LandModel_cpl; make) \
+	(cd LandModel_cpl; $(MAKE)) \
 	fi
 	if [ $(WRF_HYDRO_RAPID) -eq 1 ]; then \
 		(cd lib;rm -f librapid.a); \
 	fi
 	if [ $(WRF_HYDRO_RAPID) -eq 1 ]; then \
-		(cd Rapid_routing; make -f makefile.cpl rapid); \
+		(cd Rapid_routing; $(MAKE) -f makefile.cpl rapid); \
 	fi
 
 	@if [ -d "LandModel" ]; then \
-	(cd LandModel; make ) \
+	(cd LandModel; $(MAKE) ) \
 	fi
 
 debug::
@@ -37,13 +37,13 @@ test:
 	@echo "No libraries or utilities are built, skip testing."
 clean:
 	@if [ -d "LandModel_cpl" ]; then \
-	(cd LandModel_cpl; make clean) \
+	(cd LandModel_cpl; $(MAKE) clean) \
 	fi
-	(make -f Makefile.comm clean)
+	($(MAKE) -f Makefile.comm clean)
 	@if [ -d "LandModel" ]; then \
-	(cd LandModel; make clean) \
+	(cd LandModel; $(MAKE) clean) \
 	fi
 	if [ $(WRF_HYDRO_RAPID) -eq 1 ]; then \
-		(cd Rapid_routing; make -f makefile.cpl clean); \
+		(cd Rapid_routing; $(MAKE) -f makefile.cpl clean); \
 	fi
 	(rm -f */*.mod */*.o lib/*.a Run/wrf_hydro.exe)

--- a/src/arc/Makefile.mpp
+++ b/src/arc/Makefile.mpp
@@ -1,19 +1,25 @@
-# Makefile 
+# Makefile
 
 all:
-	(make -f Makefile.comm BASIC)
+	(make -f Makefile.comm HYDRO_drv)
 
-BASIC:
+basic:
 	make -C MPP
 	make -C IO
 	make -C utils
 	make -C OrchestratorLayer
+	make -C Debug_Utilities
+
+routing_modules: basic
 	make -C Routing/Overland
 	make -C Routing/Subsurface
 	make -C Routing/Reservoirs
+
+routing: routing_modules basic
 	make -C Data_Rec
-	make -C Debug_Utilities
 	make -C Routing
+
+HYDRO_drv: basic routing_modules routing
 	make -C HYDRO_drv
 
 clean:

--- a/src/arc/Makefile.mpp
+++ b/src/arc/Makefile.mpp
@@ -1,37 +1,37 @@
 # Makefile
 
 all:
-	(make -f Makefile.comm HYDRO_drv)
+	($(MAKE) -f Makefile.comm HYDRO_drv)
 
 basic:
-	make -C MPP
-	make -C IO
-	make -C utils
-	make -C OrchestratorLayer
-	make -C Debug_Utilities
+	$(MAKE) -C MPP
+	$(MAKE) -C IO
+	$(MAKE) -C utils
+	$(MAKE) -C OrchestratorLayer
+	$(MAKE) -C Debug_Utilities
 
 routing_modules: basic
-	make -C Routing/Overland
-	make -C Routing/Subsurface
-	make -C Routing/Reservoirs
+	$(MAKE) -C Routing/Overland
+	$(MAKE) -C Routing/Subsurface
+	$(MAKE) -C Routing/Reservoirs
 
 routing: routing_modules basic
-	make -C Data_Rec
-	make -C Routing
+	$(MAKE) -C Data_Rec
+	$(MAKE) -C Routing
 
 HYDRO_drv: basic routing_modules routing
-	make -C HYDRO_drv
+	$(MAKE) -C HYDRO_drv
 
 clean:
-	(cd IO; make -f Makefile clean)
-	(cd OrchestratorLayer; make -f Makefile clean)
-	(cd utils     ; make -f Makefile clean)
-	make -C Routing/Overland clean
-	make -C Routing/Subsurface clean
-	make -C Routing/Reservoirs clean
-	(cd Data_Rec; make -f Makefile clean)
-	(cd HYDRO_drv; make -f Makefile clean)
-	(cd MPP; make -f Makefile clean)
-	make -C Debug_Utilities/ clean
-	(cd Routing;    make -f Makefile clean)
+	(cd IO; $(MAKE) -f Makefile clean)
+	(cd OrchestratorLayer; $(MAKE) -f Makefile clean)
+	(cd utils     ; $(MAKE) -f Makefile clean)
+	$(MAKE) -C Routing/Overland clean
+	$(MAKE) -C Routing/Subsurface clean
+	$(MAKE) -C Routing/Reservoirs clean
+	(cd Data_Rec; $(MAKE) -f Makefile clean)
+	(cd HYDRO_drv; $(MAKE) -f Makefile clean)
+	(cd MPP; $(MAKE) -f Makefile clean)
+	$(MAKE) -C Debug_Utilities/ clean
+	(cd Routing;    $(MAKE) -f Makefile clean)
 	(rm -f lib/*.a */*.mod */*.o CPL/*/*.o CPL/*/*.mod)

--- a/src/arc/Makefile.seq
+++ b/src/arc/Makefile.seq
@@ -1,36 +1,36 @@
-# Makefile 
+# Makefile
 
 all:
-	(make -f Makefile BASIC)
+	($(MAKE) -f Makefile BASIC)
 
 BASIC:
-	(cd Data_Rec     ; make -f Makefile)
-	(cd Routing; make -f Makefile)
+	(cd Data_Rec     ; $(MAKE) -f Makefile)
+	(cd Routing; $(MAKE) -f Makefile)
         ifeq ($(WRF_HYDRO_NUDGING),-DWRF_HYDRO_NUDGING)
-	(cd nudging; make -f Makefile)
+	(cd nudging; $(MAKE) -f Makefile)
         endif
-	(cd HYDRO_drv;   make -f Makefile)
+	(cd HYDRO_drv;   $(MAKE) -f Makefile)
 
 LIS:
-	(make -f Makefile BASIC)
-	(cd LIS_cpl  ;   make -f Makefile)
+	($(MAKE) -f Makefile BASIC)
+	(cd LIS_cpl  ;   $(MAKE) -f Makefile)
 
 CLM:
-	(make -f Makefile BASIC)
-	(cd CLM_cpl  ;   make -f Makefile)
+	($(MAKE) -f Makefile BASIC)
+	(cd CLM_cpl  ;   $(MAKE) -f Makefile)
 
 WRF:
-	(make -f Makefile BASIC)
-	(cd WRF_cpl  ;   make -f Makefile)
+	($(MAKE) -f Makefile BASIC)
+	(cd WRF_cpl  ;   $(MAKE) -f Makefile)
 
 HYDRO:
-	(make -f Makefile BASIC)
+	($(MAKE) -f Makefile BASIC)
 
 clean:
-	(cd Data_Rec; make -f Makefile clean)
-	(cd HYDRO_drv; make -f Makefile clean)
+	(cd Data_Rec; $(MAKE) -f Makefile clean)
+	(cd HYDRO_drv; $(MAKE) -f Makefile clean)
         ifeq ($(WRF_HYDRO_NUDGING),-DWRF_HYDRO_NUDGING)
-	(cd nudging; make -f Makefile clean)
+	(cd nudging; $(MAKE) -f Makefile clean)
         endif
-	(cd Routing;    make -f Makefile clean)
+	(cd Routing;    $(MAKE) -f Makefile clean)
 	(rm -f lib/*.a */*.mod CPL/*/*.o CPL/*/*.mod)

--- a/src/compile_offline_NoahMP.sh
+++ b/src/compile_offline_NoahMP.sh
@@ -52,9 +52,9 @@ make clean; rm -f Run/wrf_hydro_NoahMP.exe ; rm -f Run/*TBL ; rm -f Run/*namelis
 
 #for debugging and testing
 #make debug; make install; make test
-NJOBS=${WRF_HYDRO_MAKE_JOBS:-4}
-echo "Building WRF-Hydro with $NJOBS Make jobs"
-make -j $NJOBS && make install
+export WRF_HYDRO_MAKE_JOBS=${WRF_HYDRO_MAKE_JOBS:-4}
+echo "Building WRF-Hydro with $WRF_HYDRO_MAKE_JOBS Make jobs"
+make -j $WRF_HYDRO_MAKE_JOBS && make install
 
 if [[ $? -eq 0 ]]; then
     echo
@@ -86,7 +86,7 @@ fi
 echo
 echo '*****************************************************************'
 echo "The environment variables used in the compile:"
-grepStr="(WRF_HYDRO)|(HYDRO_D)|(SPATIAL_SOIL)|(WRF_HYDRO_RAPID)|(HYDRO_REALTIME)|(NCEP_WCOSS)|(WRF_HYDRO_NUDGING)|(NETCDF)"
+grepStr="(WRF_HYDRO)|(HYDRO_D)|(SPATIAL_SOIL)|(WRF_HYDRO_RAPID)|(HYDRO_REALTIME)|(NCEP_WCOSS)|(WRF_HYDRO_NUDGING)|(NETCDF)|(WRF_HYDRO_MAKE_JOBS)"
 printenv | egrep -w "${grepStr}" | sort
 
 exit 0

--- a/src/compile_offline_NoahMP.sh
+++ b/src/compile_offline_NoahMP.sh
@@ -52,7 +52,9 @@ make clean; rm -f Run/wrf_hydro_NoahMP.exe ; rm -f Run/*TBL ; rm -f Run/*namelis
 
 #for debugging and testing
 #make debug; make install; make test
-make && make install
+NJOBS=${WRF_HYDRO_MAKE_JOBS:-4}
+echo "Building WRF-Hydro with $NJOBS Make jobs"
+make -j $NJOBS && make install
 
 if [[ $? -eq 0 ]]; then
     echo

--- a/src/nudging/Makefile
+++ b/src/nudging/Makefile
@@ -17,7 +17,7 @@ all:	$(OBJS)
 
 %.o: %.F
 	@echo ""
-	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(MODFLAG) -I$(NETCDF_INC) $(*).F
+	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(MODFLAG) -I$(NETCDF_INC) $<
 	@echo ""
 	@cp *.mod ../mod
 

--- a/src/nudging/Makefile
+++ b/src/nudging/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 #
 .SUFFIXES:
 .SUFFIXES: .o .F
@@ -13,21 +13,13 @@ OBJS = \
 
 
 all:	$(OBJS)
+	ar -cr ../lib/libHYDRO.a $(OBJS)
 
-#module_RT.o: module_RT.F
-#	@echo ""
-#	$(CPP) $(CPPFLAGS) $(*).F > $(*).f
-#	$(COMPILER90) -o $(@) $(F90FLAGS) $(MODFLAG)  $(*).f
-#	$(RMD) $(*).f
-#	@echo ""
-#	cp *.mod ../mod
-
-.F.o:
+%.o: %.F
 	@echo ""
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(MODFLAG) -I$(NETCDF_INC) $(*).F
 	@echo ""
-	ar -r ../lib/libHYDRO.a $(@)
-	cp *.mod ../mod
+	@cp *.mod ../mod
 
 #
 # Dependencies:

--- a/src/utils/Makefile
+++ b/src/utils/Makefile
@@ -22,7 +22,7 @@ all:	$(OBJS)
 ## The insertion of compile-time constants strangely requires the capital F in the extension.
 %.o: %.F
 	@echo "Utils Makefile:"
-	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) $(*).F
+	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) $<
 	@echo ""
 	@cp *.mod ../mod
 

--- a/src/utils/Makefile
+++ b/src/utils/Makefile
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 
 .SUFFIXES: .o .F
 
@@ -7,7 +7,7 @@ include ../macros
 wh_version := $(shell cat ../.version)
 WRF_HYDRO_VERSION=\"$(wh_version)\"
 
-nwm_version  := $(shell cat ../.nwm_version)
+nwm_version  := $(-shell cat ../.nwm_version)
 NWM_VERSION=\"$(nwm_version)\"
 
 F90FLAGS += -DNWM_VERSION=$(NWM_VERSION) -DWRF_HYDRO_VERSION=$(WRF_HYDRO_VERSION)
@@ -17,18 +17,18 @@ OBJS = \
 	module_hydro_stop.o
 
 all:	$(OBJS)
+	ar -cr ../lib/libHYDRO.a $(OBJS)
 
 ## The insertion of compile-time constants strangely requires the capital F in the extension.
-.F.o:
+%.o: %.F
 	@echo "Utils Makefile:"
 	$(COMPILER90) $(CPPINVOKE) $(CPPFLAGS) -o $(@) $(F90FLAGS) $(LDFLAGS) $(MODFLAG) -I$(NETCDFINC) $(*).F
 	@echo ""
-	ar -r ../lib/libHYDRO.a $(@)
-	cp *.mod ../mod
+	@cp *.mod ../mod
 
 #
 # Dependencies:
 #
 
-clean:	
+clean:
 	rm -f *.o *.mod *.stb *~


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: makefiles, build

SOURCE: WRF-Hydro Team @ NCAR

DESCRIPTION OF CHANGES:

Update dependencies and syntax across Makefiles to support parallel Make (`make -j`). New defaults in `compile_offline_NoahMP.sh` is to use 4 Make jobs, overridable with `$WRF_HYDRO_MAKE_JOBS`.

ISSUE: 

Fixes #685

TESTS CONDUCTED: Regression tests localy

NOTES: Leaving this as draft, as we may want to:

- change the default number of Make jobs
- remove recursive calls to`$(MAKE)` in favor of using Makefile-includes