### PR TITLE
CTest Structure and CMake Croton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(CMAKE_SKIP_BUILD_RPATH  FALSE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 
+# enable ctests
+enable_testing()
 
 #message ("-- MPI Include directories: " ${MPI_INCLUDE_PATH} )
 #message ("-- MPI C COMPILER : " ${MPI_C_COMPILER} )
@@ -246,3 +248,4 @@ include_directories(AFTER ${NETCDF_INCLUDES_F90})
 include_directories(AFTER ${PROJECT_SOURCE_DIR}/src/Data_Rec)
 
 add_subdirectory("src")
+add_subdirectory("tests/ctests")

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -50,3 +50,23 @@ available options are described in the following table.
 |------------------------------------|-------------------------------------------------------------------------------|
 | `-DWRF_HYDRO_NUOPC=1`              | Coupling with NUOPC, this option is not currently supported                   |
 | `-DWRF_HYDRO_RAPID=1`              | Coupling with the RAPID routing model, this option is not currently supported |
+
+
+### Testing with CMake
+To run CTests run the following in the CMake build directory.
+```
+$ ctest
+```
+
+To build the Croton, NY testcase in the CMake build's `Run` directory use the following command.
+```
+$ make croton
+```
+The script defaults to the gridded testcase, but the others can also be chosen.
+```
+$ make croton-gridded
+$ make croton-gridded-no-lakes
+$ make croton-nwm
+$ make croton-reach
+$ make croton-reach-lakes
+```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,18 +103,27 @@ if (HYDRO_LSM MATCHES "NoahMP")
 
     if (WRF_HYDRO_NUDGING STREQUAL "1")
         target_link_libraries(wrfhydro.exe hydro_nudging)
-         add_dependencies(wrfhydro.exe hydro_nudging)
+        add_dependencies(wrfhydro.exe hydro_nudging)
     endif (WRF_HYDRO_NUDGING STREQUAL "1")
+
+    # bash commands to copy namelists to the Run directory
+    set(BASH_CP_HRLDAS_NML "if [[ ! -f ${CMAKE_BINARY_DIR}/Run/namelist.hrldas ]]\; then cp ${PROJECT_SOURCE_DIR}/src/template/NoahMP/namelist.hrldas ${CMAKE_BINARY_DIR}/Run \; fi\;")
+    set(BASH_CP_HYDRO_NML "if [[ ! -f ${CMAKE_BINARY_DIR}/Run/hydro.namelist ]]\; then cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/hydro.namelist ${CMAKE_BINARY_DIR}/Run \; fi\;")
 
     add_custom_command(TARGET wrfhydro.exe POST_BUILD
         COMMAND mkdir -p ${CMAKE_BINARY_DIR}/Run
-        COMMAND rm -f ${CMAKE_BINARY_DIR}/Run/*
-        COMMAND cp ${PROJECT_BINARY_DIR}/src/wrfhydro.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro_NoahMP.exe
-        COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/NoahMP/* ${CMAKE_BINARY_DIR}/Run
+        COMMAND cp ${PROJECT_SOURCE_DIR}/tests/ctests/run_dir_makefile.mk ${CMAKE_BINARY_DIR}/Run/Makefile
+        # copy tables
         COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/CHANPARM.TBL ${CMAKE_BINARY_DIR}/Run
-        COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/hydro.namelist ${CMAKE_BINARY_DIR}/Run
         COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/HYDRO.TBL ${CMAKE_BINARY_DIR}/Run
         COMMAND cp ${PROJECT_SOURCE_DIR}/src/Land_models/NoahMP/run/*.TBL ${CMAKE_BINARY_DIR}/Run
+        # copy namelists
+        COMMAND bash -c "${BASH_CP_HRLDAS_NML}"
+        COMMAND bash -c "${BASH_CP_HYDRO_NML}"
+        # copy and setup executables
+        COMMAND rm -f ${CMAKE_BINARY_DIR}/Run/wrf_hydro.exe
+        COMMAND rm -f ${CMAKE_BINARY_DIR}/Run/wrf_hydro_NoahMP.exe
+        COMMAND cp ${PROJECT_BINARY_DIR}/src/wrfhydro.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro_NoahMP.exe
         COMMAND ln -s wrf_hydro_NoahMP.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro.exe
         COMMAND rm ${PROJECT_BINARY_DIR}/src/wrfhydro.exe
     )

--- a/tests/ctests/CMakeLists.txt
+++ b/tests/ctests/CMakeLists.txt
@@ -1,0 +1,34 @@
+# add Makefile target to setup test runs
+# - croton test options: {Gridded, Gridded_no_lakes, NWM, Reach, ReachLakes}
+add_custom_target(croton
+  COMMAND bash
+  ${CMAKE_CURRENT_SOURCE_DIR}/setup_cmake_testcase.sh Gridded ${CMAKE_BINARY_DIR})
+add_custom_target(croton-gridded
+  COMMAND bash
+  ${CMAKE_CURRENT_SOURCE_DIR}/setup_cmake_testcase.sh Gridded ${CMAKE_BINARY_DIR})
+add_custom_target(croton-gridded-no-lakes
+  COMMAND bash
+  ${CMAKE_CURRENT_SOURCE_DIR}/setup_cmake_testcase.sh Gridded_no_lakes ${CMAKE_BINARY_DIR})
+add_custom_target(croton-nwm
+  COMMAND bash
+  ${CMAKE_CURRENT_SOURCE_DIR}/setup_cmake_testcase.sh NWM ${CMAKE_BINARY_DIR})
+add_custom_target(croton-reach
+  COMMAND bash
+  ${CMAKE_CURRENT_SOURCE_DIR}/setup_cmake_testcase.sh Reach ${CMAKE_BINARY_DIR})
+add_custom_target(croton-reach-lakes
+  COMMAND bash
+  ${CMAKE_CURRENT_SOURCE_DIR}/setup_cmake_testcase.sh ReachLakes ${CMAKE_BINARY_DIR})
+
+
+# generic ctests
+add_executable(fortran_ctest_should_fail
+  should_fail.f90)
+add_test(NAME fortran_ctest_should_fail
+  COMMAND fortran_ctest_should_fail)
+set_tests_properties(fortran_ctest_should_fail
+  PROPERTIES WILL_FAIL TRUE)
+
+add_executable(fortran_ctest_should_not_fail
+  should_not_fail.f90)
+add_test(NAME fortran_ctest_should_not_fail
+  COMMAND fortran_ctest_should_not_fail)

--- a/tests/ctests/run_dir_makefile.mk
+++ b/tests/ctests/run_dir_makefile.mk
@@ -1,0 +1,29 @@
+# this file is to be copied into the CMake ${CMAKE_BINARY_DIR}/Run/ directory
+all: build
+
+build:
+	make -C ..
+
+run:
+	./wrf_hydro.exe
+
+# download and extract Croton, NY test case to Run directory
+# testcase options: {Gridded, Gridded_no_lakes, NWM, Reach, ReachLakes}
+croton:
+	make -C .. croton
+croton-gridded:
+	make -C .. croton-gridded
+croton-gridded-no-lakes:
+	make -C .. croton-gridded-no-lakes
+croton-nwm:
+	make -C .. croton-nwm
+croton-reach:
+	make -C .. croton-reach
+croton-reach-lakes:
+	make -C .. croton-reach-lakes
+
+clean:
+	rm -f *.LDASOUT_DOMAIN1 *.LAKEOUT_DOMAIN1 *.CHRTOUT_DOMAIN1
+	rm -f *.GWOUT_DOMAIN1 *.RTOUT_DOMAIN1 *.CHANOBS_DOMAIN1
+	rm -f RESTART.*_DOMAIN1 HYDRO_RST.*_DOMAIN1
+	rm -f diag_hydro.*

--- a/tests/ctests/setup_cmake_testcase.sh
+++ b/tests/ctests/setup_cmake_testcase.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Bash script is meant to be used by CMake. It downloads and extracts the
+# Croton, NY testcase to the CMake build Run directory. It then setups up the
+# files so ctest can run wrf_hydro.exe
+
+# setup directory variables in script
+# testcase_type values = {Gridded, Gridded_no_lakes, NWM, Reach, ReachLakes}
+testcase_type=${1}
+binary_dir=${2}
+test_file_dir=${binary_dir}/tests
+run_dir=${binary_dir}/Run
+
+# download testcase if not present
+croton_tarball=croton_NY_training_example_v5.2.tar.gz
+if [ ! -f ${test_file_dir}/${croton_tarball} ]
+then
+    cd ${test_file_dir}
+    wget -nv https://github.com/NCAR/wrf_hydro_nwm_public/releases/download/v5.2.0/${croton_tarball}
+fi
+
+# extract testcase
+cd ${run_dir}
+if [ ! -d example_case ]
+then
+   tar zxf ${test_file_dir}/${croton_tarball}
+fi
+
+# setup testcase
+testcase=example_case/
+testcase_dir=${testcase}/${testcase_type}
+cp ${testcase_dir}/hydro.namelist .
+cp ${testcase_dir}/namelist.hrldas .
+ln -sf ${testcase_dir}/DOMAIN .
+ln -sf ${testcase_dir}/RESTART .
+ln -sf ${testcase}/FORCING .

--- a/tests/ctests/should_fail.f90
+++ b/tests/ctests/should_fail.f90
@@ -1,0 +1,4 @@
+program should_fail
+  implicit none
+  error stop 1
+end program should_fail

--- a/tests/ctests/should_not_fail.f90
+++ b/tests/ctests/should_not_fail.f90
@@ -1,0 +1,4 @@
+program should_not_fail
+  implicit none
+  stop
+end program should_not_fail


### PR DESCRIPTION
TYPE: new feature, enhancement

KEYWORDS: CTest, CMake, Croton

SOURCE: Soren Rasmussen, NCAR 

DESCRIPTION OF CHANGES: These changes effect the CMake build system:
- Adding ctest structure and two basic tests. 
- Adding ability to run `$ make croton ` to download Croton testcase, extract tarball and setup in Run directory.
- Makefile copied to Run directory. 
- Cleanup of Run directory handled differently so as not to delete Croton files.

TESTS CONDUCTED: built with CMake, ran `make croton` and ran `./wrfhydro.exe` in `Run` directory.
Steps to test:
```
$ cd build
$ cmake ..
$ make -j 4
$ make croton-gridded            
$ make croton-gridded-no-lakes   
$ make croton-nwm                
$ make croton-reach              
$ make croton-reach-lakes
```

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [X] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [X] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
