### PR TITLE
bugfix: unallocated variables 

### DIFF
--- a/src/HYDRO_drv/module_HYDRO_drv.F
+++ b/src/HYDRO_drv/module_HYDRO_drv.F
@@ -990,7 +990,7 @@ else
        ,RT_DOMAIN(did)%lake_index,RT_DOMAIN(did)%link_location,&
        RT_DOMAIN(did)%mpp_nlinks,RT_DOMAIN(did)%nlinks_index, &
        RT_DOMAIN(did)%yw_mpp_nlinks  &
-       , RT_DOMAIN(did)%LNLINKSL,RT_DOMAIN(did)%LLINKID &
+       , RT_DOMAIN(did)%LNLINKSL &
        , rt_domain(did)%gtoNode,rt_domain(did)%toNodeInd,rt_domain(did)%nToInd  &
 #endif
        , rt_domain(did)%CH_LNKRT_SL   &

--- a/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -605,8 +605,9 @@ contains
     real,    dimension(xstart:xend,ystart:yend), intent(out) :: seaice
     real,    dimension(xstart:xend,ystart:yend), intent(out) :: msftx
     real,    dimension(xstart:xend,ystart:yend), intent(out) :: msfty
-    real,    dimension(xstart:xend,ystart:yend), intent(out), optional :: glact
-    real,    dimension(xstart:xend,ystart:yend), intent(out), optional :: vis_icealb
+    ! the following two vars have xstart:xend,ystart:yend dimesions
+    real,    dimension(:,:), intent(out), allocatable :: glact
+    real,    dimension(:,:), intent(out), allocatable :: vis_icealb
 
     character(len=256) :: units
     integer :: ierr
@@ -3016,9 +3017,10 @@ contains
     integer,                               intent(in) :: iswater
     integer, dimension(ixpar,jxpar),       intent(in) :: vegtyp
     integer, dimension(global_nx,global_ny) :: gvegtyp
-    integer, dimension(ixpar,jxpar), optional, intent(in) :: glacinfo
-    real,    dimension(ixpar,jxpar), optional, intent(in) :: glact
-    real,    dimension(ixpar,jxpar),           intent(in) :: vis_icealb
+    ! the following three vars have ixpar, jxpar dimensions
+    integer, dimension(:,:), allocatable, intent(in) :: glacinfo
+    real,    dimension(:,:), allocatable, intent(in) :: glact
+    real,    dimension(:,:), allocatable, intent(in) :: vis_icealb
 
     call write_io_int(vegtyp, gvegtyp)
     if(my_id .eq. io_id) then

--- a/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -605,7 +605,7 @@ contains
     real,    dimension(xstart:xend,ystart:yend), intent(out) :: seaice
     real,    dimension(xstart:xend,ystart:yend), intent(out) :: msftx
     real,    dimension(xstart:xend,ystart:yend), intent(out) :: msfty
-    ! the following two vars have xstart:xend,ystart:yend dimesions
+    ! the following two vars have xstart:xend,ystart:yend bounds
     real,    dimension(:,:), intent(out), allocatable :: glact
     real,    dimension(:,:), intent(out), allocatable :: vis_icealb
 
@@ -3017,7 +3017,7 @@ contains
     integer,                               intent(in) :: iswater
     integer, dimension(ixpar,jxpar),       intent(in) :: vegtyp
     integer, dimension(global_nx,global_ny) :: gvegtyp
-    ! the following three vars have ixpar, jxpar dimensions
+    ! the following three vars have ixpar, jxpar bounds
     integer, dimension(:,:), allocatable, intent(in) :: glacinfo
     real,    dimension(:,:), allocatable, intent(in) :: glact
     real,    dimension(:,:), allocatable, intent(in) :: vis_icealb

--- a/src/Routing/module_HYDRO_io.F
+++ b/src/Routing/module_HYDRO_io.F
@@ -1518,7 +1518,8 @@ end subroutine get_albedo12m_netcdf
    implicit none
    integer, intent(in) :: gnumbasns, numbasns
    integer(kind=int64), intent(in),  dimension(numbasns) :: basnsInd
