### PR TITLE
Text only: MPI Case Style

### DIFF
--- a/src/CPL/LIS_cpl/module_lis_HYDRO.F
+++ b/src/CPL/LIS_cpl/module_lis_HYDRO.F
@@ -52,7 +52,7 @@ module module_lis_HYDRO
 #endif
         if(nlst(did)%nsoil < 1) then
            write(6,*) "FATAL ERROR: nsoil is less than 1"
-           call hydro_stop("In module_lis_HYDRO.F module_lis_HYDRO() - nsoil is less than 1") 
+           call hydro_stop("In module_lis_HYDRO.F module_lis_HYDRO() - nsoil is less than 1")
         endif
         allocate(nlst(did)%zsoil8(nlst(did)%nsoil))
         nlst(did)%zsoil8(1) = -noah271_struc(n)%lyrthk(1)
@@ -65,15 +65,15 @@ module module_lis_HYDRO
 
 #endif
 
-        CALL mpi_initialized( mpi_inited, ierr )
+        call MPI_Initialized( mpi_inited, ierr )
         if ( .NOT. mpi_inited ) then
-           call MPI_INIT( ierr )  ! stand alone land model.
+           call MPI_Init( ierr )  ! stand alone land model.
            if (ierr /= MPI_SUCCESS) stop "MPI_INIT"
