### PR TITLE
bugfix: optional and intent(inout) attributes for glacier arrays

### DIFF
--- a/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -586,9 +586,8 @@ contains
     real,    dimension(xstart:xend,ystart:yend), intent(out) :: seaice
     real,    dimension(xstart:xend,ystart:yend), intent(out) :: msftx
     real,    dimension(xstart:xend,ystart:yend), intent(out) :: msfty
-    ! the following two vars have xstart:xend,ystart:yend bounds
-    real,    dimension(:,:), intent(out), allocatable :: glact
-    real,    dimension(:,:), intent(out), allocatable :: vis_icealb
+    real,    dimension(xstart:xend,ystart:yend), intent(inout), optional :: glact
+    real,    dimension(xstart:xend,ystart:yend), intent(inout), optional :: vis_icealb
 
     character(len=256) :: units
     integer :: ierr

--- a/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -586,8 +586,8 @@ contains
     real,    dimension(xstart:xend,ystart:yend), intent(out) :: seaice
     real,    dimension(xstart:xend,ystart:yend), intent(out) :: msftx
     real,    dimension(xstart:xend,ystart:yend), intent(out) :: msfty
-    real,    dimension(xstart:xend,ystart:yend), intent(inout), optional :: glact
-    real,    dimension(xstart:xend,ystart:yend), intent(inout), optional :: vis_icealb
+    real,    dimension(:,:), intent(inout), allocatable :: glact
+    real,    dimension(:,:), intent(inout), allocatable :: vis_icealb
 
     character(len=256) :: units
     integer :: ierr
@@ -679,6 +679,8 @@ contains
           stop "FATAL ERROR: In module_hrldas_netcdf_io.F readland_hrldas()"// &
                " - crocus_opt on but netcdf read of glacinfo returned non-zero"
        end if
+
+       if (allocated(glact) .eqv. .false.) error stop "FATAL ERROR: glact not initialized but crocus is on"
        ! Get Glacier thickness (glact)
        call get_2d_netcdf("glacier_thickness", ncid, glact,   units, xstart, xend, ystart, yend, NOT_FATAL, ierr)
        if (ierr /= 0) then
@@ -687,6 +689,7 @@ contains
                ". Setting glacier thickness to 0.0"
        end if
 
+       if (allocated(vis_icealb) .eqv. .false.) error stop "FATAL ERROR: vis_icealb not initialized but crocus is on"
        ! Get visible ice albedo map (vis_icealb)
        call get_2d_netcdf("min_vis", ncid, vis_icealb,   units, xstart, xend, ystart, yend, NOT_FATAL, ierr)
        if (ierr /= 0) then


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: Crocus, Glacier, Variable Attribute

SOURCE: Soren Rasmussen, NCAR 

DESCRIPTION OF CHANGES: Changing Crocus glacier arrays from `allocatable` to `optional`. Allocated array `glact` was becoming unallocated upon entry to the `readland_hrldas` subroutine. Changing variable attribute to `optional` fixes this. Variable will never be allocated in the function so this is appropriate. Changing intent to `inout` also fixes this. 

TESTS CONDUCTED: Builds and runs Huijie Glacier domain.

NOTES: 

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
