### PR TITLE
new feature: add repo citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,74 +1,117 @@
 authors:
-  - family-names: McCreight
-    given-names: James
-    orcid: 0000-0001-6018-425X
-  - family-names: FitzGerald
-    given-names: Katelyn
-    orcid: 0000-0003-4184-1917
-  - family-names: Cabell
-    given-names: Ryan
-    orcid: 0000-0002-3623-5130
-  - family-names: Fersch
-    given-names: Benjamin
-    # orcid:
-  - family-names: Johnson
-    given-names: Donald
-    # github-names: donaldwj
-    # orcid:
-  - family-names: Dugger
-    given-names: Aubrey
-    orcid: 0000-0001-8250-4218
-  # - family-names:
-    # given-names: laurareads
-    # orcid:
-  - family-names: Rasmussen
-    given-names: Soren
-    orcid: 0000-0003-3899-1463
-  - family-names: Eidhammer
-    given-names: Trude
-    orcid: 0000-0003-2281-9351
-  - family-names: Rosen
-    given-names: Dan
-    # orcid:
-  - family-names: McAllister
-    given-names: Molly
-    # orcid:
-  - family-names: Karsten
-    given-names: Logan
-    # github-names: logankarsten
-    # orcid:
-  - family-names: Dunlap
-    given-names: Rocky
-    # orcid:
-  # - family-names:
-    # given-names: Nels
-    # orcid:
-  - family-names: Fanfarillo
-    given-names: Alessandro
-    orcid: 0000-0003-3487-7452
-  - family-names: RafieeiNasab
-    given-names: Arezoo
-    # github-names: arezoorn
-    orcid: 0000-0002-8607-294X
-  - family-names: Mattern
+  - family-names: Gochis
     given-names: David
-    # orcid:
+    orcid: 0000-0001-8668-4850
+    # origin: technical doc
   - family-names: Barlage
     given-names: Michael
     # orcid:
+    # origin: technical doc
+  - family-names: Cabell
+    given-names: Ryan
+    orcid: 0000-0002-3623-5130
+    # origin: technical doc
+  - family-names: Casali
+    given-names: Matthew
+    # orcid: 0000-0001-6939-0332
+    # origin: technical doc
   # - family-names:
     # given-names: champham
     # orcid:
-  - family-names: Valayamkunnath
-    given-names: Prasanth
-    orcid: 0000-0003-2270-0780
-  - family-names: Lahmers
-    given-names: Tim
+    # origin: github
+  - family-names: Dugger
+    given-names: Aubrey
+    orcid: 0000-0001-8250-4218
+    # origin: technical doc
+  - family-names: Dunlap
+    given-names: Rocky
     # orcid:
+    # origin: github
+  - family-names: Eidhammer
+    given-names: Trude
+    orcid: 0000-0003-2281-9351
+    # origin: github
+  - family-names: Fanfarillo
+    given-names: Alessandro
+    orcid: 0000-0003-3487-7452
+    # origin: github
+  - family-names: Fersch
+    given-names: Benjamin
+    # orcid:
+    # origin: github
+  - family-names: FitzGerald
+    given-names: Katelyn
+    orcid: 0000-0003-4184-1917
+    # origin: technical doc
   - family-names: Heldmyer
     given-names: Aaron
     # github: aheldmyer
     orcid: 0000-0001-8608-4927
+    # origin: github
+  - family-names: Johnson
+    given-names: Donald
+    # github-names: donaldwj
+    # orcid:
+    # origin: github
+  - family-names: Karsten
+    given-names: Logan
+    # github-names: logankarsten
+    # orcid:
+    # origin: github
+  - family-names: Lahmers
+    given-names: Tim
+    # orcid:
+    # origin: github
+  - family-names: Mattern
+    given-names: David
+    # orcid:
+    # origin: github
+  - family-names: McAllister
+    given-names: Molly
+    # orcid:
+    # origin: technical doc
+  - family-names: McCreight
+    given-names: James
+    orcid: 0000-0001-6018-425X
+    # origin: technical doc
+  # - family-names:
+    # given-names: Nels
+    # orcid:
+    # origin: github
+  - family-names: RafieeiNasab
+    given-names: Arezoo
+    # github-names: arezoorn
+    orcid: 0000-0002-8607-294X
+    # origin: technical doc
+  - family-names: Rasmussen
+    given-names: Soren
+    orcid: 0000-0003-3899-1463
+    # origin: github
+  - family-names: Read
+    given-names: Laura
+    orcid: 0000-0003-3476-1249
+    # origin: technical doc
+  - family-names: Rosen
+    given-names: Dan
+    # orcid:
+    # origin: github
+  - family-names: Sampson
+    given-names: Kevin
+    orcid: 0000-0002-5537-7775
+    # origin: technical doc
+  - family-names: Valayamkunnath
+    given-names: Prasanth
+    orcid: 0000-0003-2270-0780
+    # origin: github
+  - family-names: Yates
+    given-names: David
+    orcid: 0000-0002-0688-3460
+    # origin: technical doc
+  - family-names: Zhang
+    given-names: Yongxin
+    orcid: 0000-0001-6321-1276
+    # origin: technical doc
+
 cff-version: 1.2.0
 date-released: "2021-01-29"
 title: "WRF-Hydro"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,13 +1,13 @@
 authors:
   - family-names: McCreight
     given-names: James
-    # orcid:
+    orcid: 0000-0001-6018-425X
   - family-names: FitzGerald
     given-names: Katelyn
-    # orcid:
+    orcid: 0000-0003-4184-1917
   - family-names: Cabell
     given-names: Ryan