-           call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
+           call MPI_Comm_dup(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
            if (ierr /= MPI_SUCCESS) stop "MPI_COMM_DUP"
         endif
-        call MPI_COMM_RANK( HYDRO_COMM_WORLD, my_id, ierr )
-        call MPI_COMM_SIZE( HYDRO_COMM_WORLD, numprocs, ierr )
+        call MPI_Comm_rank( HYDRO_COMM_WORLD, my_id, ierr )
+        call MPI_Comm_size( HYDRO_COMM_WORLD, numprocs, ierr )
       endif
 
         if(nlst(did)%rtFlag .eq. 0) return
@@ -184,7 +184,7 @@ module module_lis_HYDRO
             enddo
 
 #ifdef HYDRO_D
-        write(6,*) "NDHMS lis date ", LIS_rc%yr, LIS_rc%mo, LIS_rc%da, LIS_rc%hr, LIS_rc%mn, LIS_rc%ss 
+        write(6,*) "NDHMS lis date ", LIS_rc%yr, LIS_rc%mo, LIS_rc%da, LIS_rc%hr, LIS_rc%mn, LIS_rc%ss
 #endif
 !       write(11,*) "RT_DOMAIN(did)%stc",RT_DOMAIN(did)%stc(:,:,1)
 !       write(12,*) "noah271_struc(n)%noah%stc(1)",noah271_struc(n)%noah%stc(1)

--- a/src/CPL/WRF_cpl/module_wrf_HYDRO.F90
+++ b/src/CPL/WRF_cpl/module_wrf_HYDRO.F90
@@ -86,7 +86,7 @@ CONTAINS
 
 
 #ifdef MPP_LAND
-           call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
+           call MPI_Comm_dup(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
            call MPP_LAND_INIT(grid%e_we - grid%s_we - 1, grid%e_sn - grid%s_sn - 1)
 
            call mpp_land_bcast_int1 (nlst(did)%nsoil)
@@ -194,9 +194,9 @@ CONTAINS
 #endif
        else
             do k = 1, nlst(did)%nsoil
-                RT_DOMAIN(did)%STC(:,:,k) = grid%TSLB(its:ite,k,jts:jte) 
-                RT_DOMAIN(did)%smc(:,:,k) = grid%smois(its:ite,k,jts:jte) 
-                RT_DOMAIN(did)%sh2ox(:,:,k) = grid%sh2o(its:ite,k,jts:jte) 
+                RT_DOMAIN(did)%STC(:,:,k) = grid%TSLB(its:ite,k,jts:jte)
+                RT_DOMAIN(did)%smc(:,:,k) = grid%smois(its:ite,k,jts:jte)
+                RT_DOMAIN(did)%sh2ox(:,:,k) = grid%sh2o(its:ite,k,jts:jte)
             end do
             rt_domain(did)%infxsrt = grid%infxsrt(its:ite,jts:jte)
             rt_domain(did)%soldrain = grid%soldrain(its:ite,jts:jte)
@@ -215,7 +215,7 @@ CONTAINS
 ! update WRF variable after running routing model.
             grid%sfcheadrt(its:ite,jts:jte) = rt_domain(did)%overland%control%surface_water_head_lsm
 
-! provide groundwater soil flux to WRF for fully coupled simulations (FERSCH 09/2014)            
+! provide groundwater soil flux to WRF for fully coupled simulations (FERSCH 09/2014)
             if(nlst(did)%GWBASESWCRT .eq. 3 ) then
 !Wei Yu: comment the following two lines. Not ready for WRF3.7 release
 !yw             grid%qsgw(its:ite,jts:jte) = gw2d(did)%qsgw
@@ -249,7 +249,7 @@ CONTAINS
          do j = 1, jx
             do i = 1, ix
                 do k = 1, kk
-                  call interpLayer(Z1,v1(i,1:kk1,j),kk1,Z(k),vout(i,j,k)) 
+                  call interpLayer(Z1,v1(i,1:kk1,j),kk1,Z(k),vout(i,j,k))
                 end do
             end do
          end do
@@ -271,7 +271,7 @@ CONTAINS
          do j = 1, jx
             do i = 1, ix
                  do k = 1, kk
-                    call interpLayer(Z1,v1(i,j,1:kk1),kk1,Z(k),vout(i,k,j)) 
+                    call interpLayer(Z1,v1(i,j,1:kk1),kk1,Z(k),vout(i,k,j))
                  end do
             end do
          end do

--- a/src/HYDRO_drv/module_HYDRO_drv.F90
+++ b/src/HYDRO_drv/module_HYDRO_drv.F90
@@ -1821,7 +1821,7 @@ subroutine HYDRO_finish()
     close(78)
 #endif
     call mpp_land_sync()
-    call MPI_finalize(ierr)
+    call MPI_Finalize(ierr)
     stop
 #else
 

--- a/src/IO/netcdf_layer.F90
+++ b/src/IO/netcdf_layer.F90
@@ -43,7 +43,7 @@ module netcdf_layer_base
   end type NetCDF_serial_
 
   type, extends(NetCDF_layer_) :: NetCDF_parallel_
-     integer :: MPI_communicator
+     integer :: MPI_Communicator
      integer :: default_info = MPI_INFO_NULL
    contains
      procedure, pass(object) :: create_file => create_file_parallel

--- a/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -417,9 +417,9 @@ contains
     integer :: rank
 
 #ifdef _PARALLEL_
-    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
+    call MPI_Comm_rank(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In module_hrldas_netcdf_io.F "// &
-                                  "read_hrldas_hdrinfo() - MPI_COMM_RANK"
+                                  "read_hrldas_hdrinfo() - MPI_Comm_rank"
 #else
     rank = 0
 #endif
@@ -598,9 +598,9 @@ contains
     crocus_opt = local_crocus_opt ! setting module scope variable
 
 #ifdef _PARALLEL_
-    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
+    call MPI_Comm_rank(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In module_hrldas_netcdf_io.F readland_hrldas()"// &
-                                  " - MPI_COMM_RANK"
+                                  " - MPI_Comm_rank"
 #else
     rank = 0
 #endif
@@ -620,8 +620,8 @@ contains
     if (ierr /= 0) then
        write(*,'("READLAND_HRLDAS:  Problem opening wrfinput file: ''", A, "''")') trim(wrfinput_flnm)
 #ifdef _PARALLEL_
-       call mpi_finalize(ierr)
-       if (ierr /= 0) write(*, '("Problem with MPI_finalize.")')
+       call MPI_Finalize(ierr)
+       if (ierr /= 0) write(*, '("Problem with MPI_Finalize.")')
 #endif
        stop "FATAL ERROR: In module_hrldas_netcdf_io.F readland_hrldas()"// &
             " - Problem opening wrfinput file."
@@ -740,9 +740,9 @@ contains
     integer :: rank
 
 #ifdef _PARALLEL_
-    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
+    call MPI_Comm_rank(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In module_hrldas_netcdf_io.F read_mmf_runoff()"// &
-                                  " - MPI_COMM_RANK"
+                                  " - MPI_Comm_rank"
 #else
     rank = 0
 #endif
@@ -762,8 +762,8 @@ contains
     if (ierr /= 0) then
        write(*,'("read_mmf_runoff:  Problem opening wrfinput file: ''", A, "''")') trim(wrfinput_flnm)
 #ifdef _PARALLEL_
-       call mpi_finalize(ierr)
-       if (ierr /= 0) write(*, '("Problem with MPI_finalize.")')
+       call MPI_Finalize(ierr)
+       if (ierr /= 0) write(*, '("Problem with MPI_Finalize.")')
 #endif
        stop "FATAL ERROR: In module_hrldas_netcdf_io.F read_mmf_runoff()"// &
             " - Problem opening wrfinput file."
@@ -1513,9 +1513,9 @@ contains
 
 #ifdef _PARALLEL_
 
-    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
+    call MPI_Comm_rank(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In  module_hrldas_netcdf_io.F"// &
-                                  " readinit_hrldas() - MPI_COMM_RANK"
+                                  " readinit_hrldas() - MPI_Comm_rank"
 
     ierr = nf90_open_par(netcdf_flnm, NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
@@ -1534,7 +1534,7 @@ contains
 #endif
        endif
 #ifdef _PARALLEL_
-       call mpi_finalize(ierr)
+       call MPI_Finalize(ierr)
 #endif
        stop "FATAL ERROR: In  module_hrldas_netcdf_io.F readinit_hrldas()"// &
             " - Problem opening netcdf file."
@@ -1658,9 +1658,9 @@ contains
     integer :: rank
 
 #ifdef _PARALLEL_
-    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
+    call MPI_Comm_rank(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In  module_hrldas_netcdf_io.F init_interp()"// &
-                                  " - MPI_COMM_RANK."
+                                  " - MPI_Comm_rank."
 #else
     rank = 0
 #endif
@@ -1964,15 +1964,15 @@ contains
 #endif
        if (ierr /= 0) then
 #ifdef _PARALLEL_
-          call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
+          call MPI_Comm_rank(HYDRO_COMM_WORLD, rank, ierr)
           if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In  module_hrldas_netcdf_io.F"// &
-                                        " READFORC_HRLDAS() - MPI_COMM_RANK"
+                                        " READFORC_HRLDAS() - MPI_Comm_rank"
           if (rank == 0) then
 #endif
              write(*,'("A)  Problem opening netcdf file: ''", A, "''")') trim(flnm)
 #ifdef _PARALLEL_
           endif
-          call mpi_finalize(ierr)
+          call MPI_Finalize(ierr)
 #endif
           stop  "FATAL ERROR: In  module_hrldas_netcdf_io.F READFORC_HRLDAS()"// &
                 " - Problem opening netcdf file"
@@ -3099,9 +3099,9 @@ contains
 
 #ifdef _PARALLEL_
 
-    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
+    call MPI_Comm_rank(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In module_hrldas_netcdf_io.F"// &
-                                  " prepare_restart_file_seq() - MPI_COMM_RANK problem"
+                                  " prepare_restart_file_seq() - MPI_Comm_rank problem"
 
 #else
 
@@ -3433,9 +3433,9 @@ contains
     restart_filename_remember = restart_flnm
 
 #ifdef _PARALLEL_
-    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
+    call MPI_Comm_rank(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In module_hrldas_netcdf_io.F "// &
-                                  "read_restart() - MPI_COMM_RANK"
+                                  "read_restart() - MPI_Comm_rank"
 
     ierr = nf90_open_par(trim(restart_flnm), NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 #else
@@ -3615,9 +3615,9 @@ contains
 
 #ifdef _PARALLEL_
 
-    call MPI_COMM_RANK(HYDRO_COMM_WORLD, rank, ierr)
+    call MPI_Comm_rank(HYDRO_COMM_WORLD, rank, ierr)
     if (ierr /= MPI_SUCCESS) stop "FATAL ERROR: In module_hrldas_netcdf_io.F "// &
-                                  "get_from_restart_2d_float() - MPI_COMM_RANK"
+                                  "get_from_restart_2d_float() - MPI_Comm_rank"
 
     ierr = nf90_open_par(trim(restart_filename_remember), NF90_NOWRITE, HYDRO_COMM_WORLD, MPI_INFO_NULL, ncid)
 

--- a/src/Land_models/NoahMP/Utility_routines/module_wrf_utilities.F
+++ b/src/Land_models/NoahMP/Utility_routines/module_wrf_utilities.F
@@ -27,8 +27,8 @@ END SUBROUTINE wrf_error_fatal
 SUBROUTINE wrf_abort
   use module_cpl_land
   integer ierr
-  CALL MPI_ABORT(HYDRO_COMM_WORLD,1,ierr)
-  call MPI_finalize(ierr)
+  call MPI_Abort(HYDRO_COMM_WORLD,1,ierr)
+  call MPI_Finalize(ierr)
   STOP 'wrf_abort'
 END SUBROUTINE wrf_abort
 

--- a/src/MPP/CPL_WRF.F90
+++ b/src/MPP/CPL_WRF.F90
@@ -47,17 +47,17 @@ MODULE MODULE_CPL_LAND
       data cyclic/.false.,.false./  ! not cyclic
       data reorder/.false./
 
-      CALL mpi_initialized( mpi_inited, ierr )
+      call MPI_Initialized( mpi_inited, ierr )
       if ( .NOT. mpi_inited ) then
-        call mpi_init(ierr)
-        if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_INIT failed")
-        call MPI_COMM_DUP(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
-        if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_COMM_DUP failed")
+        call MPI_Init(ierr)
+        if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_Init failed")
+        call MPI_Comm_dup(MPI_COMM_WORLD, HYDRO_COMM_WORLD, ierr)
+        if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_Comm_dup failed")
       endif
 
-      call MPI_COMM_RANK( HYDRO_COMM_WORLD, my_global_id, ierr )
-      call MPI_COMM_SIZE( HYDRO_COMM_WORLD, total_pe_num, ierr )
-      if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_COMM_RANK and/or MPI_COMM_SIZE failed")
+      call MPI_Comm_rank( HYDRO_COMM_WORLD, my_global_id, ierr )
+      call MPI_Comm_size( HYDRO_COMM_WORLD, total_pe_num, ierr )
+      if (ierr /= MPI_SUCCESS) call fatal_error_stop("MPI Error: MPI_Comm_rank and/or MPI_Comm_size failed")
 
       allocate(node_info(9,total_pe_num))
 
@@ -98,7 +98,7 @@ MODULE MODULE_CPL_LAND
       call MPI_Cart_create(HYDRO_COMM_WORLD, ndim, dims, &
                           cyclic, reorder, cartGridComm, ierr)
 
-      call MPI_CART_GET(cartGridComm, 2, dims, cyclic, coords, ierr)
+      call MPI_Cart_get(cartGridComm, 2, dims, cyclic, coords, ierr)
 
       p_up_down = coords(0)
       p_left_right = coords(1)
@@ -116,21 +116,21 @@ MODULE MODULE_CPL_LAND
 
         if(my_global_id .eq. 0) then
            do i = 1, total_pe_num-1
-             call mpi_recv(node_info(:,i+1),size,MPI_INTEGER,  &
+             call MPI_Recv(node_info(:,i+1),size,MPI_INTEGER,  &
                 i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
            enddo
         else
-           call mpi_send(node_info(:,my_global_id+1),size,   &
+           call MPI_Send(node_info(:,my_global_id+1),size,   &
                MPI_INTEGER,0,tag,HYDRO_COMM_WORLD,ierr)
         endif
 
-        call MPI_barrier( HYDRO_COMM_WORLD ,ierr)
+        call MPI_Barrier( HYDRO_COMM_WORLD ,ierr)
 
         size = 9 * total_pe_num
-        call mpi_bcast(node_info,size,MPI_INTEGER,   &
+        call MPI_Bcast(node_info,size,MPI_INTEGER,   &
             0,HYDRO_COMM_WORLD,ierr)
 
-        call MPI_barrier( HYDRO_COMM_WORLD ,ierr)
+        call MPI_Barrier( HYDRO_COMM_WORLD ,ierr)
 
      end  subroutine send_info
 

--- a/src/MPP/module_mpp_GWBUCKET.F90
+++ b/src/MPP/module_mpp_GWBUCKET.F90
@@ -37,7 +37,7 @@ MODULE MODULE_mpp_GWBUCKET
 
      if(my_id .ne. IO_id) then
           tag = 66
-          call mpi_send(numbasns,1,MPI_INTEGER, IO_id,     &
+          call MPI_Send(numbasns,1,MPI_INTEGER, IO_id,     &
                 tag,HYDRO_COMM_WORLD,ierr)
      else
           do i = 0, numprocs - 1
@@ -45,7 +45,7 @@ MODULE MODULE_mpp_GWBUCKET
                  sizeInd(i+1) = numbasns
               else
                  tag = 66
-                 call mpi_recv(rcv,1,&
+                 call MPI_Recv(rcv,1,&
                      MPI_INTEGER,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
 
                  sizeInd(i+1) = rcv
@@ -81,10 +81,10 @@ MODULE MODULE_mpp_GWBUCKET
      if(my_id .ne. IO_id) then
         if(numbasns .gt. 0) then
           tag = 62
-          call mpi_send(inV,numbasns,MPI_REAL, IO_id,     &
+          call MPI_Send(inV,numbasns,MPI_REAL, IO_id,     &
                 tag,HYDRO_COMM_WORLD,ierr)
           tag2 = 63
-          call mpi_send(ind,numbasns,MPI_INTEGER8, IO_id,     &
+          call MPI_Send(ind,numbasns,MPI_INTEGER8, IO_id,     &
                 tag2,HYDRO_COMM_WORLD,ierr)
         endif
       else
@@ -97,10 +97,10 @@ MODULE MODULE_mpp_GWBUCKET
             if(i .ne. IO_id) then
                if(sizeInd(i+1) .gt. 0) then
                   tag = 62
-                  call mpi_recv(vbuff(1:sizeInd(i+1)),sizeInd(i+1),&
+                  call MPI_Recv(vbuff(1:sizeInd(i+1)),sizeInd(i+1),&
                       MPI_REAL,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                   tag2 = 63
-                  call mpi_recv(ibuff(1:sizeInd(i+1)),sizeInd(i+1),&
+                  call MPI_Recv(ibuff(1:sizeInd(i+1)),sizeInd(i+1),&
                       MPI_INTEGER8,i,tag2,HYDRO_COMM_WORLD,mpp_status,ierr)
                   do k = 1, sizeInd(i+1)
                      outV(ibuff(k)) = vbuff(k)
@@ -139,10 +139,10 @@ MODULE MODULE_mpp_GWBUCKET
       if(my_id .ne. IO_id) then
          if(numbasns .gt. 0) then
            tag = 62
-           call mpi_send(inV,numbasns,MPI_INTEGER8, IO_id,     &
+           call MPI_Send(inV,numbasns,MPI_INTEGER8, IO_id,     &
                  tag,HYDRO_COMM_WORLD,ierr)
            tag2 = 63
-           call mpi_send(ind,numbasns,MPI_INTEGER8, IO_id,     &
+           call MPI_Send(ind,numbasns,MPI_INTEGER8, IO_id,     &
                  tag2,HYDRO_COMM_WORLD,ierr)
          endif
        else
@@ -155,10 +155,10 @@ MODULE MODULE_mpp_GWBUCKET
              if(i .ne. IO_id) then
                 if(sizeInd(i+1) .gt. 0) then
                    tag = 62
-                   call mpi_recv(vbuff(1:sizeInd(i+1)),sizeInd(i+1),&
+                   call MPI_Recv(vbuff(1:sizeInd(i+1)),sizeInd(i+1),&
                        MPI_INTEGER8,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                    tag2 = 63
-                   call mpi_recv(ibuff(1:sizeInd(i+1)),sizeInd(i+1),&
+                   call MPI_Recv(ibuff(1:sizeInd(i+1)),sizeInd(i+1),&
                        MPI_INTEGER8,i,tag2,HYDRO_COMM_WORLD,mpp_status,ierr)
                    do k = 1, sizeInd(i+1)
                       outV(ibuff(k)) = vbuff(k)

--- a/src/MPP/module_mpp_ReachLS.F90
+++ b/src/MPP/module_mpp_ReachLS.F90
@@ -82,30 +82,30 @@ MODULE MODULE_mpp_ReachLS
      if(my_id .ne. IO_id) then
 
           tag = 101
-          call mpi_send(LLINKLEN,1,MPI_INTEGER, IO_id,     &
+          call MPI_Send(LLINKLEN,1,MPI_INTEGER, IO_id,     &
                 tag,HYDRO_COMM_WORLD,ierr)
           if(LLINKLEN .gt. 0) then
               tag = 102
-              call mpi_send(LLINKIDINDX,LLINKLEN,MPI_INTEGER, IO_id,     &
+              call MPI_Send(LLINKIDINDX,LLINKLEN,MPI_INTEGER, IO_id,     &
                     tag,HYDRO_COMM_WORLD,ierr)
               tag = 103
-              call mpi_send(LinkV,LLINKLEN,MPI_DOUBLE_PRECISION, IO_id,     &
+              call MPI_Send(LinkV,LLINKLEN,MPI_DOUBLE_PRECISION, IO_id,     &
                    tag,HYDRO_COMM_WORLD,ierr)
           endif
       else
           do i = 0, numprocs - 1
             if(i .ne. IO_id) then
                 tag = 101
-                call mpi_recv(lsize,1,MPI_INTEGER, i,     &
+                call MPI_Recv(lsize,1,MPI_INTEGER, i,     &
                             tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                 if(lsize .gt. 0) then
                       allocate(lindex(lsize) )
                       allocate(tmpBuf(lsize) )
                       tag = 102
-                      call mpi_recv(lindex,lsize,MPI_INTEGER, i,     &
+                      call MPI_Recv(lindex,lsize,MPI_INTEGER, i,     &
                             tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                       tag = 103
-                      call mpi_recv(tmpBuf,lsize,&
+                      call MPI_Recv(tmpBuf,lsize,&
                             MPI_DOUBLE_PRECISION,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                       do k = 1, lsize
                           gLinkV_r8(lindex(k)) = gLinkV_r8(lindex(k)) + tmpBuf(k)
@@ -146,30 +146,30 @@ MODULE MODULE_mpp_ReachLS
      if(my_id .ne. IO_id) then
 
           tag = 101
-          call mpi_send(LLINKLEN,1,MPI_INTEGER, IO_id,     &
+          call MPI_Send(LLINKLEN,1,MPI_INTEGER, IO_id,     &
                 tag,HYDRO_COMM_WORLD,ierr)
           if(LLINKLEN .gt. 0) then
               tag = 102
-              call mpi_send(LLINKIDINDX,LLINKLEN,MPI_INTEGER, IO_id,     &
+              call MPI_Send(LLINKIDINDX,LLINKLEN,MPI_INTEGER, IO_id,     &
                     tag,HYDRO_COMM_WORLD,ierr)
               tag = 103
-              call mpi_send(LinkV,LLINKLEN,MPI_REAL, IO_id,     &
+              call MPI_Send(LinkV,LLINKLEN,MPI_REAL, IO_id,     &
                    tag,HYDRO_COMM_WORLD,ierr)
           endif
       else
           do i = 0, numprocs - 1
             if(i .ne. IO_id) then
                 tag = 101
-                call mpi_recv(lsize,1,MPI_INTEGER, i,     &
+                call MPI_Recv(lsize,1,MPI_INTEGER, i,     &
                             tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                 if(lsize .gt. 0) then
                       allocate(lindex(lsize) )
                       allocate(tmpBuf(lsize) )
                       tag = 102
-                      call mpi_recv(lindex,lsize,MPI_INTEGER, i,     &
+                      call MPI_Recv(lindex,lsize,MPI_INTEGER, i,     &
                             tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                       tag = 103
-                      call mpi_recv(tmpBuf,lsize,&
+                      call MPI_Recv(tmpBuf,lsize,&
                             MPI_REAL,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                       do k = 1, lsize
                           gLinkV_r4(lindex(k)) = gLinkV_r4(lindex(k)) + tmpBuf(k)
@@ -204,14 +204,14 @@ MODULE MODULE_mpp_ReachLS
 
      if(my_id .ne. IO_id) then
           tag = 102
-          call mpi_send(gLinkV,gnlinksl,MPI_DOUBLE_PRECISION, IO_id,     &
+          call MPI_Send(gLinkV,gnlinksl,MPI_DOUBLE_PRECISION, IO_id,     &
                 tag,HYDRO_COMM_WORLD,ierr)
       else
           gLinkV_r = gLinkV
           do i = 0, numprocs - 1
             if(i .ne. IO_id) then
                tag = 102
-               call mpi_recv(gLinkV,gnlinksl,&
+               call MPI_Recv(gLinkV,gnlinksl,&
                    MPI_DOUBLE_PRECISION,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                gLinkV_r = gLinkV_r + gLinkV
             end if
@@ -237,14 +237,14 @@ MODULE MODULE_mpp_ReachLS
 
      if(my_id .ne. IO_id) then
           tag = 102
-          call mpi_send(gLinkV,gnlinksl,MPI_REAL, IO_id,     &
+          call MPI_Send(gLinkV,gnlinksl,MPI_REAL, IO_id,     &
                 tag,HYDRO_COMM_WORLD,ierr)
       else
           gLinkV_r = gLinkV
           do i = 0, numprocs - 1
             if(i .ne. IO_id) then
                tag = 102
-               call mpi_recv(gLinkV,gnlinksl,&
+               call MPI_Recv(gLinkV,gnlinksl,&
                    MPI_REAL,i,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                gLinkV_r = gLinkV_r + gLinkV
             end if
@@ -260,7 +260,7 @@ MODULE MODULE_mpp_ReachLS
      real, dimension(:) :: inV
      integer :: ierr
      call ReachLS_write_io(inV,outV)
-     call mpi_bcast(outV(1:gnlinksl),gnlinksl,MPI_REAL,   &
+     call MPI_Bcast(outV(1:gnlinksl),gnlinksl,MPI_REAL,   &
             IO_id,HYDRO_COMM_WORLD,ierr)
   end subroutine gbcastReal
 
@@ -277,7 +277,7 @@ MODULE MODULE_mpp_ReachLS
             bsize = linkls_e(i+1) - linkls_s(i+1) + 1
          if(linkls_e(i+1) .gt. 0) then
             if(my_id .eq. i) tmpV(1:bsize) = inV(1:bsize)
-            call mpi_bcast(tmpV(1:bsize),bsize,MPI_REAL,   &
+            call MPI_Bcast(tmpV(1:bsize),bsize,MPI_REAL,   &
                 i,HYDRO_COMM_WORLD,ierr)
             do j = 1, size1
                 do k = 1, bsize
@@ -304,7 +304,7 @@ MODULE MODULE_mpp_ReachLS
      integer :: ierr, k, i, m, j, bsize
      outV = 0
      call ReachLS_write_io(inV,gbuf)
-     call mpi_bcast(gbuf,gnlinksl,MPI_REAL,   &
+     call MPI_Bcast(gbuf,gnlinksl,MPI_REAL,   &
             IO_id,HYDRO_COMM_WORLD,ierr)
      do j = 1, size1
         outV(j) = gbuf(index(j))
@@ -320,7 +320,7 @@ MODULE MODULE_mpp_ReachLS
      integer, dimension(:) :: inV
      integer :: ierr
      call ReachLS_write_io(inV,outV)
-     call mpi_bcast(outV(1:gnlinksl),gnlinksl,MPI_INTEGER,   &
+     call MPI_Bcast(outV(1:gnlinksl),gnlinksl,MPI_INTEGER,   &
             IO_id,HYDRO_COMM_WORLD,ierr)
   end subroutine gbcastInt
 
@@ -330,7 +330,7 @@ MODULE MODULE_mpp_ReachLS
       integer(kind=int64), dimension(:) :: inV
       integer :: ierr
       call ReachLS_write_io(inV,outV)
-      call mpi_bcast(outV(1:gnlinksl),gnlinksl,MPI_INTEGER8,   &
+      call MPI_Bcast(outV(1:gnlinksl),gnlinksl,MPI_INTEGER8,   &
               IO_id,HYDRO_COMM_WORLD,ierr)
   end subroutine gbcastInt8
 
@@ -347,7 +347,7 @@ MODULE MODULE_mpp_ReachLS
 
        call ReachLS_write_io(LINKID,gLinkId)
 
-       call mpi_bcast(gLinkId(1:glinksl),glinksl,MPI_INTEGER8,   &
+       call MPI_Bcast(gLinkId(1:glinksl),glinksl,MPI_INTEGER8,   &
             IO_id,HYDRO_COMM_WORLD,ierr)
 
        ! The following loops are replaced by a hashtable-based algorithm
@@ -386,8 +386,8 @@ MODULE MODULE_mpp_ReachLS
      integer :: i, ii, ierr
 
 ! get my_id and numprocs
-     call MPI_COMM_RANK( HYDRO_COMM_WORLD, my_id, ierr )
-     call MPI_COMM_SIZE( HYDRO_COMM_WORLD, numprocs, ierr )
+     call MPI_Comm_rank( HYDRO_COMM_WORLD, my_id, ierr )
+     call MPI_Comm_size( HYDRO_COMM_WORLD, numprocs, ierr )
 
 
      nlinksl = glinksl / numprocs
@@ -453,7 +453,7 @@ MODULE MODULE_mpp_ReachLS
          if(my_id .eq. n-1) then
              tmpS = sDataRec
          endif
-         call mpi_bcast(tmpS,numprocs,MPI_INTEGER,   &
+         call MPI_Bcast(tmpS,numprocs,MPI_INTEGER,   &
             n-1,HYDRO_COMM_WORLD,ierr)
          rDataRec(n) = tmpS(n)
      enddo
@@ -475,7 +475,7 @@ MODULE MODULE_mpp_ReachLS
                 endif
             else
                 if(aLinksl(i) .gt. 0) then
-                    call mpi_send(inV(linkls_s(i):linkls_e(i)), &
+                    call MPI_Send(inV(linkls_s(i):linkls_e(i)), &
                         aLinksl(i), &
                         MPI_REAL, i-1 ,tag,HYDRO_COMM_WORLD,ierr)
                 endif
@@ -483,7 +483,7 @@ MODULE MODULE_mpp_ReachLS
          end do
       else
          if(aLinksl(my_id+1) .gt. 0) then
-             call mpi_recv(outV(1:(linkls_e(my_id+1)-linkls_s(my_id+1)+1) ), &  !! this one has +1!
+             call MPI_Recv(outV(1:(linkls_e(my_id+1)-linkls_s(my_id+1)+1) ), &  !! this one has +1!
               aLinksl(my_id+1),                                        &
               MPI_REAL, io_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
          endif
@@ -505,7 +505,7 @@ MODULE MODULE_mpp_ReachLS
                 endif
             else
                 if(aLinksl(i) .gt. 0) then
-                    call mpi_send(inV(linkls_s(i):linkls_e(i)), &
+                    call MPI_Send(inV(linkls_s(i):linkls_e(i)), &
                         aLinksl(i), &
                         MPI_REAL8, i-1 ,tag,HYDRO_COMM_WORLD,ierr)
                 endif
@@ -513,7 +513,7 @@ MODULE MODULE_mpp_ReachLS
          end do
       else
          if(aLinksl(my_id+1) .gt. 0) then
-             call mpi_recv(outV(1:(linkls_e(my_id+1)-linkls_s(my_id+1)+1) ), &  !! this one has +1!
+             call MPI_Recv(outV(1:(linkls_e(my_id+1)-linkls_s(my_id+1)+1) ), &  !! this one has +1!
               aLinksl(my_id+1),                                        &
               MPI_REAL8, io_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
          endif
@@ -535,7 +535,7 @@ MODULE MODULE_mpp_ReachLS
                 endif
             else
                if(aLinksl(i) .gt. 0) then
-                  call mpi_send(inV(linkls_s(i):linkls_e(i)), &
+                  call MPI_Send(inV(linkls_s(i):linkls_e(i)), &
                       aLinksl(i),                &
                       MPI_INTEGER, i-1,tag,HYDRO_COMM_WORLD,ierr)
                endif
@@ -543,7 +543,7 @@ MODULE MODULE_mpp_ReachLS
          end do
       else
           if(aLinksl(my_id+1) .gt. 0) then
-               call mpi_recv(outV(1:linkls_e(my_id+1)-linkls_s(my_id+1)+1), &
+               call MPI_Recv(outV(1:linkls_e(my_id+1)-linkls_s(my_id+1)+1), &
                     alinksl(my_id+1),                           &
                     MPI_INTEGER, io_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
           endif
@@ -567,7 +567,7 @@ MODULE MODULE_mpp_ReachLS
                   endif
               else
                   if(aLinksl(i) .gt. 0) then
-                      call mpi_send(inV(linkls_s(i):linkls_e(i)), &
+                      call MPI_Send(inV(linkls_s(i):linkls_e(i)), &
                               aLinksl(i),                &
                               MPI_INTEGER8, i-1,tag,HYDRO_COMM_WORLD,ierr)
                   endif
@@ -575,7 +575,7 @@ MODULE MODULE_mpp_ReachLS
           end do
       else
           if(aLinksl(my_id+1) .gt. 0) then
-              call mpi_recv(outV(1:linkls_e(my_id+1)-linkls_s(my_id+1)+1), &
+              call MPI_Recv(outV(1:linkls_e(my_id+1)-linkls_s(my_id+1)+1), &
                       alinksl(my_id+1),                           &
                       MPI_INTEGER8, io_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
           endif
@@ -602,8 +602,8 @@ MODULE MODULE_mpp_ReachLS
               endif
            else
               if(aLinksl(i) .gt. 0) then
-                 ! The mpi_send takes what you give it and THEN treats each caracter as an array element.
-                 call mpi_send(inV(linkls_s(i):linkls_e(i)),       &
+                 ! The MPI_Send takes what you give it and THEN treats each caracter as an array element.
+                 call MPI_Send(inV(linkls_s(i):linkls_e(i)),       &
                       strLen*aLinksl(i),                           &
                       MPI_CHARACTER, i-1, tag, HYDRO_COMM_WORLD, ierr)
               endif
@@ -611,8 +611,8 @@ MODULE MODULE_mpp_ReachLS
         end do
      else
         if(aLinksl(my_id+1) .gt. 0) then
-           ! The mpi_recv treats each caracter as an array element.
-           call mpi_recv(outV(1 : (linkls_e(my_id+1)-linkls_s(my_id+1)+1) ), &  !jlm should have +1
+           ! The MPI_Recv treats each caracter as an array element.
+           call MPI_Recv(outV(1 : (linkls_e(my_id+1)-linkls_s(my_id+1)+1) ), &  !jlm should have +1
                 strLen*alinksl(my_id+1),                                              &
                 MPI_CHARACTER, io_id, tag, HYDRO_COMM_WORLD, mpp_status,ierr          )
         endif
@@ -637,7 +637,7 @@ MODULE MODULE_mpp_ReachLS
             else
                 if(aLinksl(i) .gt. 0) then
 
-                    call mpi_recv(outV(linkls_s(i):linkls_e(i)), &
+                    call MPI_Recv(outV(linkls_s(i):linkls_e(i)), &
                          aLinksl(i),                            &
                          MPI_REAL,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                 endif
@@ -647,7 +647,7 @@ MODULE MODULE_mpp_ReachLS
           if(aLinksl(my_id+1) .gt. 0) then
                tag = 12
                ss = size(inv,1)
-               call mpi_send(inV(1:aLinksl(my_id+1) ), &
+               call MPI_Send(inV(1:aLinksl(my_id+1) ), &
                       aLinksl(my_id+1),                      &
                       MPI_REAL,io_id,tag,HYDRO_COMM_WORLD,ierr)
           endif
@@ -671,7 +671,7 @@ MODULE MODULE_mpp_ReachLS
             else
                 if(aLinksl(i) .gt. 0) then
 
-                    call mpi_recv(outV(linkls_s(i):linkls_e(i)), &
+                    call MPI_Recv(outV(linkls_s(i):linkls_e(i)), &
                          aLinksl(i),                            &
                          MPI_REAL8,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                 endif
@@ -681,7 +681,7 @@ MODULE MODULE_mpp_ReachLS
           if(aLinksl(my_id+1) .gt. 0) then
                tag = 12
                ss = size(inv,1)
-               call mpi_send(inV(1:aLinksl(my_id+1) ), &
+               call MPI_Send(inV(1:aLinksl(my_id+1) ), &
                       aLinksl(my_id+1),                      &
                       MPI_REAL8,io_id,tag,HYDRO_COMM_WORLD,ierr)
           endif
@@ -705,7 +705,7 @@ MODULE MODULE_mpp_ReachLS
             else
                if(aLinksl(i) .gt. 0) then
                   tag = 12
-                  call mpi_recv(outV(linkls_s(i):linkls_e(i)), &
+                  call MPI_Recv(outV(linkls_s(i):linkls_e(i)), &
                        aLinksl(i),                             &
                        MPI_INTEGER,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                endif
@@ -714,7 +714,7 @@ MODULE MODULE_mpp_ReachLS
       else
            if(aLinksl(my_id+1) .gt. 0) then
                 tag = 12
-                call mpi_send(inV(1:aLinksl(my_id+1) ), &
+                call MPI_Send(inV(1:aLinksl(my_id+1) ), &
                       aLinksl(my_id+1),                      &
                       MPI_INTEGER,io_id,tag,HYDRO_COMM_WORLD,ierr)
            endif
@@ -737,7 +737,7 @@ MODULE MODULE_mpp_ReachLS
               else
                   if(aLinksl(i) .gt. 0) then
                       tag = 12
-                      call mpi_recv(outV(linkls_s(i):linkls_e(i)), &
+                      call MPI_Recv(outV(linkls_s(i):linkls_e(i)), &
                               aLinksl(i),                             &
                               MPI_INTEGER8,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                   endif
@@ -746,7 +746,7 @@ MODULE MODULE_mpp_ReachLS
       else
           if(aLinksl(my_id+1) .gt. 0) then
               tag = 12
-              call mpi_send(inV(1:aLinksl(my_id+1) ), &
+              call MPI_Send(inV(1:aLinksl(my_id+1) ), &
                       aLinksl(my_id+1),                      &
                       MPI_INTEGER8,io_id,tag,HYDRO_COMM_WORLD,ierr)
           endif
@@ -770,7 +770,7 @@ MODULE MODULE_mpp_ReachLS
             else
                if(aLinksl(i) .gt. 0) then
                   tag = 12
-                  call mpi_recv(outV(linkls_s(i):linkls_e(i)), &
+                  call MPI_Recv(outV(linkls_s(i):linkls_e(i)), &
                        aLinksl(i),                             &
                        MPI_INTEGER,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                endif
@@ -779,7 +779,7 @@ MODULE MODULE_mpp_ReachLS
       else
            if(aLinksl(my_id+1) .gt. 0) then
                 tag = 12
-                call mpi_send(inV(1:aLinksl(my_id+1) ), &
+                call MPI_Send(inV(1:aLinksl(my_id+1) ), &
                       aLinksl(my_id+1),                      &
                       MPI_INTEGER,io_id,tag,HYDRO_COMM_WORLD,ierr)
            endif
@@ -803,7 +803,7 @@ MODULE MODULE_mpp_ReachLS
             else
                 if(aLinksl(i) .gt. 0) then
                     tag = 12
-                    call mpi_recv(outV(linkls_s(i):linkls_e(i)), &
+                    call MPI_Recv(outV(linkls_s(i):linkls_e(i)), &
                          aLinksl(i),                            &
                          MPI_REAL,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                 endif
@@ -812,7 +812,7 @@ MODULE MODULE_mpp_ReachLS
       else
           if(aLinksl(my_id+1) .gt. 0) then
                tag = 12
-               call mpi_send(inV(1:aLinksl(my_id+1) ), &
+               call MPI_Send(inV(1:aLinksl(my_id+1) ), &
                       aLinksl(my_id+1),                      &
                       MPI_REAL,io_id,tag,HYDRO_COMM_WORLD,ierr)
           endif
@@ -837,8 +837,8 @@ MODULE MODULE_mpp_ReachLS
               if(aLinksl(i) .gt. 0) then
                  tag = 12
                  ! ? seems asymmetric with ReachLS_decompChar
-                 call mpi_recv(outV( linkls_s(i) : linkls_e(i) ), &
-!                 call mpi_recv(outV( ((linkls_s(i)-1)+1) : (linkls_e(i)) ), &
+                 call MPI_Recv(outV( linkls_s(i) : linkls_e(i) ), &
+!                 call MPI_Recv(outV( ((linkls_s(i)-1)+1) : (linkls_e(i)) ), &
                       aLinksl(i),                                                  &
                       MPI_CHARACTER, i-1, tag, HYDRO_COMM_WORLD, mpp_status, ierr           )
               endif
@@ -847,8 +847,8 @@ MODULE MODULE_mpp_ReachLS
      else
         if(aLinksl(my_id+1) .gt. 0) then
            tag = 12
-           ! The mpi_send takes what you give it and THEN treats each caracter as an array element.
-           call mpi_send(inV(1:aLinksl(my_id+1)),              &
+           ! The MPI_Send takes what you give it and THEN treats each caracter as an array element.
+           call MPI_Send(inV(1:aLinksl(my_id+1)),              &
                 aLinksl(my_id+1),                       &
                 MPI_CHARACTER, io_id, tag, HYDRO_COMM_WORLD, ierr)
         endif
@@ -984,7 +984,7 @@ MODULE MODULE_mpp_ReachLS
 
     ToInd(my_id+1) = kk
     do i = 0, numprocs - 1
-       call mpi_bcast(ToInd(i+1),1,MPI_INTEGER8,   &
+       call MPI_Bcast(ToInd(i+1),1,MPI_INTEGER8,   &
             i,HYDRO_COMM_WORLD,ierr)
     end do
 
@@ -1025,7 +1025,7 @@ MODULE MODULE_mpp_ReachLS
                 endif
             else
                 if(ssize .gt. 0 ) then
-                   call mpi_send(inV(start:start+ssize-1), ssize,       &
+                   call MPI_Send(inV(start:start+ssize-1), ssize,       &
                       MPI_INTEGER, i-1,tag,HYDRO_COMM_WORLD,ierr)
                 endif
             endif
@@ -1038,7 +1038,7 @@ MODULE MODULE_mpp_ReachLS
               endif
               if( lsize .gt. 0) then
                   allocate(outV(lsize) )
-                  call mpi_recv(outV,lsize,                           &
+                  call MPI_Recv(outV,lsize,                           &
                         MPI_INTEGER, io_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
               endif
       endif
@@ -1082,7 +1082,7 @@ MODULE MODULE_mpp_ReachLS
                   endif
               else
                   if(ssize .gt. 0 ) then
-                      call mpi_send(inV(start:start+ssize-1), ssize,       &
+                      call MPI_Send(inV(start:start+ssize-1), ssize,       &
                               MPI_INTEGER8, i-1,tag,HYDRO_COMM_WORLD,ierr)
                   endif
               endif
@@ -1095,7 +1095,7 @@ MODULE MODULE_mpp_ReachLS
           endif
           if( lsize .gt. 0) then
               allocate(outV(lsize) )
-              call mpi_recv(outV,lsize,                           &
+              call MPI_Recv(outV,lsize,                           &
                       MPI_INTEGER8, io_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
           endif
       endif
@@ -1134,7 +1134,7 @@ MODULE MODULE_mpp_ReachLS
                 endif
             else
                 if(rsize .gt. 0 ) then
-                  call mpi_recv(outV(start:start+rsize-1), rsize,          &
+                  call MPI_Recv(outV(start:start+rsize-1), rsize,          &
                         MPI_INTEGER, i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                 endif
             endif
@@ -1146,7 +1146,7 @@ MODULE MODULE_mpp_ReachLS
                    lsize = ncomsize
               endif
               if( lsize .gt. 0) then
-                   call mpi_send(inV, lsize,       &
+                   call MPI_Send(inV, lsize,       &
                       MPI_INTEGER, io_id,tag,HYDRO_COMM_WORLD,ierr)
               endif
       endif
@@ -1185,7 +1185,7 @@ MODULE MODULE_mpp_ReachLS
                   endif
               else
                   if(rsize .gt. 0 ) then
-                      call mpi_recv(outV(start:start+rsize-1), rsize,          &
+                      call MPI_Recv(outV(start:start+rsize-1), rsize,          &
                               MPI_INTEGER8, i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                   endif
               endif
@@ -1197,7 +1197,7 @@ MODULE MODULE_mpp_ReachLS
               lsize = ncomsize
           endif
           if( lsize .gt. 0) then
-              call mpi_send(inV, lsize,       &
+              call MPI_Send(inV, lsize,       &
                       MPI_INTEGER8, io_id,tag,HYDRO_COMM_WORLD,ierr)
           endif
       endif
@@ -1239,7 +1239,7 @@ MODULE MODULE_mpp_ReachLS
       if(my_id .ne. IO_id) then
           tag = 72
           if(lnsizes(my_id + 1) .gt. 0) then
-             call mpi_recv(bufid,lnsizes(my_id + 1),&
+             call MPI_Recv(bufid,lnsizes(my_id + 1),&
                    MPI_INTEGER,io_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
           endif
       else
@@ -1247,7 +1247,7 @@ MODULE MODULE_mpp_ReachLS
             if(i .ne. my_id) then
                tag = 72
                if(lnsizes(i+1) .gt. 0) then
-                  call mpi_send(buf(istart(i+1):istart(i+1)+lnsizes(i+1)-1),  &
+                  call MPI_Send(buf(istart(i+1):istart(i+1)+lnsizes(i+1)-1),  &
                       lnsizes(i+1),MPI_INTEGER,i, tag,HYDRO_COMM_WORLD,ierr)
                endif
             else
@@ -1295,7 +1295,7 @@ MODULE MODULE_mpp_ReachLS
       if(my_id .ne. IO_id) then
           tag = 72
           if(lnsizes(my_id + 1) .gt. 0) then
-              call mpi_recv(bufid,lnsizes(my_id + 1),&
+              call MPI_Recv(bufid,lnsizes(my_id + 1),&
                       MPI_INTEGER8,io_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
           endif
       else
@@ -1303,7 +1303,7 @@ MODULE MODULE_mpp_ReachLS
               if(i .ne. my_id) then
                   tag = 72
                   if(lnsizes(i+1) .gt. 0) then
-                      call mpi_send(buf(istart(i+1):istart(i+1)+lnsizes(i+1)-1),  &
+                      call MPI_Send(buf(istart(i+1):istart(i+1)+lnsizes(i+1)-1),  &
                               lnsizes(i+1),MPI_INTEGER8,i, tag,HYDRO_COMM_WORLD,ierr)
                   endif
               else
@@ -1343,7 +1343,7 @@ MODULE MODULE_mpp_ReachLS
       if(my_id .ne. IO_id) then
           tag = 72
           if(lnsizes(my_id + 1) .gt. 0) then
-             call mpi_recv(bufid,lnsizes(my_id + 1),&
+             call MPI_Recv(bufid,lnsizes(my_id + 1),&
                    MPI_DOUBLE_PRECISION,io_id,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
           endif
       else
@@ -1351,7 +1351,7 @@ MODULE MODULE_mpp_ReachLS
             if(i .ne. my_id) then
                tag = 72
                if(lnsizes(i+1) .gt. 0) then
-                  call mpi_send(buf(istart(i+1):istart(i+1)+lnsizes(i+1)-1),  &
+                  call MPI_Send(buf(istart(i+1):istart(i+1)+lnsizes(i+1)-1),  &
                       lnsizes(i+1),MPI_DOUBLE_PRECISION,i, tag,HYDRO_COMM_WORLD,ierr)
                endif
             else
@@ -1395,15 +1395,15 @@ MODULE MODULE_mpp_ReachLS
                 end do
             else
                   tag = 82
-                  call mpi_recv(tmpSize,1,MPI_INTEGER,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+                  call MPI_Recv(tmpSize,1,MPI_INTEGER,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                   if(tmpSize .gt. 0) then
                       allocate(buf(tmpSize))
                       allocate(tmpInd(tmpSize))
                       tag = 83
-                      call mpi_recv(tmpInd, tmpSize , &
+                      call MPI_Recv(tmpInd, tmpSize , &
                            MPI_INTEGER,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                       tag = 84
-                      call mpi_recv(buf, tmpSize , &
+                      call MPI_Recv(buf, tmpSize , &
                            MPI_INTEGER,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                       do k = 1, tmpSize
                          if(buf(k) .ne. flag) then
@@ -1417,13 +1417,13 @@ MODULE MODULE_mpp_ReachLS
          end do
       else
           tag = 82
-          call mpi_send(size,1,MPI_INTEGER,io_id,tag,HYDRO_COMM_WORLD,ierr)
+          call MPI_Send(size,1,MPI_INTEGER,io_id,tag,HYDRO_COMM_WORLD,ierr)
           if(size .gt. 0) then
              tag = 83
-             call mpi_send(ind(1:size),size, &
+             call MPI_Send(ind(1:size),size, &
                  MPI_INTEGER,io_id,tag,HYDRO_COMM_WORLD,ierr)
              tag = 84
-             call mpi_send(inVar(1:size),size, &
+             call MPI_Send(inVar(1:size),size, &
                  MPI_INTEGER,io_id,tag,HYDRO_COMM_WORLD,ierr)
           endif
       endif
@@ -1460,15 +1460,15 @@ MODULE MODULE_mpp_ReachLS
                   end do
               else
                   tag = 82
-                  call mpi_recv(tmpSize,1,MPI_INTEGER,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
+                  call MPI_Recv(tmpSize,1,MPI_INTEGER,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                   if(tmpSize .gt. 0) then
                       allocate(buf(tmpSize))
                       allocate(tmpInd(tmpSize))
                       tag = 83
-                      call mpi_recv(tmpInd, tmpSize , &
+                      call MPI_Recv(tmpInd, tmpSize , &
                               MPI_INTEGER,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                       tag = 84
-                      call mpi_recv(buf, tmpSize , &
+                      call MPI_Recv(buf, tmpSize , &
                               MPI_INTEGER8,i-1,tag,HYDRO_COMM_WORLD,mpp_status,ierr)
                       do k = 1, tmpSize
                           if(buf(k) .ne. flag) then
@@ -1482,13 +1482,13 @@ MODULE MODULE_mpp_ReachLS
           end do
       else
           tag = 82
-          call mpi_send(size,1,MPI_INTEGER,io_id,tag,HYDRO_COMM_WORLD,ierr)
+          call MPI_Send(size,1,MPI_INTEGER,io_id,tag,HYDRO_COMM_WORLD,ierr)
           if(size .gt. 0) then
               tag = 83
-              call mpi_send(ind(1:size),size, &
+              call MPI_Send(ind(1:size),size, &
                       MPI_INTEGER,io_id,tag,HYDRO_COMM_WORLD,ierr)
               tag = 84
-              call mpi_send(inVar(1:size),size, &
+              call MPI_Send(inVar(1:size),size, &
                       MPI_INTEGER8,io_id,tag,HYDRO_COMM_WORLD,ierr)
           endif
       endif

--- a/src/Routing/module_NWM_io.F90
+++ b/src/Routing/module_NWM_io.F90
@@ -172,7 +172,7 @@ subroutine output_chrt_NWM(domainId)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
+      call MPI_Comm_rank( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -1144,7 +1144,7 @@ subroutine output_NoahMP_NWM(outDir,iGrid,output_timestep,itime,startdate,date,i
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
+      call MPI_Comm_rank( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -1857,7 +1857,7 @@ subroutine output_rt_NWM(domainId,iGrid)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
+      call MPI_Comm_rank( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -2433,7 +2433,7 @@ subroutine output_lakes_NWM(domainId,iGrid)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
+      call MPI_Comm_rank( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -3125,7 +3125,7 @@ subroutine output_chrtout_grd_NWM(domainId,iGrid)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
+      call MPI_Comm_rank( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -3613,7 +3613,7 @@ subroutine output_lsmOut_NWM(domainId)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
+      call MPI_Comm_rank( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -4067,7 +4067,7 @@ implicit none
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
+      call MPI_Comm_rank( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -4375,7 +4375,7 @@ subroutine output_chanObs_NWM(domainId)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
+      call MPI_Comm_rank( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -5090,7 +5090,7 @@ subroutine output_gw_NWM(domainId,iGrid)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
+      call MPI_Comm_rank( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else

--- a/src/Routing/module_gw_gw2d.F90
+++ b/src/Routing/module_gw_gw2d.F90
@@ -801,12 +801,12 @@ deallocate(hh)
 
 #ifdef MPP_LAND
 
-call mpi_reduce(delcur, mpiDelcur, 1, MPI_REAL, MPI_SUM, 0, HYDRO_COMM_WORLD, ierr)
-call MPI_COMM_SIZE( HYDRO_COMM_WORLD, mpiSize, ierr )
+call MPI_Reduce(delcur, mpiDelcur, 1, MPI_REAL, MPI_SUM, 0, HYDRO_COMM_WORLD, ierr)
+call MPI_Comm_size( HYDRO_COMM_WORLD, mpiSize, ierr )
 
 if(my_id .eq. IO_id) delcur = mpiDelcur/mpiSize
 
-call mpi_bcast(delcur, 1, mpi_real, 0, HYDRO_COMM_WORLD, ierr)
+call MPI_Bcast(delcur, 1, MPI_REAL, 0, HYDRO_COMM_WORLD, ierr)
 
 #endif
 
@@ -886,10 +886,10 @@ if(my_id .eq. IO_id)  write(6,*) "Iteration", iter, "of", itermax, "error:", del
 #ifdef HYDRO_D
 #ifdef MPP_LAND
 
-      call MPI_REDUCE(dtot,gdtot,1, MPI_REAL, MPI_SUM, IO_id, HYDRO_COMM_WORLD, ierr)
-      call MPI_REDUCE(dtoa,gdtoa,1, MPI_REAL, MPI_SUM, IO_id, HYDRO_COMM_WORLD, ierr)
-      call MPI_REDUCE(eocn,geocn,1, MPI_REAL, MPI_SUM, IO_id, HYDRO_COMM_WORLD, ierr)
-      call MPI_REDUCE(ebot,gebot,1, MPI_REAL, MPI_SUM, IO_id, HYDRO_COMM_WORLD, ierr)
+      call MPI_Reduce(dtot,gdtot,1, MPI_REAL, MPI_SUM, IO_id, HYDRO_COMM_WORLD, ierr)
+      call MPI_Reduce(dtoa,gdtoa,1, MPI_REAL, MPI_SUM, IO_id, HYDRO_COMM_WORLD, ierr)
+      call MPI_Reduce(eocn,geocn,1, MPI_REAL, MPI_SUM, IO_id, HYDRO_COMM_WORLD, ierr)
+      call MPI_Reduce(ebot,gebot,1, MPI_REAL, MPI_SUM, IO_id, HYDRO_COMM_WORLD, ierr)
 
       if(my_id .eq. IO_id) then
         write (*,900)                         &
@@ -1239,11 +1239,11 @@ end subroutine aggregateQsgw
 ! ! Send (ZSPS,j)th equations.
 ! ! Receive (ZSPS+1,j)th equations.
 
- call mpi_cart_shift(cartGridComm, rowshift, 1, source, dest, ierr)
- call MPI_ISEND(zntmp, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, sendReq, ierr)
- call MPI_IRECV(   zn, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, recvReq, ierr)
- call mpi_wait(sendReq, mpp_status, ierr)
- call mpi_wait(recvReq, mpp_status, ierr)
+ call MPI_Cart_shift(cartGridComm, rowshift, 1, source, dest, ierr)
+ call MPI_Isend(zntmp, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, sendReq, ierr)
+ call MPI_Irecv(   zn, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, recvReq, ierr)
+ call MPI_Wait(sendReq, mpp_status, ierr)
+ call MPI_Wait(recvReq, mpp_status, ierr)
 
 #ifdef TIMING
         tf = click()
@@ -1271,9 +1271,9 @@ end subroutine aggregateQsgw
 #endif
 ! ! Receive (0,j)th equations.
 
- call mpi_cart_shift(cartGridComm, rowshift, -1, source, dest, ierr)
- call MPI_IRECV(   zn, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, recvReq, ierr)
- call mpi_wait(recvReq, mpp_status, ierr)
+ call MPI_Cart_shift(cartGridComm, rowshift, -1, source, dest, ierr)
+ call MPI_Irecv(   zn, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, recvReq, ierr)
+ call MPI_Wait(recvReq, mpp_status, ierr)
 
 #ifdef TIMING
         tf = click()
@@ -1305,11 +1305,11 @@ end subroutine aggregateQsgw
 ! ! Send (ZSPS,j)th equations.
 ! ! Receive (ZSPS+1,j)th equations.
 
- call mpi_cart_shift(cartGridComm, rowshift, 1, source, dest, ierr)
- call MPI_ISEND(zntmp, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, sendReq, ierr)
- call MPI_IRECV(   zn, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, recvReq, ierr)
- call mpi_wait(sendReq, mpp_status, ierr)
- call mpi_wait(recvReq, mpp_status, ierr)
+ call MPI_Cart_shift(cartGridComm, rowshift, 1, source, dest, ierr)
+ call MPI_Isend(zntmp, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, sendReq, ierr)
+ call MPI_Irecv(   zn, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, recvReq, ierr)
+ call MPI_Wait(sendReq, mpp_status, ierr)
+ call MPI_Wait(recvReq, mpp_status, ierr)
 #ifdef TIMING
         tf = click()
         call add_dt(ct,tf,ti,dt)
@@ -1339,8 +1339,8 @@ end subroutine aggregateQsgw
         call add_dt(ct,tf,ti,dt)
 #endif
 
- call mpi_cart_shift(cartGridComm, rowshift, -1, source, dest, ierr)
- call MPI_ISEND(zntmp, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, sendReq, ierr)
+ call MPI_Cart_shift(cartGridComm, rowshift, -1, source, dest, ierr)
+ call MPI_Isend(zntmp, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, sendReq, ierr)
 
         do 60 j = 1, XSPS
 ! Backward elimination in (0,j)th equations.
@@ -1352,7 +1352,7 @@ end subroutine aggregateQsgw
    70   continue
    60   continue
 
- call mpi_wait(sendReq, mpp_status, ierr)
+ call MPI_Wait(sendReq, mpp_status, ierr)
 
 
       else if (z_pid .lt. ZDNS) then
@@ -1362,9 +1362,9 @@ end subroutine aggregateQsgw
 #endif
 ! ! Receive (ZSPS+1,j)th equations.
 
- call mpi_cart_shift(cartGridComm, rowshift, 1, source, dest, ierr)
- call MPI_IRECV(   zn, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, recvReq, ierr)
- call mpi_wait(recvReq, mpp_status, ierr)
+ call MPI_Cart_shift(cartGridComm, rowshift, 1, source, dest, ierr)
+ call MPI_Irecv(   zn, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, recvReq, ierr)
+ call MPI_Wait(recvReq, mpp_status, ierr)
 
 #ifdef TIMING
         tf = click()
@@ -1397,11 +1397,11 @@ end subroutine aggregateQsgw
 ! ! Send (1,j)th equations.
 ! ! Receive (0,j)th equations.
 
- call mpi_cart_shift(cartGridComm, rowshift, -1, source, dest, ierr)
- call MPI_ISEND(zntmp, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, sendReq, ierr)
- call MPI_IRECV(   zn, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, recvReq, ierr)
- call mpi_wait(sendReq, mpp_status, ierr)
- call mpi_wait(recvReq, mpp_status, ierr)
+ call MPI_Cart_shift(cartGridComm, rowshift, -1, source, dest, ierr)
+ call MPI_Isend(zntmp, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, sendReq, ierr)
+ call MPI_Irecv(   zn, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, recvReq, ierr)
+ call MPI_Wait(sendReq, mpp_status, ierr)
+ call MPI_Wait(recvReq, mpp_status, ierr)
 
 #ifdef TIMING
         tf = click()
@@ -1427,8 +1427,8 @@ end subroutine aggregateQsgw
 #endif
 ! ! Send (ZSPS,j)th equations.
 
- call mpi_cart_shift(cartGridComm, rowshift, 1, source, dest, ierr)
- call MPI_ISEND(zntmp, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, sendReq, ierr)
+ call MPI_Cart_shift(cartGridComm, rowshift, 1, source, dest, ierr)
+ call MPI_Isend(zntmp, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, sendReq, ierr)
 
 #ifdef TIMING
         tf = click()
@@ -1445,7 +1445,7 @@ end subroutine aggregateQsgw
   110   continue
   100   continue
 
- call mpi_wait(sendReq, mpp_status, ierr)
+ call MPI_Wait(sendReq, mpp_status, ierr)
 
       else
 
@@ -1461,11 +1461,11 @@ end subroutine aggregateQsgw
 ! ! Send (1,j)th equations.
 ! ! Receive (0,j)th equations.
 
- call mpi_cart_shift(cartGridComm, rowshift, -1, source, dest, ierr)
- call MPI_ISEND(zntmp, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, sendReq, ierr)
- call MPI_IRECV(   zn, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, recvReq, ierr)
- call mpi_wait(sendReq, mpp_status, ierr)
- call mpi_wait(recvReq, mpp_status, ierr)
+ call MPI_Cart_shift(cartGridComm, rowshift, -1, source, dest, ierr)
+ call MPI_Isend(zntmp, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, sendReq, ierr)
+ call MPI_Irecv(   zn, cnt, MPI_REAL, dest, ZN_REC, cartGridComm, recvReq, ierr)
+ call MPI_Wait(sendReq, mpp_status, ierr)
+ call MPI_Wait(recvReq, mpp_status, ierr)
 
 #ifdef TIMING
         tf = click()
@@ -1550,11 +1550,11 @@ end subroutine aggregateQsgw
 ! ! Send (i,XSPS)th equations.
 ! ! Receive (i,(XSPS + 1))th equations.
 
- call mpi_cart_shift(cartGridComm, colshift, 1, source, dest, ierr)
- call MPI_ISEND(xntmp, cnt, MPI_REAL, dest, XN_REC, cartGridComm, sendReq, ierr)
- call MPI_IRECV(   xn, cnt, MPI_REAL, dest, XN_REC, cartGridComm, recvReq, ierr)
- call mpi_wait(sendReq, mpp_status, ierr)
- call mpi_wait(recvReq, mpp_status, ierr)
+ call MPI_Cart_shift(cartGridComm, colshift, 1, source, dest, ierr)
+ call MPI_Isend(xntmp, cnt, MPI_REAL, dest, XN_REC, cartGridComm, sendReq, ierr)
+ call MPI_Irecv(   xn, cnt, MPI_REAL, dest, XN_REC, cartGridComm, recvReq, ierr)
+ call MPI_Wait(sendReq, mpp_status, ierr)
+ call MPI_Wait(recvReq, mpp_status, ierr)
 
 #ifdef TIMING
         tf = click()
@@ -1585,9 +1585,9 @@ end subroutine aggregateQsgw
 #endif
 ! ! Receive (i,0)th equations.
 
- call mpi_cart_shift(cartGridComm, colshift, -1, source, dest, ierr)
- call MPI_IRECV(   xn, cnt, MPI_REAL, dest, XN_REC, cartGridComm, recvReq, ierr)
- call mpi_wait(recvReq, mpp_status, ierr)
+ call MPI_Cart_shift(cartGridComm, colshift, -1, source, dest, ierr)
+ call MPI_Irecv(   xn, cnt, MPI_REAL, dest, XN_REC, cartGridComm, recvReq, ierr)
+ call MPI_Wait(recvReq, mpp_status, ierr)
 
 #ifdef TIMING
         tf = click()
@@ -1618,11 +1618,11 @@ end subroutine aggregateQsgw
 ! ! Send (i,XSPS)th equations.
 ! ! Receive (i,(XSPS + 1))th equations.
 
- call mpi_cart_shift(cartGridComm, colshift, 1, source, dest, ierr)
- call MPI_ISEND(xntmp, cnt, MPI_REAL, dest, XN_REC, cartGridComm, sendReq, ierr)
- call MPI_IRECV(   xn, cnt, MPI_REAL, dest, XN_REC, cartGridComm, recvReq, ierr)
- call mpi_wait(sendReq, mpp_status, ierr)
- call mpi_wait(recvReq, mpp_status, ierr)
+ call MPI_Cart_shift(cartGridComm, colshift, 1, source, dest, ierr)
+ call MPI_Isend(xntmp, cnt, MPI_REAL, dest, XN_REC, cartGridComm, sendReq, ierr)
+ call MPI_Irecv(   xn, cnt, MPI_REAL, dest, XN_REC, cartGridComm, recvReq, ierr)
+ call MPI_Wait(sendReq, mpp_status, ierr)
+ call MPI_Wait(recvReq, mpp_status, ierr)
 #ifdef TIMING
         tf = click()
         call add_dt(ct,tf,ti,dt)
@@ -1651,8 +1651,8 @@ end subroutine aggregateQsgw
         tf = click()
         call add_dt(ct,tf,ti,dt)
 #endif
- call mpi_cart_shift(cartGridComm, colshift, -1, source, dest, ierr)
- call MPI_ISEND(xntmp, cnt, MPI_REAL, dest, XN_REC, cartGridComm, sendReq, ierr)
+ call MPI_Cart_shift(cartGridComm, colshift, -1, source, dest, ierr)
+ call MPI_Isend(xntmp, cnt, MPI_REAL, dest, XN_REC, cartGridComm, sendReq, ierr)
 
         do 60 i = 1, ZSPS
 ! Backward elimination in (i,0)th equations.
@@ -1666,7 +1666,7 @@ end subroutine aggregateQsgw
           r(i,j) = r(i,j) - b(i,j)*r(i,XSPS) - c(i,j)*r(i,1)
    70   continue
 
- call mpi_wait(sendReq, mpp_status, ierr)
+ call MPI_Wait(sendReq, mpp_status, ierr)
 
       else if (x_pid .lt. XDNS) then
 
@@ -1676,9 +1676,9 @@ end subroutine aggregateQsgw
 #endif
 ! ! Receive (i,XSPS+1)th equations.
 
- call mpi_cart_shift(cartGridComm, colshift, 1, source, dest, ierr)
- call MPI_IRECV(   xn, cnt, MPI_REAL, dest, XN_REC, cartGridComm, recvReq, ierr)
- call mpi_wait(recvReq, mpp_status, ierr)
+ call MPI_Cart_shift(cartGridComm, colshift, 1, source, dest, ierr)
+ call MPI_Irecv(   xn, cnt, MPI_REAL, dest, XN_REC, cartGridComm, recvReq, ierr)
+ call MPI_Wait(recvReq, mpp_status, ierr)
 
 #ifdef TIMING
         tf = click()
@@ -1708,11 +1708,11 @@ end subroutine aggregateQsgw
 #endif
 ! ! Send (i,1)th equations.
 ! ! Receive (i,0)th equations.
- call mpi_cart_shift(cartGridComm, colshift, -1, source, dest, ierr)
- call MPI_ISEND(xntmp, cnt, MPI_REAL, dest, XN_REC, cartGridComm, sendReq, ierr)
- call MPI_IRECV(   xn, cnt, MPI_REAL, dest, XN_REC, cartGridComm, recvReq, ierr)
- call mpi_wait(sendReq, mpp_status, ierr)
- call mpi_wait(recvReq, mpp_status, ierr)
+ call MPI_Cart_shift(cartGridComm, colshift, -1, source, dest, ierr)
+ call MPI_Isend(xntmp, cnt, MPI_REAL, dest, XN_REC, cartGridComm, sendReq, ierr)
+ call MPI_Irecv(   xn, cnt, MPI_REAL, dest, XN_REC, cartGridComm, recvReq, ierr)
+ call MPI_Wait(sendReq, mpp_status, ierr)
+ call MPI_Wait(recvReq, mpp_status, ierr)
 
 #ifdef TIMING
         tf = click()
@@ -1738,8 +1738,8 @@ end subroutine aggregateQsgw
 #endif
 ! ! Send (i,XSPS)th equations.
 
- call mpi_cart_shift(cartGridComm, colshift, 1, source, dest, ierr)
- call MPI_ISEND(xntmp, cnt, MPI_REAL, dest, XN_REC, cartGridComm, sendReq, ierr)
+ call MPI_Cart_shift(cartGridComm, colshift, 1, source, dest, ierr)
+ call MPI_Isend(xntmp, cnt, MPI_REAL, dest, XN_REC, cartGridComm, sendReq, ierr)
 #ifdef TIMING
         tf = click()
         call add_dt(ct,tf,ti,dt)
@@ -1757,7 +1757,7 @@ end subroutine aggregateQsgw
           r(i,j) = r(i,j) - c(i,j)*r(i,1) - b(i,j)*r(i,XSPS)
   110   continue
 
- call mpi_wait(sendReq, mpp_status, ierr)
+ call MPI_Wait(sendReq, mpp_status, ierr)
 
       else
 
@@ -1774,11 +1774,11 @@ end subroutine aggregateQsgw
 ! ! Send (i,1)th equations.
 ! ! Receive (i,0)th equations.
 
- call mpi_cart_shift(cartGridComm, colshift, -1, source, dest, ierr)
- call MPI_ISEND(xntmp, cnt, MPI_REAL, dest, XN_REC, cartGridComm, sendReq, ierr)
- call MPI_IRECV(   xn, cnt, MPI_REAL, dest, XN_REC, cartGridComm, recvReq, ierr)
- call mpi_wait(sendReq, mpp_status, ierr)
- call mpi_wait(recvReq, mpp_status, ierr)
+ call MPI_Cart_shift(cartGridComm, colshift, -1, source, dest, ierr)
+ call MPI_Isend(xntmp, cnt, MPI_REAL, dest, XN_REC, cartGridComm, sendReq, ierr)
+ call MPI_Irecv(   xn, cnt, MPI_REAL, dest, XN_REC, cartGridComm, recvReq, ierr)
+ call MPI_Wait(sendReq, mpp_status, ierr)
+ call MPI_Wait(recvReq, mpp_status, ierr)
 
 #ifdef TIMING
         tf = click()

--- a/src/Routing/module_reservoir_routing.F90
+++ b/src/Routing/module_reservoir_routing.F90
@@ -1,5 +1,5 @@
 ! Intended purpose is to provide a module for all subroutines related to
-! reservoir routing, including active management, level pool, and integrating live 
+! reservoir routing, including active management, level pool, and integrating live
 ! data feeds. As of NWMv2.0, this module stub can read in a timeslice file
 ! to incorporate data from external sources, should a data service become available.
 
@@ -83,7 +83,7 @@ subroutine read_reservoir_obs(domainId)
    ! If not MPI, then default to 0, which is the I/O ID.
    if(mppFlag .eq. 1) then
 #ifdef MPP_LAND
-      call MPI_COMM_RANK( HYDRO_COMM_WORLD, myId, ierr )
+      call MPI_Comm_rank( HYDRO_COMM_WORLD, myId, ierr )
       call nwmCheck(diagFlag,ierr,'ERROR: Unable to determine MPI process ID.')
 #endif
    else
@@ -92,7 +92,7 @@ subroutine read_reservoir_obs(domainId)
 
    ! Open up and read in the NetCDF file containing disharge data.
    if(myId .eq. 0) then
-      ! Initialize our missing flag to 0. If at any point we don't find a file, 
+      ! Initialize our missing flag to 0. If at any point we don't find a file,
       ! the flag value will go to 1 to indicate no files were found.
       missingFlag = 0
 

--- a/src/utils/module_hydro_stop.F90
+++ b/src/utils/module_hydro_stop.F90
@@ -35,7 +35,7 @@ contains
 !        call flush(my_id+90)
 
          call mpp_land_abort()
-         call MPI_finalize(ierr)
+         call MPI_Finalize(ierr)
 #else
          stop "FATAL ERROR: Program stopped. Recompile with environment variable HYDRO_D set to 1 for enhanced debug information."
 #endif


### PR DESCRIPTION
TYPE: text only, no impact

KEYWORDS: formatting, MPI

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Formatting MPI function calls to standard MPI style of `MPI_Foo_bar()`. This is only changing the capitalization of letters so it is a text only change and shouldn't touch anything else.

TESTS CONDUCTED: Built and ran Croton just to double check the text-only change didn't accidentally affect something else.

NOTE: tried switching from `mpi` to `mpi_f08` but because some of libraries and the models we couple with use the older style, meaning all the MPI types are integers, it currently won't work out.

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
