### PR TITLE
Alma tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ set (CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/src/cmake-modules)
 set (NETCDF_F90 "YES")
 set (NETCDF_F77 "YES")
 find_package(NetCDF REQUIRED)
-message("-- NetCDF Include Dir: ${NETCDF_INCLUDES}")
+message("-- NetCDF Include Dir(s): ${NETCDF_INCLUDES_F77} ${NETCDF_INCLUDES_F90}")
 
 # set user controled enviorment variables
 set (HYDRO_LSM $ENV{HYDRO_LSM} CACHE STRING "Name of the Land Surface Model to Use")
@@ -240,7 +240,9 @@ set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/mods)
 #add common include directores need in the build
 include_directories(AFTER ${PROJECT_BINARY_DIR}/mods)
 include_directories(AFTER ${MPI_INCLUDE_PATH})
-include_directories(AFTER ${NETCDF_INCLUDES})
+# include_directories(AFTER ${NETCDF_INCLUDES})  # NOTE: We don't need the C include for netCDF
+include_directories(AFTER ${NETCDF_INCLUDES_F77})
+include_directories(AFTER ${NETCDF_INCLUDES_F90})
 include_directories(AFTER ${PROJECT_SOURCE_DIR}/src/Data_Rec)
 
 add_subdirectory("src")

--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,7 @@ debug::
 debug:: $(CMD)
 
 install:
-	-rm -f ./Run/wrf_hydro.exe; \
+	-rm -f ./Run/wrf_hydro.exe
 	mv LandModel/run/hrldas.exe  ./Run/wrf_hydro.exe
 test:
 	@echo "No libraries or utilities are built, skip testing."

--- a/src/arc/Makefile.NoahMP
+++ b/src/arc/Makefile.NoahMP
@@ -31,7 +31,7 @@ debug::
 debug:: $(CMD)
 
 install:
-	-rm -f ./Run/wrf_hydro.exe; \
+	-rm -f ./Run/wrf_hydro.exe
 	mv LandModel/run/hrldas.exe  ./Run/wrf_hydro.exe
 test:
 	@echo "No libraries or utilities are built, skip testing."

--- a/src/cmake-modules/FindNetCDF.cmake
+++ b/src/cmake-modules/FindNetCDF.cmake
@@ -32,6 +32,8 @@ endif (NETCDF_INCLUDES AND NETCDF_LIBRARIES)
 
 find_path (NETCDF_INCLUDES netcdf.h HINTS NETCDF_DIR "$ENV{NETCDF}/include" ENV NETCDF_DIR)
 
+find_path (NETCDF_MODULES netcdf.mod HINTS NETCDF_DIR "$ENV{NETCDF}/mod" ENV NETCDF_MOD "/usr/lib64/gfortran/modules")
+
 find_library(NETCDF_LIBRARIES NAMES netcdf PATHS "$ENV{NETCDF}/lib" ENV NETCDF_LIB)
 
 find_library (NETCDF_LIBRARIES_C NAMES netcdf PATHS "$ENV{NETCDF}/lib" ENV NETCDF_LIB)
@@ -46,7 +48,7 @@ get_filename_component (NetCDF_lib_dirs "${NETCDF_LIBRARIES_C}" PATH)
 macro (NetCDF_check_interface lang header libs)
   if (NETCDF_${lang})
     find_path (NETCDF_INCLUDES_${lang} NAMES ${header}
-      HINTS "${NETCDF_INCLUDES}" NO_DEFAULT_PATH)
+      HINTS "${NETCDF_INCLUDES}" "${NETCDF_MODULES}" NO_DEFAULT_PATH)
     find_library (NETCDF_LIBRARIES_${lang} NAMES ${libs}
       HINTS "${NetCDF_lib_dirs}" NO_DEFAULT_PATH)
     mark_as_advanced (NETCDF_INCLUDES_${lang} NETCDF_LIBRARIES_${lang})

--- a/src/configure
+++ b/src/configure
@@ -51,6 +51,12 @@ if [[ ! -e ${NETCDF_LIB}/libnetcdff.a ]]; then
     echo "NETCDFLIB       =       -L${NETCDF_LIB} -lnetcdf" >> macros.tmp 
 fi
  
+# add any additional F90 flags that came out of nf-config (most likely separate module/library path)
+if command -v nf-config &> /dev/null; then             # ignore if nf-config isn't available
+    echo "F90FLAGS        +=      $(nf-config --fflags)" >> macros.tmp 
+    echo "NETCDFLIB       +=      $(nf-config --flibs)" >> macros.tmp
+fi
+
 ###################################
 ## File/dir setups
 if [[ -e macros ]]; then rm -f macros; fi


### PR DESCRIPTION
TYPE: choose one of bug fix

KEYWORDS: redhat, build, alma

SOURCE: Ryan @ NCAR

DESCRIPTION OF CHANGES: 

RedHat-style installations of gfortran and gfortran-built system libraries place the resulting `.mod` files into a separate path hierarchy (something like `/usr/lib64/gfortran/modules`) because of the incompatibility of compiled MOD files between compiler vendors and versions. Both the CMake-based `FindNetCDF.cmake` and the legacy WRF-Hydro build system expect to find these .mod files in the standard header/include path. This PR adds support to search these additional directories and/or use `nf-config` to find the needed module files. 

As NCAR is moving to RedHat-compatible OSs on smaller clusters, this will be important to support.

TESTS CONDUCTED: Tested with and without RedHat to check for regressions in build system.