-    # orcid:
+    orcid: 0000-0002-3623-5130
   - family-names: Fersch
     given-names: Benjamin
     # orcid:
@@ -17,13 +17,16 @@ authors:
     # orcid:
   - family-names: Dugger
     given-names: Aubrey
-    # orcid:
+    orcid: 0000-0001-8250-4218
   # - family-names:
-  #   given-names: laurareads
+    # given-names: laurareads
     # orcid:
   - family-names: Rasmussen
     given-names: Soren
-    # orcid:
+    orcid: 0000-0003-3899-1463
+  - family-names: Eidhammer
+    given-names: Trude
+    orcid: 0000-0003-2281-9351
   - family-names: Rosen
     given-names: Dan
     # orcid:
@@ -38,15 +41,15 @@ authors:
     given-names: Rocky
     # orcid:
   # - family-names:
-  #   given-names: Nels
+    # given-names: Nels
     # orcid:
   - family-names: Fanfarillo
     given-names: Alessandro
-    # orcid:
+    orcid: 0000-0003-3487-7452
   - family-names: RafieeiNasab
     given-names: Arezoo
     # github-names: arezoorn
-    # orcid:
+    orcid: 0000-0002-8607-294X
   - family-names: Mattern
     given-names: David
     # orcid:
@@ -54,18 +57,18 @@ authors:
     given-names: Michael
     # orcid:
   # - family-names:
-  #   given-names: champham
+    # given-names: champham
     # orcid:
   - family-names: Valayamkunnath
     given-names: Prasanth
-    # orcid:
+    orcid: 0000-0003-2270-0780
   - family-names: Lahmers
     given-names: Tim
     # orcid:
   - family-names: Heldmyer
     given-names: Aaron
     # github: aheldmyer
-    # orcid:
+    orcid: 0000-0001-8608-4927
 cff-version: 1.2.0
 date-released: "2021-01-29"
 title: "WRF-Hydro"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,93 @@
+authors:
+  - family-names: McCreight
+    given-names: James
+    # orcid:
+  - family-names: FitzGerald
+    given-names: Katelyn
+    # orcid:
+  - family-names: Cabell
+    given-names: Ryan
+    # orcid:
+  - family-names: Fersch
+    given-names: Benjamin
+    # orcid:
+  - family-names: Johnson
+    given-names: Donald
+    # github-names: donaldwj
+    # orcid:
+  - family-names: Dugger
+    given-names: Aubrey
+    # orcid:
+  # - family-names:
+  #   given-names: laurareads
+    # orcid:
+  - family-names: Rasmussen
+    given-names: Soren
+    # orcid:
+  - family-names: Rosen
+    given-names: Dan
+    # orcid:
+  - family-names: McAllister
+    given-names: Molly
+    # orcid:
+  - family-names: Karsten
+    given-names: Logan
+    # github-names: logankarsten
+    # orcid:
+  - family-names: Dunlap
+    given-names: Rocky
+    # orcid:
+  # - family-names:
+  #   given-names: Nels
+    # orcid:
+  - family-names: Fanfarillo
+    given-names: Alessandro
+    # orcid:
+  - family-names: RafieeiNasab
+    given-names: Arezoo
+    # github-names: arezoorn
+    # orcid:
+  - family-names: Mattern
+    given-names: David
+    # orcid:
+  - family-names: Barlage
+    given-names: Michael
+    # orcid:
+  # - family-names:
+  #   given-names: champham
+    # orcid:
+  - family-names: Valayamkunnath
+    given-names: Prasanth
+    # orcid:
+  - family-names: Lahmers
+    given-names: Tim
+    # orcid:
+  - family-names: Heldmyer
+    given-names: Aaron
+    # github: aheldmyer
+    # orcid:
+cff-version: 1.2.0
+date-released: "2021-01-29"
+title: "WRF-Hydro"
+repository-code: "https://github.com/NCAR/wrf_hydro_nwm_public"
+version: 5.3.0
+url: "https://ral.ucar.edu/projects/wrf_hydro"
+keywords:
+  - "hydrologic model"
+  - "hydrology"
+  - "hydrometeorology"
+license-url: "https://github.com/NCAR/wrf_hydro_nwm_public/blob/main/LICENSE.txt"
+identifiers:
+  - description: "This is the archived snapshot of all versions of WRF-Hydro"
+    type: doi
+    value: 10.5281/zenodo.3625237
+  - description: "This is the archived snapshot of version v5.2.0 of WRF-Hydro"
+    type: doi
+    value: 10.5281/zenodo.4479912
+  - description: "This is the archived snapshot of version v5.1.2 of WRF-Hydro"
+    type: doi
+    value: 10.5281/zenodo.3678643
+  - description: "This is the archived snapshot of version v5.1.1 of WRF-Hydro"
+    type: doi
+    value: 10.5281/zenodo.3625238
+message: "Please cite this software using the metadata from this file."


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: citation, cff file

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Initial version of a `CITATION.cff` file, a Github repo [citation file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files). Note that the first Zenodo identifier listed in the file is the one for all versions of WRF-Hydro and specific versions are listed below it. This helps solve the chicken-and-egg problem of creating a new Zenodo release but documentation pointing to the old version. 

The authorship order is based on number of git commits, this can be manually changed in the file and we should discuss that order before merging. I believe that once the `CITATION.cff` file is added Zenodo will take it's authorship order from it for future releases. Here is an example screenshot of what the repo homepage will look like:
<img width="500" alt="image" src="https://github.com/NCAR/wrf_hydro_nwm_public/assets/5750642/3acf47aa-4c94-4715-9a0b-cdfd6412d81a">

TESTS CONDUCTED: text only change. 

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