-   real,    intent(out), dimension(numbasns) :: gw_buck_coeff, gw_buck_exp, gw_buck_loss
+   real,    intent(out), dimension(numbasns) :: gw_buck_coeff, gw_buck_exp
+   real,    intent(out), dimension(:), allocatable :: gw_buck_loss
    real,    intent(out), dimension(numbasns) :: z_max, z_gwsubbas, basns_area
    integer, intent(out), dimension(numbasns) :: bas_id
    real, dimension(gnumbasns) :: tmp_buck_coeff, tmp_buck_exp, tmp_buck_loss

--- a/src/Routing/module_channel_routing.F
+++ b/src/Routing/module_channel_routing.F
@@ -306,7 +306,7 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
             Km = dt
           endif
 
-          if ( (h_0 .gt. bfd) .and. (TwCC .gt. 0.0) .and. (nCC .gt. 0.0) .and. (Ck .gt. 0.0) ) then 
+          if ( (h_0 .gt. bfd) .and. (TwCC .gt. 0.0) .and. (nCC .gt. 0.0) .and. (Ck .gt. 0.0) ) then
           !water outside of defined channel
              X = min(0.5,max(0.0,0.5*(1-(Qj_0/(2.0*TwCC*So*Ck*dx)))))
           else
@@ -572,7 +572,7 @@ END SUBROUTINE SUBMUSKINGCUNGE
        NLINKSL, LINKID, node_area  &
 #ifdef MPP_LAND
        , lake_index,link_location,mpp_nlinks,nlinks_index,yw_mpp_nlinks  &
-       , LNLINKSL, LLINKID  &
+       , LNLINKSL  &
        , gtoNode,toNodeInd,nToNodeInd &
 #endif
        , CH_LNKRT_SL &
@@ -633,8 +633,8 @@ END SUBROUTINE SUBMUSKINGCUNGE
         REAL, DIMENSION(NLINKS)                   :: dzGwChanHead
         REAL, DIMENSION(NLINKS)                   :: Q_GW_CHAN_FLUX     !DJG !!! Change 'INTENT' to 'OUT' when ready to update groundwater state...
         REAL, DIMENSION(IXRT,JXRT)                :: ZWATTBLRT          !DJG !!! Match with subsfce/gw routing & Change 'INTENT' to 'INOUT' when ready to update groundwater state...
-        REAL, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: gwHead            !DJG !!! groundwater head from Fersch-2d gw implementation...units (m ASL)
-        REAL, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: qgw_chanrt         !DJG !!! Channel-gw flux as used in Fersch 2d gw implementation...units (m^3/s)...Change 'INTENT' to 'OUT' when ready to update groundwater state...
+        REAL, INTENT(INOUT), DIMENSION(:,:), allocatable :: gwHead      !DJG !!! groundwater head from Fersch-2d gw implementation...units (m ASL)
+        REAL, INTENT(INOUT), DIMENSION(:,:), allocatable :: qgw_chanrt  !DJG !!! Channel-gw flux as used in Fersch 2d gw implementation...units (m^3/s)...Change 'INTENT' to 'OUT' when ready to update groundwater state...
 
 
 
@@ -671,7 +671,6 @@ END SUBROUTINE SUBMUSKINGCUNGE
         integer(kind=int64) link_location(ixrt,jxrt)
         real     ywtmp(ixrt,jxrt)
         integer LNLINKSL
-        integer(kind=int64), dimension(LNLINKSL) :: LLINKID
         real*8,  dimension(LNLINKSL) :: LQLateral
 !        real*4,  dimension(LNLINKSL) :: LQLateral
         integer, dimension(:) ::  toNodeInd


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: runtime checks, allocatable variables

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Running after compiling with `-fcheck=all` leads to errors of the following variables not being allocated: `gw_buck_loss`, `RT_DOMAIN(did)%LLINKID`, `gw2d, qgw_chanrt`, and `vis_icealb`. This was because they were unallocated but being passed to a subroutine that didn't have them labeled as `allocatable`. This normally doesn't cause problems but could possibly cause issues during debugging so it is good to fix. Also switched crocus variable from `optional` to `allocatable` to better represent their functionality and for the above reasons. Also the `RT_DOMAIN(did)%LLINKID` variable wasn't being used so I removed it from the subroutine argument list.

TESTS CONDUCTED: Compiled and ran Croton test to completion with `-fcheck=all` GNU compile flag.

### Checklist
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
