### PR TITLE
Enhancement: liquid water fraction and forcing variable names

### DIFF
--- a/src/CPL/NoahMP_cpl/hrldas_drv_HYDRO.F
+++ b/src/CPL/NoahMP_cpl/hrldas_drv_HYDRO.F
@@ -74,7 +74,7 @@
 
        subroutine HYDRO_frocing_drv (indir,forc_typ, snow_assim,olddate,     &
           ixs, ixe,jxs,jxe,                       &
-          T2,Q2X,U,V,PRES,XLONG,SHORT,PRCP1,SNOWBL,lai,fpar,snodep, kt, FORCING_TIMESTEP,pcp_old)
+          T2,Q2X,U,V,PRES,XLONG,SHORT,PRCP1,lai,SNOWBL,fpar,snodep, kt, FORCING_TIMESTEP,pcp_old)
 
          use module_lsm_forcing, only: read_hydro_forcing
          use config_base, only: nlst

--- a/src/CPL/NoahMP_cpl/hrldas_drv_HYDRO.F
+++ b/src/CPL/NoahMP_cpl/hrldas_drv_HYDRO.F
@@ -74,7 +74,7 @@
 
        subroutine HYDRO_frocing_drv (indir,forc_typ, snow_assim,olddate,     &
           ixs, ixe,jxs,jxe,                       &
-          T2,Q2X,U,V,PRES,XLONG,SHORT,PRCP1,lai,lqf,fpar,snodep, kt, FORCING_TIMESTEP,pcp_old)
+          T2,Q2X,U,V,PRES,XLONG,SHORT,PRCP1,SNOWBL,lai,fpar,snodep, kt, FORCING_TIMESTEP,pcp_old)
 
          use module_lsm_forcing, only: read_hydro_forcing
          use config_base, only: nlst
@@ -84,18 +84,19 @@
          character(len=19) :: olddate
          character(len=*) :: indir
          real, dimension(ixs:ixe,jxs:jxe):: T2,Q2X,U,V,PRES,XLONG,SHORT,PRCP1, &
-                 lai, lqf, fpar, snodep, pcp_old
+                 lai, snowbl, fpar, snodep, pcp_old
          integer :: forc_typ, snow_assim, FORCING_TIMESTEP
 
          ix = ixe-ixs+1
          jx = jxe-jxs+1
          did = 1
+
          call read_hydro_forcing( &
             indir, olddate, &
             nlst(did)%hgrid,&
             ix,jx,forc_typ,snow_assim,  &
             T2,q2x,u,v,pres,xlong,short,prcp1,&
-            lai,lqf,fpar,snodep,FORCING_TIMESTEP*1.0,kt, pcp_old)
+            lai,snowbl,fpar,snodep,FORCING_TIMESTEP*1.0,kt, pcp_old)
        end subroutine HYDRO_frocing_drv
 
        subroutine get_greenfrac(inFile,greenfrac, idim, jdim, olddate,SHDMAX)

--- a/src/CPL/NoahMP_cpl/hrldas_drv_HYDRO.F
+++ b/src/CPL/NoahMP_cpl/hrldas_drv_HYDRO.F
@@ -74,7 +74,7 @@
 
        subroutine HYDRO_frocing_drv (indir,forc_typ, snow_assim,olddate,     &
           ixs, ixe,jxs,jxe,                       &
-          T2,Q2X,U,V,PRES,XLONG,SHORT,PRCP1,lai,fpar,snodep, kt, FORCING_TIMESTEP,pcp_old)
+          T2,Q2X,U,V,PRES,XLONG,SHORT,PRCP1,lai,lqf,fpar,snodep, kt, FORCING_TIMESTEP,pcp_old)
 
          use module_lsm_forcing, only: read_hydro_forcing
          use config_base, only: nlst
@@ -84,7 +84,7 @@
          character(len=19) :: olddate
          character(len=*) :: indir
          real, dimension(ixs:ixe,jxs:jxe):: T2,Q2X,U,V,PRES,XLONG,SHORT,PRCP1, &
-                 lai, fpar,snodep, pcp_old
+                 lai, lqf, fpar, snodep, pcp_old
          integer :: forc_typ, snow_assim, FORCING_TIMESTEP
 
          ix = ixe-ixs+1
@@ -95,7 +95,7 @@
             nlst(did)%hgrid,&
             ix,jx,forc_typ,snow_assim,  &
             T2,q2x,u,v,pres,xlong,short,prcp1,&
-            lai,fpar,snodep,FORCING_TIMESTEP*1.0,kt, pcp_old)
+            lai,lqf,fpar,snodep,FORCING_TIMESTEP*1.0,kt, pcp_old)
        end subroutine HYDRO_frocing_drv
 
        subroutine get_greenfrac(inFile,greenfrac, idim, jdim, olddate,SHDMAX)

--- a/src/CPL/NoahMP_cpl/hrldas_drv_HYDRO.F
+++ b/src/CPL/NoahMP_cpl/hrldas_drv_HYDRO.F
@@ -74,6 +74,8 @@
 
        subroutine HYDRO_frocing_drv (indir,forc_typ, snow_assim,olddate,     &
           ixs, ixe,jxs,jxe,                       &
+          forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+          forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
           T2,Q2X,U,V,PRES,XLONG,SHORT,PRCP1,lai,SNOWBL,fpar,snodep, kt, FORCING_TIMESTEP,pcp_old)
 
          use module_lsm_forcing, only: read_hydro_forcing
@@ -83,6 +85,16 @@
          integer ix,jx, kt
          character(len=19) :: olddate
          character(len=*) :: indir
+         character(len=256), intent(in)  :: forcing_name_T
+         character(len=256), intent(in)  :: forcing_name_Q
+         character(len=256), intent(in)  :: forcing_name_U
+         character(len=256), intent(in)  :: forcing_name_V
+         character(len=256), intent(in)  :: forcing_name_P
+         character(len=256), intent(in)  :: forcing_name_LW
+         character(len=256), intent(in)  :: forcing_name_SW
+         character(len=256), intent(in)  :: forcing_name_PR
+         character(len=256), intent(in)  :: forcing_name_SN
+         character(len=256), intent(in)  :: forcing_name_LF
          real, dimension(ixs:ixe,jxs:jxe):: T2,Q2X,U,V,PRES,XLONG,SHORT,PRCP1, &
                  lai, snowbl, fpar, snodep, pcp_old
          integer :: forc_typ, snow_assim, FORCING_TIMESTEP
@@ -95,6 +107,8 @@
             indir, olddate, &
             nlst(did)%hgrid,&
             ix,jx,forc_typ,snow_assim,  &
+            forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+            forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
             T2,q2x,u,v,pres,xlong,short,prcp1,&
             lai,snowbl,fpar,snodep,FORCING_TIMESTEP*1.0,kt, pcp_old)
        end subroutine HYDRO_frocing_drv

--- a/src/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/src/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -237,6 +237,7 @@ module module_NoahMP_hrldas_driver
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  STBLCPXY  ! stable carbon in deep soil [g/m2]
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  FASTCPXY  ! short-lived carbon, shallow soil [g/m2]
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  LAI       ! leaf area index
+  REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  LQF       ! liquid fraction
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  XSAIXY    ! stem area index
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  TAUSSXY   ! snow age factor
 
@@ -862,6 +863,7 @@ module module_NoahMP_hrldas_driver
   ALLOCATE ( STBLCPXY  (XSTART:XEND,YSTART:YEND) )  ! stable carbon in deep soil [g/m2]
   ALLOCATE ( FASTCPXY  (XSTART:XEND,YSTART:YEND) )  ! short-lived carbon, shallow soil [g/m2]
   ALLOCATE ( LAI       (XSTART:XEND,YSTART:YEND) )  ! leaf area index
+  ALLOCATE ( LQF       (XSTART:XEND,YSTART:YEND) )  ! liquid fraction
   ALLOCATE ( XSAIXY    (XSTART:XEND,YSTART:YEND) )  ! stem area index
   ALLOCATE ( TAUSSXY   (XSTART:XEND,YSTART:YEND) )  ! snow age factor
 
@@ -1061,6 +1063,7 @@ module module_NoahMP_hrldas_driver
   STBLCPXY   = undefined_real
   FASTCPXY   = undefined_real
   LAI        = undefined_real
+  LQF        = undefined_real
   XSAIXY     = undefined_real
   TAUSSXY    = undefined_real
   XLONIN     = undefined_real
@@ -1738,8 +1741,7 @@ end subroutine land_driver_ini
            CALL HYDRO_frocing_drv(trim(noah_lsm%indir), forc_typ, wrf_hydro%snow_assim,olddate,                      &
                xstart, xend, ystart, yend,    &
                T_PHY(:,1,:),QV_CURR(:,1,:),U_PHY(:,1,:),V_PHY(:,1,:),P8W(:,1,:),    &
-               GLW,SWDOWN,RAINBL_tmp,LAI,VEGFRA,state%SNOWH,ITIME,noah_lsm%FORCING_TIMESTEP,prcp0)
-
+               GLW,SWDOWN,RAINBL_tmp,LAI,LQF,VEGFRA,state%SNOWH,ITIME,noah_lsm%FORCING_TIMESTEP,prcp0)
                if(maxval(VEGFRA) .le. 1)  VEGFRA = VEGFRA * 100
 
            call geth_newdate(newdate, forcDate, noah_lsm%FORCING_TIMESTEP)
@@ -1778,7 +1780,7 @@ end subroutine land_driver_ini
      V_PHY(:,2,:)   = V_PHY(:,1,:)    !
      QV_CURR(:,2,:) = QV_CURR(:,1,:)  !
      RAINBL = RAINBL_tmp * DTBL       ! RAINBL in WRF is [mm]
-     SNOWBL = SNOWBL * DTBL           ! 
+     SNOWBL = SNOWBL * DTBL           !
      SR         = 0.0                 ! Will only use component if opt_snf=4
      RAINCV     = 0.0
      RAINNCV    = RAINBL

--- a/src/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/src/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -1727,8 +1727,10 @@ end subroutine land_driver_ini
      if(forc_typ .eq. 0) then
         CALL READFORC_HRLDAS(INFLNM_TEMPLATE, noah_lsm%FORCING_TIMESTEP, OLDDATE,  &
              XSTART, XEND, YSTART, YEND,                                  &
-       forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
-       forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, &
+             noah_lsm%forcing_name_T ,noah_lsm%forcing_name_Q ,noah_lsm%forcing_name_U , &
+	     noah_lsm%forcing_name_V ,noah_lsm%forcing_name_P ,noah_lsm%forcing_name_LW, &
+	     noah_lsm%forcing_name_SW,noah_lsm%forcing_name_PR,noah_lsm%forcing_name_SN, &
+	     noah_lsm%forcing_name_LF, &
              T_PHY(:,1,:),QV_CURR(:,1,:),U_PHY(:,1,:),V_PHY(:,1,:),          &
 	       P8W(:,1,:), GLW       ,SWDOWN      ,RAINBL_tmp, SNOWBL, VEGFRA, update_veg, LAI, update_lai)
      else
@@ -1748,8 +1750,10 @@ end subroutine land_driver_ini
 #else
      CALL READFORC_HRLDAS(INFLNM_TEMPLATE, noah_lsm%FORCING_TIMESTEP, OLDDATE,  &
           XSTART, XEND, YSTART, YEND,                                  &
-       forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
-       forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, &
+          noah_lsm%forcing_name_T ,noah_lsm%forcing_name_Q ,noah_lsm%forcing_name_U , &
+	  noah_lsm%forcing_name_V ,noah_lsm%forcing_name_P ,noah_lsm%forcing_name_LW, &
+	  noah_lsm%forcing_name_SW,noah_lsm%forcing_name_PR,noah_lsm%forcing_name_SN, &
+	  noah_lsm%forcing_name_LF, &
           T_PHY(:,1,:),QV_CURR(:,1,:),U_PHY(:,1,:),V_PHY(:,1,:),          &
 	    P8W(:,1,:), GLW       ,SWDOWN      ,RAINBL_tmp, SNOWBL, VEGFRA, update_veg, LAI, update_lai)
 #endif

--- a/src/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/src/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -237,7 +237,6 @@ module module_NoahMP_hrldas_driver
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  STBLCPXY  ! stable carbon in deep soil [g/m2]
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  FASTCPXY  ! short-lived carbon, shallow soil [g/m2]
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  LAI       ! leaf area index
-  REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  LQF       ! liquid fraction
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  XSAIXY    ! stem area index
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  TAUSSXY   ! snow age factor
 
@@ -863,7 +862,6 @@ module module_NoahMP_hrldas_driver
   ALLOCATE ( STBLCPXY  (XSTART:XEND,YSTART:YEND) )  ! stable carbon in deep soil [g/m2]
   ALLOCATE ( FASTCPXY  (XSTART:XEND,YSTART:YEND) )  ! short-lived carbon, shallow soil [g/m2]
   ALLOCATE ( LAI       (XSTART:XEND,YSTART:YEND) )  ! leaf area index
-  ALLOCATE ( LQF       (XSTART:XEND,YSTART:YEND) )  ! liquid fraction
   ALLOCATE ( XSAIXY    (XSTART:XEND,YSTART:YEND) )  ! stem area index
   ALLOCATE ( TAUSSXY   (XSTART:XEND,YSTART:YEND) )  ! snow age factor
 
@@ -1063,7 +1061,6 @@ module module_NoahMP_hrldas_driver
   STBLCPXY   = undefined_real
   FASTCPXY   = undefined_real
   LAI        = undefined_real
-  LQF        = undefined_real
   XSAIXY     = undefined_real
   TAUSSXY    = undefined_real
   XLONIN     = undefined_real
@@ -1735,13 +1732,17 @@ end subroutine land_driver_ini
 	     noah_lsm%forcing_name_SW,noah_lsm%forcing_name_PR,noah_lsm%forcing_name_SN, &
 	     noah_lsm%forcing_name_LF, &
              T_PHY(:,1,:),QV_CURR(:,1,:),U_PHY(:,1,:),V_PHY(:,1,:),          &
-	       P8W(:,1,:), GLW       ,SWDOWN      ,RAINBL_tmp, SNOWBL, VEGFRA, update_veg, LAI, update_lai)
+             P8W(:,1,:), GLW       ,SWDOWN      ,RAINBL_tmp, &
+             SNOWBL, VEGFRA, update_veg, LAI, &
+             update_lai)
      else
         if(olddate == forcDate) then
-           CALL HYDRO_frocing_drv(trim(noah_lsm%indir), forc_typ, wrf_hydro%snow_assim,olddate,                      &
+           CALL HYDRO_frocing_drv(trim(noah_lsm%indir), forc_typ, wrf_hydro%snow_assim, olddate,                     &
                xstart, xend, ystart, yend,    &
-               T_PHY(:,1,:),QV_CURR(:,1,:),U_PHY(:,1,:),V_PHY(:,1,:),P8W(:,1,:),    &
-               GLW,SWDOWN,RAINBL_tmp,LAI,LQF,VEGFRA,state%SNOWH,ITIME,noah_lsm%FORCING_TIMESTEP,prcp0)
+               T_PHY(:,1,:), QV_CURR(:,1,:), U_PHY(:,1,:), V_PHY(:,1,:), &
+               P8W(:,1,:), GLW, SWDOWN, RAINBL_tmp, &
+               LAI, SNOWBL, VEGFRA, state%SNOWH, &
+               ITIME, noah_lsm%FORCING_TIMESTEP, prcp0)
                if(maxval(VEGFRA) .le. 1)  VEGFRA = VEGFRA * 100
 
            call geth_newdate(newdate, forcDate, noah_lsm%FORCING_TIMESTEP)

--- a/src/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/src/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -1187,11 +1187,11 @@ module module_NoahMP_hrldas_driver
      !PSNOWAGEXY     = undefined_real
 
 ! These should probably be kept initialized with an undefined value (above)
-! to allow tracking of cells that fall through the cracks in value updates 
+! to allow tracking of cells that fall through the cracks in value updates
 ! (also worth noting that 0 is not a valid value for all of these variables).
-! However, since restarts are not currently water-masking 2d reals, this makes 
+! However, since restarts are not currently water-masking 2d reals, this makes
 ! for odd value ranges in the LSM restarts so leaving as 0s for now.
-! On quick tests, the only one of these that changes answers if NOT initialized 
+! On quick tests, the only one of these that changes answers if NOT initialized
 ! at 0 is PSNOWHISTXY so making sure that one is covered in value initialization
 ! loop below in case we go back to undefined_real for these.
      PSNOWLIQXY     = 0.
@@ -1739,6 +1739,10 @@ end subroutine land_driver_ini
         if(olddate == forcDate) then
            CALL HYDRO_frocing_drv(trim(noah_lsm%indir), forc_typ, wrf_hydro%snow_assim, olddate,                     &
                xstart, xend, ystart, yend,    &
+               noah_lsm%forcing_name_T ,noah_lsm%forcing_name_Q ,noah_lsm%forcing_name_U , &
+               noah_lsm%forcing_name_V ,noah_lsm%forcing_name_P ,noah_lsm%forcing_name_LW, &
+               noah_lsm%forcing_name_SW,noah_lsm%forcing_name_PR,noah_lsm%forcing_name_SN, &
+               noah_lsm%forcing_name_LF, &
                T_PHY(:,1,:), QV_CURR(:,1,:), U_PHY(:,1,:), V_PHY(:,1,:), &
                P8W(:,1,:), GLW, SWDOWN, RAINBL_tmp, &
                LAI, SNOWBL, VEGFRA, state%SNOWH, &

--- a/src/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
+++ b/src/Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
@@ -136,6 +136,7 @@ module module_NoahMP_hrldas_driver
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  GLW       ! longwave down at surface [W m-2]
   REAL,    ALLOCATABLE, DIMENSION(:,:,:)  ::  P8W       ! 3D pressure, valid at interface [Pa]
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  RAINBL, RAINBL_tmp    ! precipitation entering land model [mm]
+  REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  SNOWBL    ! snow entering land model [mm]
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  SR        ! frozen precip ratio entering land model [-]
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  RAINCV    ! convective precip forcing [mm]
   REAL,    ALLOCATABLE, DIMENSION(:,:)    ::  RAINNCV   ! non-convective precip forcing [mm]
@@ -762,6 +763,7 @@ module module_NoahMP_hrldas_driver
   ALLOCATE ( GLW       (XSTART:XEND,YSTART:YEND) )    ! longwave down at surface [W m-2]
   ALLOCATE ( P8W       (XSTART:XEND,KDS:KDE,YSTART:YEND) )  ! 3D pressure, valid at interface [Pa]
   ALLOCATE ( RAINBL    (XSTART:XEND,YSTART:YEND) )    ! total precipitation entering land model [mm]
+  ALLOCATE ( SNOWBL    (XSTART:XEND,YSTART:YEND) )    ! snow entering land model [mm]
   ALLOCATE ( RAINBL_tmp    (XSTART:XEND,YSTART:YEND) )    ! precipitation entering land model [mm]
   ALLOCATE ( SR        (XSTART:XEND,YSTART:YEND) )    ! frozen precip ratio entering land model [-]
   ALLOCATE ( RAINCV    (XSTART:XEND,YSTART:YEND) )    ! convective precip forcing [mm]
@@ -1005,6 +1007,7 @@ module module_NoahMP_hrldas_driver
   GLW        = undefined_real
   P8W        = undefined_real
   RAINBL     = undefined_real
+  SNOWBL     = undefined_real
   RAINBL_tmp = undefined_real
   SR         = undefined_real
   RAINCV     = undefined_real
@@ -1724,8 +1727,10 @@ end subroutine land_driver_ini
      if(forc_typ .eq. 0) then
         CALL READFORC_HRLDAS(INFLNM_TEMPLATE, noah_lsm%FORCING_TIMESTEP, OLDDATE,  &
              XSTART, XEND, YSTART, YEND,                                  &
+       forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+       forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, &
              T_PHY(:,1,:),QV_CURR(:,1,:),U_PHY(:,1,:),V_PHY(:,1,:),          &
-	       P8W(:,1,:), GLW       ,SWDOWN      ,RAINBL_tmp, VEGFRA, update_veg, LAI, update_lai)
+	       P8W(:,1,:), GLW       ,SWDOWN      ,RAINBL_tmp, SNOWBL, VEGFRA, update_veg, LAI, update_lai)
      else
         if(olddate == forcDate) then
            CALL HYDRO_frocing_drv(trim(noah_lsm%indir), forc_typ, wrf_hydro%snow_assim,olddate,                      &
@@ -1743,8 +1748,10 @@ end subroutine land_driver_ini
 #else
      CALL READFORC_HRLDAS(INFLNM_TEMPLATE, noah_lsm%FORCING_TIMESTEP, OLDDATE,  &
           XSTART, XEND, YSTART, YEND,                                  &
+       forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+       forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, &
           T_PHY(:,1,:),QV_CURR(:,1,:),U_PHY(:,1,:),V_PHY(:,1,:),          &
-	    P8W(:,1,:), GLW       ,SWDOWN      ,RAINBL_tmp, VEGFRA, update_veg, LAI, update_lai)
+	    P8W(:,1,:), GLW       ,SWDOWN      ,RAINBL_tmp, SNOWBL, VEGFRA, update_veg, LAI, update_lai)
 #endif
 
 991  continue
@@ -1757,6 +1764,7 @@ end subroutine land_driver_ini
      where(XLAND > 1.5)     GLW        = 0.0
      where(XLAND > 1.5)  SWDOWN        = 0.0
      where(XLAND > 1.5) RAINBL_tmp     = 0.0
+     where(XLAND > 1.5) SNOWBL         = 0.0
 
      QV_CURR(:,1,:) = QV_CURR(:,1,:)/(1.0 - QV_CURR(:,1,:))  ! Assuming input forcing are specific hum.;
                                                              ! WRF wants mixing ratio at driver level
@@ -1766,11 +1774,12 @@ end subroutine land_driver_ini
      V_PHY(:,2,:)   = V_PHY(:,1,:)    !
      QV_CURR(:,2,:) = QV_CURR(:,1,:)  !
      RAINBL = RAINBL_tmp * DTBL       ! RAINBL in WRF is [mm]
+     SNOWBL = SNOWBL * DTBL           ! 
      SR         = 0.0                 ! Will only use component if opt_snf=4
      RAINCV     = 0.0
      RAINNCV    = RAINBL
      RAINSHV    = 0.0
-     SNOWNCV    = 0.0
+     SNOWNCV    = SNOWBL
      GRAUPELNCV = 0.0
      HAILNCV    = 0.0
      DZ8W = 2 * noah_lsm%ZLVL                    ! 2* to be consistent with WRF model level

--- a/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -48,6 +48,7 @@ module module_hrldas_netcdf_io
      real, pointer, dimension(:,:) :: lw
      real, pointer, dimension(:,:) :: sw
      real, pointer, dimension(:,:) :: pcp
+     real, pointer, dimension(:,:) :: snow
      real, pointer, dimension(:,:) :: vegfra
      real, pointer, dimension(:,:) :: lai
   end type inputstruct
@@ -1873,7 +1874,9 @@ contains
 !---------------------------------------------------------------------------------------------------------
 
   subroutine READFORC_HRLDAS(flnm_template, forcing_timestep, target_date, xstart, xend, ystart, yend,  &
-       t,q,u,v,p,lw,sw,pcp,vegfra,update_veg,lai,update_lai)
+       forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+       forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, &
+       t,q,u,v,p,lw,sw,pcp,snow,vegfra,update_veg,lai,update_lai)
     use kwm_string_utilities
     implicit none
 
@@ -1882,6 +1885,16 @@ contains
     integer,                            intent(in)  :: xstart, xend
     integer,                            intent(in)  :: ystart, yend
     character(len=19),                  intent(in)  :: target_date ! (YYYY-MM-DD_hh:mm:ss)
+    character(len=256),                 intent(in)  :: forcing_name_T
+    character(len=256),                 intent(in)  :: forcing_name_Q
+    character(len=256),                 intent(in)  :: forcing_name_U
+    character(len=256),                 intent(in)  :: forcing_name_V
+    character(len=256),                 intent(in)  :: forcing_name_P
+    character(len=256),                 intent(in)  :: forcing_name_LW
+    character(len=256),                 intent(in)  :: forcing_name_SW
+    character(len=256),                 intent(in)  :: forcing_name_PR
+    character(len=256),                 intent(in)  :: forcing_name_SN
+
     real,             dimension(xstart:xend,ystart:yend), intent(out)   :: t
     real,             dimension(xstart:xend,ystart:yend), intent(out)   :: q
     real,             dimension(xstart:xend,ystart:yend), intent(out)   :: u
@@ -1890,6 +1903,7 @@ contains
     real,             dimension(xstart:xend,ystart:yend), intent(out)   :: lw
     real,             dimension(xstart:xend,ystart:yend), intent(out)   :: sw
     real,             dimension(xstart:xend,ystart:yend), intent(out)   :: pcp
+    real,             dimension(xstart:xend,ystart:yend), intent(out)   :: snow
     real,             dimension(xstart:xend,ystart:yend), intent(inout) :: lai    !Barlage v3.7: change to inout
     real,             dimension(xstart:xend,ystart:yend), intent(inout) :: vegfra
     logical,                            intent(in)  :: update_veg, update_lai  ! Barlage v3.7: for veg read control
@@ -1902,9 +1916,9 @@ contains
     integer :: rank
 
     type(inputstruct) :: lastread = inputstruct("0000-00-00_00:00:00", &
-         null(), null(), null(), null(), null(), null(), null(), null(), null(), null() )
+         null(), null(), null(), null(), null(), null(), null(), null(), null(), null(), null() )
     type(inputstruct) :: nextread= inputstruct("0000-00-00_00:00:00", &
-         null(), null(), null(), null(), null(), null(), null(), null(), null(), null() )
+         null(), null(), null(), null(), null(), null(), null(), null(), null(), null(), null() )
 
 !KWM    print*, 'target_date        = ', target_date
 !KWM    print*, 'lastread%read_date = ', lastread%read_date
@@ -1985,15 +1999,18 @@ contains
        call allocate_inputstruct(nextread, xstart, xend, ystart, yend)
 
        ! Read the data
-       call get_2d_netcdf("T2D",     ncid, nextread%t,     units, xstart, xend, ystart, yend, FATAL, ierr)
-       call get_2d_netcdf("Q2D",     ncid, nextread%q,     units, xstart, xend, ystart, yend, FATAL, ierr)
-       call get_2d_netcdf("U2D",     ncid, nextread%u,     units, xstart, xend, ystart, yend, FATAL, ierr)
-       call get_2d_netcdf("V2D",     ncid, nextread%v,     units, xstart, xend, ystart, yend, FATAL, ierr)
-       call get_2d_netcdf("PSFC",    ncid, nextread%p,     units, xstart, xend, ystart, yend, FATAL, ierr)
-       call get_2d_netcdf("LWDOWN",  ncid, nextread%lw,    units, xstart, xend, ystart, yend, FATAL, ierr)
-       call get_2d_netcdf("SWDOWN",  ncid, nextread%sw,    units, xstart, xend, ystart, yend, FATAL, ierr)
-       call get_2d_netcdf("RAINRATE",ncid, nextread%pcp,   units, xstart, xend, ystart, yend, FATAL, ierr)
-
+       call get_2d_netcdf(trim(forcing_name_T) , ncid, nextread%t,     units, xstart, xend, ystart, yend, FATAL, ierr)
+       call get_2d_netcdf(trim(forcing_name_Q) , ncid, nextread%q,     units, xstart, xend, ystart, yend, FATAL, ierr)
+       call get_2d_netcdf(trim(forcing_name_U) , ncid, nextread%u,     units, xstart, xend, ystart, yend, FATAL, ierr)
+       call get_2d_netcdf(trim(forcing_name_V) , ncid, nextread%v,     units, xstart, xend, ystart, yend, FATAL, ierr)
+       call get_2d_netcdf(trim(forcing_name_P) , ncid, nextread%p,     units, xstart, xend, ystart, yend, FATAL, ierr)
+       call get_2d_netcdf(trim(forcing_name_LW), ncid, nextread%lw,    units, xstart, xend, ystart, yend, FATAL, ierr)
+       call get_2d_netcdf(trim(forcing_name_SW), ncid, nextread%sw,    units, xstart, xend, ystart, yend, FATAL, ierr)
+       call get_2d_netcdf(trim(forcing_name_PR), ncid, nextread%pcp,   units, xstart, xend, ystart, yend, FATAL, ierr)
+       
+       nextread%snow = 0.0  ! Assume zero in case not present
+       call get_2d_netcdf(trim(forcing_name_SN), ncid, nextread%snow,  units, xstart, xend, ystart, yend, NOT_FATAL, ierr)
+       
        if(update_veg) then    ! Barlage v3.7: update only if dveg option is appropriate
 
          call get_2d_netcdf("VEGFRA",  ncid, nextread%vegfra,units, xstart, xend, ystart, yend, NOT_FATAL, ierr)
@@ -2046,7 +2063,7 @@ contains
        !
 
        ! Fill the t, q, u, v, ... arrays with data from the nextread structure.
-       call copyfrom_inputstruct(nextread, t, q, u, v, p, lw, sw, pcp, vegfra, lai, &
+       call copyfrom_inputstruct(nextread, t, q, u, v, p, lw, sw, pcp, snow, vegfra, lai, &
                                  update_veg, update_lai, xstart, xend, ystart, yend)
 
        ! Clear the old lastread data
@@ -2071,7 +2088,7 @@ contains
 
        ! Fill the t, q, u, v, ... arrays with data interpolated between lastread and nextread times.
        call interpolate_inputstruct(lastread, nextread, target_date, &
-            t, q, u, v, p, lw, sw, pcp, vegfra, lai, update_veg, update_lai, xstart, xend, ystart, yend)
+            t, q, u, v, p, lw, sw, pcp, snow, vegfra, lai, update_veg, update_lai, xstart, xend, ystart, yend)
 
     else
 
@@ -2122,6 +2139,9 @@ contains
     allocate(instruct%pcp (xstart:xend,ystart:yend), stat=allostat )
     if (allostat/=0) stop "FATAL ERROR: In allocate_inputstruct() - Problem allocating instruct%pcp"
 
+    allocate(instruct%snow (xstart:xend,ystart:yend), stat=allostat )
+    if (allostat/=0) stop "Problem allocating instruct%snow"
+
     allocate(instruct%vegfra(xstart:xend,ystart:yend), stat=allostat )
     if (allostat/=0) stop "FATAL ERROR: In allocate_inputstruct()- Problem allocating instruct%vegfra"
 
@@ -2135,13 +2155,13 @@ contains
 !---------------------------------------------------------------------------------------------------------
 !---------------------------------------------------------------------------------------------------------
 
-  subroutine copyfrom_inputstruct(instruct, t, q, u, v, p, lw, sw, pcp, vegfra, lai, &
+  subroutine copyfrom_inputstruct(instruct, t, q, u, v, p, lw, sw, pcp, snow, vegfra, lai, &
                                   update_veg, update_lai, xstart, xend, ystart, yend)
     implicit none
     type(inputstruct), intent(in) :: instruct
     integer,           intent(in) :: xstart, xend, ystart, yend
     logical,           intent(in)  :: update_veg, update_lai  ! Barlage v3.7: for veg read control
-    real, dimension(xstart:xend,ystart:yend), intent(out) :: t, q, u, v, p, lw, sw, pcp, vegfra, lai
+    real, dimension(xstart:xend,ystart:yend), intent(out) :: t, q, u, v, p, lw, sw, pcp, snow, vegfra, lai
     t    = instruct%t
     q    = instruct%q
     u    = instruct%u
@@ -2149,6 +2169,7 @@ contains
     p    = instruct%p
     lw   = instruct%lw
     sw   = instruct%sw
+    snow = instruct%snow
     pcp  = instruct%pcp
     if(update_veg) vegfra = instruct%vegfra
     if(update_lai)   lai  = instruct%lai
@@ -2158,13 +2179,13 @@ contains
 !---------------------------------------------------------------------------------------------------------
 
   subroutine interpolate_inputstruct(instructA, instructB, target_date, &
-       t, q, u, v, p, lw, sw, pcp, vegfra, lai, update_veg, update_lai, xstart, xend, ystart, yend)
+       t, q, u, v, p, lw, sw, pcp, snow, vegfra, lai, update_veg, update_lai, xstart, xend, ystart, yend)
     implicit none
     type(inputstruct),                        intent(in)  :: instructA, instructB
     character(len=19),                        intent(in)  :: target_date
     integer,                                  intent(in)  :: xstart, xend, ystart, yend
     logical,                                  intent(in)  :: update_veg, update_lai  ! Barlage v3.7: for veg read control
-    real, dimension(xstart:xend,ystart:yend), intent(out) :: t, q, u, v, p, lw, sw, pcp, vegfra, lai
+    real, dimension(xstart:xend,ystart:yend), intent(out) :: t, q, u, v, p, lw, sw, pcp, snow, vegfra, lai
 
     integer :: idts, idts2
     real    :: fraction
@@ -2180,6 +2201,7 @@ contains
     p  = ( instructA%p  * fraction ) + ( instructB%p  * (1.0-fraction) )
     lw = ( instructA%lw * fraction ) + ( instructB%lw * (1.0-fraction) )
     sw = ( instructA%sw * fraction ) + ( instructB%sw * (1.0-fraction) )
+    snow = instructA%snow
     pcp = instructA%pcp
     if(update_veg) vegfra = instructA%vegfra
     if(update_lai)   lai  = instructA%lai
@@ -2230,6 +2252,11 @@ contains
     if (associated(instruct%pcp)) then
        deallocate(instruct%pcp)
        nullify(instruct%pcp)
+    endif
+
+    if (associated(instruct%snow)) then
+       deallocate(instruct%snow)
+       nullify(instruct%snow)
     endif
 
     if (associated(instruct%vegfra)) then

--- a/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -2011,19 +2011,19 @@ contains
        call get_2d_netcdf(trim(forcing_name_LW), ncid, nextread%lw,    units, xstart, xend, ystart, yend, FATAL, ierr)
        call get_2d_netcdf(trim(forcing_name_SW), ncid, nextread%sw,    units, xstart, xend, ystart, yend, FATAL, ierr)
        call get_2d_netcdf(trim(forcing_name_PR), ncid, nextread%pcp,   units, xstart, xend, ystart, yend, FATAL, ierr)
-       
+
        nextread%snow = 0.0  ! Assume zero in case not present
-       if(forcing_name_SN /= "") then
+       if(trim(forcing_name_SN) /= "") then
          call get_2d_netcdf(trim(forcing_name_SN), ncid, nextread%snow,  units, xstart, xend, ystart, yend, NOT_FATAL, ierr)
          if(ierr == 0) snow_read = .true.
        end if
-       
-       if(forcing_name_LF /= "" .and. .not. snow_read) then   ! snow was not read in
+
+       if(trim(forcing_name_LF) /= "" .and. .not. snow_read) then   ! snow was not read in
          liqfrac = 1.0            ! Assume all liquid in case not present
          call get_2d_netcdf(trim(forcing_name_LF), ncid, liqfrac,  units, xstart, xend, ystart, yend, NOT_FATAL, ierr)
          if (ierr == 0) nextread%snow = (1.0 - liqfrac ) * nextread%pcp
        end if
-       
+
        if(update_veg) then    ! Barlage v3.7: update only if dveg option is appropriate
 
          call get_2d_netcdf("VEGFRA",  ncid, nextread%vegfra,units, xstart, xend, ystart, yend, NOT_FATAL, ierr)

--- a/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
+++ b/src/Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
@@ -1875,7 +1875,7 @@ contains
 
   subroutine READFORC_HRLDAS(flnm_template, forcing_timestep, target_date, xstart, xend, ystart, yend,  &
        forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
-       forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, &
+       forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
        t,q,u,v,p,lw,sw,pcp,snow,vegfra,update_veg,lai,update_lai)
     use kwm_string_utilities
     implicit none
@@ -1894,6 +1894,7 @@ contains
     character(len=256),                 intent(in)  :: forcing_name_SW
     character(len=256),                 intent(in)  :: forcing_name_PR
     character(len=256),                 intent(in)  :: forcing_name_SN
+    character(len=256),                 intent(in)  :: forcing_name_LF
 
     real,             dimension(xstart:xend,ystart:yend), intent(out)   :: t
     real,             dimension(xstart:xend,ystart:yend), intent(out)   :: q
@@ -1908,6 +1909,9 @@ contains
     real,             dimension(xstart:xend,ystart:yend), intent(inout) :: vegfra
     logical,                            intent(in)  :: update_veg, update_lai  ! Barlage v3.7: for veg read control
 
+    real,             dimension(xstart:xend,ystart:yend)                :: liqfrac
+    logical :: snow_read = .false.
+
     character(len=256) :: flnm
     character(len=256) :: units
     character(len=256) :: nextflnm
@@ -1916,9 +1920,9 @@ contains
     integer :: rank
 
     type(inputstruct) :: lastread = inputstruct("0000-00-00_00:00:00", &
-         null(), null(), null(), null(), null(), null(), null(), null(), null(), null(), null() )
+         null(), null(), null(), null(), null(), null(), null(), null(), null(), null(), null())
     type(inputstruct) :: nextread= inputstruct("0000-00-00_00:00:00", &
-         null(), null(), null(), null(), null(), null(), null(), null(), null(), null(), null() )
+         null(), null(), null(), null(), null(), null(), null(), null(), null(), null(), null())
 
 !KWM    print*, 'target_date        = ', target_date
 !KWM    print*, 'lastread%read_date = ', lastread%read_date
@@ -2009,7 +2013,16 @@ contains
        call get_2d_netcdf(trim(forcing_name_PR), ncid, nextread%pcp,   units, xstart, xend, ystart, yend, FATAL, ierr)
        
        nextread%snow = 0.0  ! Assume zero in case not present
-       call get_2d_netcdf(trim(forcing_name_SN), ncid, nextread%snow,  units, xstart, xend, ystart, yend, NOT_FATAL, ierr)
+       if(forcing_name_SN /= "") then
+         call get_2d_netcdf(trim(forcing_name_SN), ncid, nextread%snow,  units, xstart, xend, ystart, yend, NOT_FATAL, ierr)
+         if(ierr == 0) snow_read = .true.
+       end if
+       
+       if(forcing_name_LF /= "" .and. .not. snow_read) then   ! snow was not read in
+         liqfrac = 1.0            ! Assume all liquid in case not present
+         call get_2d_netcdf(trim(forcing_name_LF), ncid, liqfrac,  units, xstart, xend, ystart, yend, NOT_FATAL, ierr)
+         if (ierr == 0) nextread%snow = (1.0 - liqfrac ) * nextread%pcp
+       end if
        
        if(update_veg) then    ! Barlage v3.7: update only if dveg option is appropriate
 

--- a/src/OrchestratorLayer/config.f90
+++ b/src/OrchestratorLayer/config.f90
@@ -39,6 +39,17 @@ module config_base
      integer            :: glacier_option
      integer            :: surface_resistance_option
 
+     character(len=256) :: forcing_name_T
+     character(len=256) :: forcing_name_Q
+     character(len=256) :: forcing_name_U
+     character(len=256) :: forcing_name_V
+     character(len=256) :: forcing_name_P
+     character(len=256) :: forcing_name_LW
+     character(len=256) :: forcing_name_SW
+     character(len=256) :: forcing_name_PR
+     character(len=256) :: forcing_name_SN
+     character(len=256) :: forcing_name_LF
+
      integer            :: soil_data_option = 1
      integer            :: pedotransfer_option = 0
      integer            :: crop_option = 0
@@ -889,6 +900,16 @@ contains
      character(len=256) :: restart_filename_requested = " "
      integer            :: restart_frequency_hours
      integer            :: output_timestep
+     character(len=256) :: forcing_name_T = "T2D"
+     character(len=256) :: forcing_name_Q = "Q2D"
+     character(len=256) :: forcing_name_U = "U2D"
+     character(len=256) :: forcing_name_V = "V2D"
+     character(len=256) :: forcing_name_P = "PSFC"
+     character(len=256) :: forcing_name_LW = "LWDOWN"
+     character(len=256) :: forcing_name_SW = "SWDOWN"
+     character(len=256) :: forcing_name_PR = "RAINRATE"
+     character(len=256) :: forcing_name_SN = ""
+     character(len=256) :: forcing_name_LF = ""
      integer            :: dynamic_veg_option
      integer            :: canopy_stomatal_resistance_option
      integer            :: btr_option
@@ -932,6 +953,9 @@ contains
          start_year, start_month, start_day, start_hour, start_min, &
          outdir, &
          restart_filename_requested, restart_frequency_hours, output_timestep, &
+
+         forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+         forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN,forcing_name_LF, &
 
          dynamic_veg_option, canopy_stomatal_resistance_option, &
          btr_option, runoff_option, surface_drag_option, supercooled_water_option, &
@@ -1031,6 +1055,16 @@ contains
     noah_lsm%restart_filename_requested = restart_filename_requested
     noah_lsm%restart_frequency_hours = restart_frequency_hours
     noah_lsm%output_timestep = output_timestep
+    noah_lsm%forcing_name_T = forcing_name_T
+    noah_lsm%forcing_name_Q = forcing_name_Q
+    noah_lsm%forcing_name_U = forcing_name_U
+    noah_lsm%forcing_name_V = forcing_name_V
+    noah_lsm%forcing_name_P = forcing_name_P
+    noah_lsm%forcing_name_LW = forcing_name_LW
+    noah_lsm%forcing_name_SW = forcing_name_SW
+    noah_lsm%forcing_name_PR = forcing_name_PR
+    noah_lsm%forcing_name_SN = forcing_name_SN
+    noah_lsm%forcing_name_LF = forcing_name_LF
     noah_lsm%dynamic_veg_option = dynamic_veg_option
     noah_lsm%canopy_stomatal_resistance_option = canopy_stomatal_resistance_option
     noah_lsm%btr_option = btr_option

--- a/src/Routing/module_lsm_forcing.F
+++ b/src/Routing/module_lsm_forcing.F
@@ -443,13 +443,26 @@ Contains
 
 
 
-  subroutine READFORC_HRLDAS(flnm,ix,jx,target_date,t,q,u,v,p,lw,sw,pcp,lai,snowbl,fpar)
+  subroutine READFORC_HRLDAS(flnm,ix,jx,target_date, &
+       forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+       forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
+       t,q,u,v,p,lw,sw,pcp,lai,snowbl,fpar)
     implicit none
 
     character(len=*),                   intent(in)  :: flnm
     integer,                            intent(in)  :: ix
     integer,                            intent(in)  :: jx
     character(len=*),                   intent(in)  :: target_date
+    character(len=256), intent(in)  :: forcing_name_T
+    character(len=256), intent(in)  :: forcing_name_Q
+    character(len=256), intent(in)  :: forcing_name_U
+    character(len=256), intent(in)  :: forcing_name_V
+    character(len=256), intent(in)  :: forcing_name_P
+    character(len=256), intent(in)  :: forcing_name_LW
+    character(len=256), intent(in)  :: forcing_name_SW
+    character(len=256), intent(in)  :: forcing_name_PR
+    character(len=256), intent(in)  :: forcing_name_SN
+    character(len=256), intent(in)  :: forcing_name_LF
     real,             dimension(ix,jx), intent(out) :: t
     real,             dimension(ix,jx), intent(out) :: q
     real,             dimension(ix,jx), intent(out) :: u
@@ -473,23 +486,24 @@ Contains
        call hydro_stop("In READFORC_HRLDAS() - Problem opening netcdf file")
     endif
 
-    call get_2d_netcdf("T2D",     ncid, t,     units, ix, jx, .TRUE., ierr)
-    call get_2d_netcdf("Q2D",     ncid, q,     units, ix, jx, .TRUE., ierr)
-    call get_2d_netcdf("U2D",     ncid, u,     units, ix, jx, .TRUE., ierr)
-    call get_2d_netcdf("V2D",     ncid, v,     units, ix, jx, .TRUE., ierr)
-    call get_2d_netcdf("PSFC",    ncid, p,     units, ix, jx, .TRUE., ierr)
-    call get_2d_netcdf("LWDOWN",  ncid, lw,    units, ix, jx, .TRUE., ierr)
-    call get_2d_netcdf("SWDOWN",  ncid, sw,    units, ix, jx, .TRUE., ierr)
-    call get_2d_netcdf("RAINRATE",ncid, pcp,   units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_T),     ncid, t,     units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_Q),     ncid, q,     units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_U),     ncid, u,     units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_V),     ncid, v,     units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_P),    ncid, p,     units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_lw),  ncid, lw,    units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_sw),  ncid, sw,    units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_pr),ncid, pcp,   units, ix, jx, .TRUE., ierr)
     call get_2d_netcdf("VEGFRA",  ncid, fpar,  units, ix, jx, .FALSE., ierr)
     if (ierr == 0) then
       if(maxval(fpar) .gt. 10 .and. maxval(fpar) .lt. 10000)  fpar = fpar * 1.E-2
     endif
+
     call get_2d_netcdf("LAI",     ncid, lai,   units, ix, jx, .FALSE., ierr)
-    call get_2d_netcdf("SNOW",    ncid, snowbl,units, ix, jx, .FALSE., ierr)
+    call get_2d_netcdf(trim(forcing_name_SN),    ncid, snowbl,units, ix, jx, .FALSE., ierr)
     if (ierr /= 0) then
        allocate(liqfrac(ix,jx))
-       call get_2d_netcdf("LQFRAC", ncid, liqfrac, units, ix, jx, .FALSE., ierr)
+       call get_2d_netcdf(trim(forcing_name_LF), ncid, liqfrac, units, ix, jx, .FALSE., ierr)
        if (ierr == 0) then
           snowbl = (1.0 - liqfrac) * pcp
        else
@@ -912,6 +926,8 @@ Contains
  subroutine read_hydro_forcing_seq( &
        indir,olddate,hgrid, &
        ix,jx,forc_typ,snow_assim,  &
+       forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+       forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
        T2,q2x,u,v,pres,xlong,short,prcp1,&
        lai,snowbl,fpar,snodep,dt,k,prcp_old)
 ! This subrouting is going to read different forcing.
@@ -920,6 +936,16 @@ Contains
    character(len=*) :: olddate,hgrid,indir
    character(len=256) :: filename
    integer :: ix,jx,forc_typ,k,snow_assim  ! k is time loop
+   character(len=256), intent(in)  :: forcing_name_T
+   character(len=256), intent(in)  :: forcing_name_Q
+   character(len=256), intent(in)  :: forcing_name_U
+   character(len=256), intent(in)  :: forcing_name_V
+   character(len=256), intent(in)  :: forcing_name_P
+   character(len=256), intent(in)  :: forcing_name_LW
+   character(len=256), intent(in)  :: forcing_name_SW
+   character(len=256), intent(in)  :: forcing_name_PR
+   character(len=256), intent(in)  :: forcing_name_SN
+   character(len=256), intent(in)  :: forcing_name_LF
    real,dimension(ix,jx):: T2,q2x,u,v,pres,xlong,short,prcp1,&
           prcpnew,weasd,snodep,prcp0,prcp2,prcp_old
    real ::  dt, wrf_dt
@@ -948,8 +974,11 @@ Contains
            call hydro_stop("In read_hydro_forcing_seq")
         endif
 
-      CALL READFORC_HRLDAS(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
-          PRES,XLONG,SHORT,PRCP1,LAI,snowbl,FPAR)
+        CALL READFORC_HRLDAS(inflnm,IX,JX,OLDDATE, &
+             forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+             forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
+             T2,Q2X,U,V,   &
+             PRES,XLONG,SHORT,PRCP1,LAI,snowbl,FPAR)
    end if
 
 
@@ -967,8 +996,11 @@ Contains
            print*, "no forcing data found", inflnm
            call hydro_stop("In read_hydro_forcing_seq() - no forcing data found")
         endif
-      CALL READFORC_HRLDAS(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
-          PRES,XLONG,SHORT,PRCP1,LAI,snowbl,FPAR)
+        CALL READFORC_HRLDAS(inflnm,IX,JX,OLDDATE, &
+             forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+             forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
+             T2,Q2X,U,V,   &
+             PRES,XLONG,SHORT,PRCP1,LAI,snowbl,FPAR)
    end if
 
 
@@ -1153,7 +1185,10 @@ Contains
            print*, "reading forcing data at this time", inflnm
 #endif
 
-           CALL READFORC_HRLDAS(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
+           CALL READFORC_HRLDAS(inflnm,IX,JX,OLDDATE,&
+                forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+                forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
+                T2,Q2X,U,V,   &
                 PRES,XLONG,SHORT,PRCP1,LAI,snowbl,FPAR)
            PRCP_old = PRCP1  ! This assigns new precip to last precip as a fallback for missing data...
         endif
@@ -1730,6 +1765,8 @@ Contains
  subroutine read_hydro_forcing_mpp( &
        indir,olddate,hgrid, &
        ix,jx,forc_typ,snow_assim,  &
+       forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+       forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
        T2,q2x,u,v,pres,xlong,short,prcp1,&
        lai,snowbl,fpar,snodep,dt,k,prcp_old)
 ! This subrouting is going to read different forcing.
@@ -1740,6 +1777,16 @@ Contains
    character(len=*) :: olddate,hgrid,indir
    character(len=256) :: filename
    integer :: ix,jx,forc_typ,k,snow_assim  ! k is time loop
+   character(len=256), intent(in)  :: forcing_name_T
+   character(len=256), intent(in)  :: forcing_name_Q
+   character(len=256), intent(in)  :: forcing_name_U
+   character(len=256), intent(in)  :: forcing_name_V
+   character(len=256), intent(in)  :: forcing_name_P
+   character(len=256), intent(in)  :: forcing_name_LW
+   character(len=256), intent(in)  :: forcing_name_SW
+   character(len=256), intent(in)  :: forcing_name_PR
+   character(len=256), intent(in)  :: forcing_name_SN
+   character(len=256), intent(in)  :: forcing_name_LF
    real,dimension(ix,jx):: T2,q2x,u,v,pres,xlong,short,prcp1,&
           prcpnew,lai,snowbl,fpar,snodep,prcp_old
    real ::  dt
@@ -1773,6 +1820,8 @@ Contains
       call read_hydro_forcing_seq( &
         indir,olddate,hgrid,&
         global_nx,global_ny,forc_typ,snow_assim,  &
+        forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+        forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
         g_T2,g_q2x,g_u,g_v,g_pres,g_xlong,g_short,g_prcp1,&
         g_lai,g_snowbl,g_fpar,g_snodep,dt,k,g_prcp_old)
 #ifdef HYDRO_D
@@ -2264,6 +2313,8 @@ Contains
 subroutine read_hydro_forcing_mpp1( &
      indir,olddate,hgrid, &
      ix,jx,forc_typ,snow_assim,  &
+     forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+     forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
      T2,q2x,u,v,pres,xlong,short,prcp1,&
      lai,snowbl,fpar,snodep,dt,k,prcp_old)
 ! This subrouting is going to read different forcing.
@@ -2272,6 +2323,16 @@ implicit none
 character(len=*) :: olddate,hgrid,indir
 character(len=256) :: filename
 integer :: ix,jx,forc_typ,k,snow_assim  ! k is time loop
+character(len=256), intent(in)  :: forcing_name_T
+character(len=256), intent(in)  :: forcing_name_Q
+character(len=256), intent(in)  :: forcing_name_U
+character(len=256), intent(in)  :: forcing_name_V
+character(len=256), intent(in)  :: forcing_name_P
+character(len=256), intent(in)  :: forcing_name_LW
+character(len=256), intent(in)  :: forcing_name_SW
+character(len=256), intent(in)  :: forcing_name_PR
+character(len=256), intent(in)  :: forcing_name_SN
+character(len=256), intent(in)  :: forcing_name_LF
 real,dimension(ix,jx):: T2,q2x,u,v,pres,xlong,short,prcp1,&
      prcpnew,weasd,snodep,prcp0,prcp2,prcp_old
 real ::  dt, wrf_dt
@@ -2311,7 +2372,10 @@ if(FORC_TYP.eq.1) then
 #ifdef HYDRO_D
    print*, "read forcing data at ", OLDDATE,  trim(inflnm)
 #endif
-   call READFORC_HRLDAS_mpp(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
+   call READFORC_HRLDAS_mpp(inflnm,IX,JX,OLDDATE, &
+        forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+        forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
+        T2,Q2X,U,V,   &
         PRES,XLONG,SHORT,PRCP1,LAI,snowbl,FPAR)
 
    where(PRCP1 .lt. 0) PRCP1= 0  ! set minimum to be 0
@@ -2337,7 +2401,10 @@ if(FORC_TYP.eq.2) then
       print*, "no forcing data found", inflnm
       call hydro_stop("In read_hydro_forcing_mpp1() - no forcing data found")
    endif
-   call READFORC_HRLDAS_mpp(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
+   call READFORC_HRLDAS_mpp(inflnm,IX,JX,OLDDATE,&
+        forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+        forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
+        T2,Q2X,U,V,   &
         PRES,XLONG,SHORT,PRCP1,LAI,snowbl,FPAR)
 
    where(PRCP1 .lt. 0) PRCP1= 0  ! set minimum to be 0
@@ -2551,7 +2618,10 @@ if(FORC_TYP.eq.6) then
       print*, "reading forcing data at this time", inflnm
 #endif
 
-      call READFORC_HRLDAS_mpp(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
+      call READFORC_HRLDAS_mpp(inflnm,IX,JX,OLDDATE,&
+           forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+           forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
+           T2,Q2X,U,V,   &
            PRES,XLONG,SHORT,PRCP1,LAI,snowbl,FPAR)
       PRCP_old = PRCP1  ! This assigns new precip to last precip as a fallback for missing data...
    endif
@@ -2741,13 +2811,26 @@ end subroutine read_hydro_forcing_mpp1
 
 
 
-  subroutine READFORC_HRLDAS_mpp(flnm,ix,jx,target_date, t,q,u,v,p,lw,sw,pcp,lai,snowbl,fpar)
+    subroutine READFORC_HRLDAS_mpp(flnm,ix,jx,target_date, &
+         forcing_name_T,forcing_name_Q,forcing_name_U,forcing_name_V,forcing_name_P, &
+         forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN, forcing_name_LF,&
+         t,q,u,v,p,lw,sw,pcp,lai,snowbl,fpar)
     implicit none
 
     character(len=*),                   intent(in)  :: flnm
     integer,                            intent(in)  :: ix
     integer,                            intent(in)  :: jx
     character(len=*),                   intent(in)  :: target_date
+    character(len=256), intent(in)  :: forcing_name_T
+    character(len=256), intent(in)  :: forcing_name_Q
+    character(len=256), intent(in)  :: forcing_name_U
+    character(len=256), intent(in)  :: forcing_name_V
+    character(len=256), intent(in)  :: forcing_name_P
+    character(len=256), intent(in)  :: forcing_name_LW
+    character(len=256), intent(in)  :: forcing_name_SW
+    character(len=256), intent(in)  :: forcing_name_PR
+    character(len=256), intent(in)  :: forcing_name_SN
+    character(len=256), intent(in)  :: forcing_name_LF
     real,             dimension(ix,jx), intent(out) :: t
     real,             dimension(ix,jx), intent(out) :: q
     real,             dimension(ix,jx), intent(out) :: u
@@ -2784,21 +2867,21 @@ end subroutine read_hydro_forcing_mpp1
     endif
 
 
-    if(my_id .eq. io_id ) call get_2d_netcdf("T2D", ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
+    if(my_id .eq. io_id ) call get_2d_netcdf(trim(forcing_name_T), ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
     call decompose_data_real (buf2,t)
-    if(my_id .eq. io_id ) call get_2d_netcdf("Q2D", ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
+    if(my_id .eq. io_id ) call get_2d_netcdf(trim(forcing_name_Q), ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
     call decompose_data_real (buf2,q)
-    if(my_id .eq. io_id ) call get_2d_netcdf("U2D", ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
+    if(my_id .eq. io_id ) call get_2d_netcdf(trim(forcing_name_U), ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
     call decompose_data_real (buf2,u)
-    if(my_id .eq. io_id ) call get_2d_netcdf("V2D", ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
+    if(my_id .eq. io_id ) call get_2d_netcdf(trim(forcing_name_V), ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
     call decompose_data_real (buf2,v)
-    if(my_id .eq. io_id ) call get_2d_netcdf("PSFC", ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
+    if(my_id .eq. io_id ) call get_2d_netcdf(trim(forcing_name_P), ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
     call decompose_data_real (buf2,p)
-    if(my_id .eq. io_id ) call get_2d_netcdf("LWDOWN", ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
+    if(my_id .eq. io_id ) call get_2d_netcdf(trim(forcing_name_LW), ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
     call decompose_data_real (buf2,lw)
-    if(my_id .eq. io_id ) call get_2d_netcdf("SWDOWN", ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
+    if(my_id .eq. io_id ) call get_2d_netcdf(trim(forcing_name_SW), ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
     call decompose_data_real (buf2,sw)
-    if(my_id .eq. io_id ) call get_2d_netcdf("RAINRATE", ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
+    if(my_id .eq. io_id ) call get_2d_netcdf(trim(forcing_name_PR), ncid,buf2, units, global_nx, global_ny, .TRUE., ierr)
     call decompose_data_real (buf2,pcp)
     if(my_id .eq. io_id ) then
           call get_2d_netcdf("VEGFRA", ncid,buf2, units, global_nx, global_ny, .FALSE., ierr)
@@ -2811,12 +2894,12 @@ end subroutine read_hydro_forcing_mpp1
     if(my_id .eq. io_id ) call get_2d_netcdf("LAI",     ncid, buf2,   units, global_nx, global_ny, .FALSE., ierr)
     call mpp_land_bcast_int1(ierr)
     if(ierr == 0) call decompose_data_real (buf2,lai)
-    if(my_id .eq. io_id ) call get_2d_netcdf("SNOW", ncid, buf2, units, global_nx, global_ny, .FALSE., ierr)
+    if(my_id .eq. io_id ) call get_2d_netcdf(trim(forcing_name_SN), ncid, buf2, units, global_nx, global_ny, .FALSE., ierr)
     call mpp_land_bcast_int1(ierr)
     if (ierr == 0) then
        call decompose_data_real (buf2,snowbl)
     else
-       if(my_id .eq. io_id ) call get_2d_netcdf("LQFRAC", ncid, buf2, units, global_nx, global_ny, .FALSE., ierr)
+       if(my_id .eq. io_id ) call get_2d_netcdf(trim(forcing_name_LF), ncid, buf2, units, global_nx, global_ny, .FALSE., ierr)
        call mpp_land_bcast_int1(ierr)
        if(ierr == 0) then
           allocate(liqfrac(ix,jx))
@@ -2835,24 +2918,25 @@ end subroutine read_hydro_forcing_mpp1
        write(*,'("READFORC Problem opening netcdf file: ''", A, "''")') trim(flnm)
        call hydro_stop("READFORC_HRLDAS")
     endif
-    call get_2d_netcdf("T2D",     ncid, t,     units, ix, jx, .TRUE., ierr)
-    call get_2d_netcdf("Q2D",     ncid, q,     units, ix, jx, .TRUE., ierr)
-    call get_2d_netcdf("U2D",     ncid, u,     units, ix, jx, .TRUE., ierr)
-    call get_2d_netcdf("V2D",     ncid, v,     units, ix, jx, .TRUE., ierr)
-    call get_2d_netcdf("PSFC",    ncid, p,     units, ix, jx, .TRUE., ierr)
-    call get_2d_netcdf("LWDOWN",  ncid, lw,    units, ix, jx, .TRUE., ierr)
-    call get_2d_netcdf("SWDOWN",  ncid, sw,    units, ix, jx, .TRUE., ierr)
-    call get_2d_netcdf("RAINRATE",ncid, pcp,   units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_T),     ncid, t,     units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_Q),     ncid, q,     units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_U),     ncid, u,     units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_V),     ncid, v,     units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_P),    ncid, p,     units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_LW),  ncid, lw,    units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_SW),  ncid, sw,    units, ix, jx, .TRUE., ierr)
+    call get_2d_netcdf(trim(forcing_name_PR),ncid, pcp,   units, ix, jx, .TRUE., ierr)
     call get_2d_netcdf("VEGFRA",  ncid, fpar,  units, ix, jx, .FALSE., ierr)
 
     if (ierr == 0) then
       if(maxval(fpar) .gt. 10 .and. maxval(fpar) .lt. 10000)  fpar = fpar * 1.E-2
     endif
+
     call get_2d_netcdf("LAI",     ncid, lai,   units, ix, jx, .FALSE., ierr)
-    call get_2d_netcdf("SNOW",    ncid, snowbl,units, ix, jx, .FALSE., ierr)
+    call get_2d_netcdf(trim(forcing_name_SN),    ncid, snowbl,units, ix, jx, .FALSE., ierr)
     if (ierr /= 0) then
        allocate(liqfrac(ix,jx))
-       call get_2d_netcdf("LQFRAC", ncid, liqfrac, units, ix, jx, .FALSE., ierr)
+       call get_2d_netcdf(trim(forcing_name_LF), ncid, liqfrac, units, ix, jx, .FALSE., ierr)
        if (ierr == 0) then
           snowbl = (1.0 - liqfrac) * pcp
        else
@@ -2864,7 +2948,6 @@ end subroutine read_hydro_forcing_mpp1
 #endif
 
     ierr = nf_close(ncid)
-
   end subroutine READFORC_HRLDAS_mpp
 
   subroutine READFORC_WRF_mpp(flnm,ix,jx,target_date,t,q,u,v,p,lw,sw,pcp,lai,fpar)

--- a/src/Routing/module_lsm_forcing.F
+++ b/src/Routing/module_lsm_forcing.F
@@ -443,7 +443,7 @@ Contains
 
 
 
-  subroutine READFORC_HRLDAS(flnm,ix,jx,target_date, t,q,u,v,p,lw,sw,pcp,lai,fpar)
+  subroutine READFORC_HRLDAS(flnm,ix,jx,target_date,t,q,u,v,p,lw,sw,pcp,lai,lqf,fpar)
     implicit none
 
     character(len=*),                   intent(in)  :: flnm
@@ -460,6 +460,7 @@ Contains
     real,             dimension(ix,jx), intent(out) :: pcp
     real,             dimension(ix,jx), intent(inout) :: lai
     real,             dimension(ix,jx), intent(inout) :: fpar
+    real,             dimension(ix,jx), intent(inout) :: lqf
 
     character(len=256) :: units
     integer :: ierr
@@ -485,6 +486,7 @@ Contains
       if(maxval(fpar) .gt. 10 .and. maxval(fpar) .lt. 10000)  fpar = fpar * 1.E-2
     endif
     call get_2d_netcdf("LAI",     ncid, lai,   units, ix, jx, .FALSE., ierr)
+    call get_2d_netcdf("LQFRAC",  ncid, lqf,   units, ix, jx, .FALSE., ierr)
 
     ierr = nf_close(ncid)
 
@@ -901,7 +903,7 @@ Contains
        indir,olddate,hgrid, &
        ix,jx,forc_typ,snow_assim,  &
        T2,q2x,u,v,pres,xlong,short,prcp1,&
-       lai,fpar,snodep,dt,k,prcp_old)
+       lai,lqf,fpar,snodep,dt,k,prcp_old)
 ! This subrouting is going to read different forcing.
    implicit none
    ! in variable
@@ -914,14 +916,13 @@ Contains
    ! tmp variable
    character(len=256) :: inflnm, inflnm2, product
    integer  :: i,j,mmflag,ierr_flg
-   real,dimension(ix,jx):: lai,fpar
+   real,dimension(ix,jx):: lai,lqf,fpar
    character(len=4) nwxst_t
    logical :: fexist
 
         inflnm = trim(indir)//"/"//&
              olddate(1:4)//olddate(6:7)//olddate(9:10)//olddate(12:13)//&
              ".LDASIN_DOMAIN"//hgrid
-
 !!!DJG... Call READFORC_(variable) Subroutine for forcing data...
 !!!DJG HRLDAS Format Forcing with hour format filename (NOTE: precip must be in mm/s!!!)
    if(FORC_TYP.eq.1) then
@@ -938,7 +939,7 @@ Contains
         endif
 
       CALL READFORC_HRLDAS(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
-          PRES,XLONG,SHORT,PRCP1,LAI,FPAR)
+          PRES,XLONG,SHORT,PRCP1,LAI,LQF,FPAR)
    end if
 
 
@@ -957,7 +958,7 @@ Contains
            call hydro_stop("In read_hydro_forcing_seq() - no forcing data found")
         endif
       CALL READFORC_HRLDAS(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
-          PRES,XLONG,SHORT,PRCP1,LAI,FPAR)
+          PRES,XLONG,SHORT,PRCP1,LAI,LQF,FPAR)
    end if
 
 
@@ -1143,7 +1144,7 @@ Contains
 #endif
 
            CALL READFORC_HRLDAS(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
-                PRES,XLONG,SHORT,PRCP1,LAI,FPAR)
+                PRES,XLONG,SHORT,PRCP1,LAI,LQF,FPAR)
            PRCP_old = PRCP1  ! This assigns new precip to last precip as a fallback for missing data...
         endif
 
@@ -1720,7 +1721,7 @@ Contains
        indir,olddate,hgrid, &
        ix,jx,forc_typ,snow_assim,  &
        T2,q2x,u,v,pres,xlong,short,prcp1,&
-       lai,fpar,snodep,dt,k,prcp_old)
+       lai,lqf,fpar,snodep,dt,k,prcp_old)
 ! This subrouting is going to read different forcing.
 
 
@@ -1730,13 +1731,13 @@ Contains
    character(len=256) :: filename
    integer :: ix,jx,forc_typ,k,snow_assim  ! k is time loop
    real,dimension(ix,jx):: T2,q2x,u,v,pres,xlong,short,prcp1,&
-          prcpnew,lai,fpar,snodep,prcp_old
+          prcpnew,lai,lqf,fpar,snodep,prcp_old
    real ::  dt
    ! tmp variable
    character(len=256) :: inflnm, product
    integer  :: i,j,mmflag
    real,dimension(global_nx,global_ny):: g_T2,g_Q2X,g_U,g_V,g_XLONG, &
-             g_SHORT,g_PRCP1,g_PRES,g_lai,g_snodep,g_prcp_old, g_fpar
+             g_SHORT,g_PRCP1,g_PRES,g_lai,g_lqf,g_snodep,g_prcp_old, g_fpar
    integer flag
 
 
@@ -1752,6 +1753,7 @@ Contains
      call write_io_real(prcp_old,g_PRCP_old)
 
      call write_io_real(lai,g_lai)
+     call write_io_real(lqf,g_lqf)
      call write_io_real(fpar,g_fpar)
      call write_io_real(snodep,g_snodep)
 
@@ -1762,7 +1764,7 @@ Contains
         indir,olddate,hgrid,&
         global_nx,global_ny,forc_typ,snow_assim,  &
         g_T2,g_q2x,g_u,g_v,g_pres,g_xlong,g_short,g_prcp1,&
-        g_lai,g_fpar,g_snodep,dt,k,g_prcp_old)
+        g_lai,g_lqf,g_fpar,g_snodep,dt,k,g_prcp_old)
 #ifdef HYDRO_D
      write(6,*) "finish read forcing,olddate ",olddate
 #endif
@@ -2253,7 +2255,7 @@ subroutine read_hydro_forcing_mpp1( &
      indir,olddate,hgrid, &
      ix,jx,forc_typ,snow_assim,  &
      T2,q2x,u,v,pres,xlong,short,prcp1,&
-     lai,fpar,snodep,dt,k,prcp_old)
+     lai,lqf,fpar,snodep,dt,k,prcp_old)
 ! This subrouting is going to read different forcing.
 implicit none
 ! in variable
@@ -2266,7 +2268,7 @@ real ::  dt, wrf_dt
 ! tmp variable
 character(len=256) :: inflnm, inflnm2, product
 integer  :: i,j,mmflag,ierr_flg
-real,dimension(ix,jx):: lai,fpar
+real,dimension(ix,jx):: lai,lqf,fpar
 character(len=4) nwxst_t
 logical :: fexist
 
@@ -2274,9 +2276,9 @@ inflnm = trim(indir)//"/"//&
          olddate(1:4)//olddate(6:7)//olddate(9:10)//olddate(12:13)//&
          ".LDASIN_DOMAIN"//hgrid
 
+
 !!!DJG... Call READFORC_(variable) Subroutine for forcing data...
 !!!DJG HRLDAS Format Forcing with hour format filename (NOTE: precip must be in mm/s!!!)
-
 
 !!! FORC_TYPE 1 ============================================================================
 if(FORC_TYP.eq.1) then
@@ -2300,7 +2302,7 @@ if(FORC_TYP.eq.1) then
    print*, "read forcing data at ", OLDDATE,  trim(inflnm)
 #endif
    call READFORC_HRLDAS_mpp(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
-        PRES,XLONG,SHORT,PRCP1,LAI,FPAR)
+        PRES,XLONG,SHORT,PRCP1,LAI,LQF,FPAR)
 
    where(PRCP1 .lt. 0) PRCP1= 0  ! set minimum to be 0
    where(PRCP1 .gt. 0.138889) PRCP1= 0.138889 ! set maximum to be 500 mm/h
@@ -2326,7 +2328,7 @@ if(FORC_TYP.eq.2) then
       call hydro_stop("In read_hydro_forcing_mpp1() - no forcing data found")
    endif
    call READFORC_HRLDAS_mpp(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
-        PRES,XLONG,SHORT,PRCP1,LAI,FPAR)
+        PRES,XLONG,SHORT,PRCP1,LAI,LQF,FPAR)
 
    where(PRCP1 .lt. 0) PRCP1= 0  ! set minimum to be 0
    where(PRCP1 .gt. 0.138889) PRCP1= 0.138889 ! set maximum to be 500 mm/h
@@ -2540,7 +2542,7 @@ if(FORC_TYP.eq.6) then
 #endif
 
       call READFORC_HRLDAS_mpp(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
-           PRES,XLONG,SHORT,PRCP1,LAI,FPAR)
+           PRES,XLONG,SHORT,PRCP1,LAI,LQF,FPAR)
       PRCP_old = PRCP1  ! This assigns new precip to last precip as a fallback for missing data...
    endif
 
@@ -2729,7 +2731,7 @@ end subroutine read_hydro_forcing_mpp1
 
 
 
-  subroutine READFORC_HRLDAS_mpp(flnm,ix,jx,target_date, t,q,u,v,p,lw,sw,pcp,lai,fpar)
+  subroutine READFORC_HRLDAS_mpp(flnm,ix,jx,target_date, t,q,u,v,p,lw,sw,pcp,lai,lqf,fpar)
     implicit none
 
     character(len=*),                   intent(in)  :: flnm
@@ -2745,6 +2747,7 @@ end subroutine read_hydro_forcing_mpp1
     real,             dimension(ix,jx), intent(out) :: sw
     real,             dimension(ix,jx), intent(out) :: pcp
     real,             dimension(ix,jx), intent(inout) :: lai
+    real,             dimension(ix,jx), intent(inout) :: lqf
     real,             dimension(ix,jx), intent(inout) :: fpar
 
     character(len=256) :: units
@@ -2754,6 +2757,7 @@ end subroutine read_hydro_forcing_mpp1
     ! Open the NetCDF file.
 #ifdef MPP_LAND
     real, allocatable, dimension(:,:):: buf2
+
     if(my_id .eq. io_id) then
         allocate(buf2(global_nx,global_ny))
     else
@@ -2796,6 +2800,9 @@ end subroutine read_hydro_forcing_mpp1
     if(my_id .eq. io_id ) call get_2d_netcdf("LAI",     ncid, buf2,   units, global_nx, global_ny, .FALSE., ierr)
     call mpp_land_bcast_int1(ierr)
     if(ierr == 0) call decompose_data_real (buf2,lai)
+    if(my_id .eq. io_id ) call get_2d_netcdf("LQFRAC", ncid,buf2, units, global_nx, global_ny, .FALSE., ierr)
+    call mpp_land_bcast_int1(ierr)
+    if(ierr == 0) call decompose_data_real (buf2,lqf)
 
     deallocate(buf2)
 #else
@@ -2818,6 +2825,7 @@ end subroutine read_hydro_forcing_mpp1
       if(maxval(fpar) .gt. 10 .and. maxval(fpar) .lt. 10000)  fpar = fpar * 1.E-2
     endif
     call get_2d_netcdf("LAI",     ncid, lai,   units, ix, jx, .FALSE., ierr)
+    call get_2d_netcdf("LQFRAC",  ncid, lqf,   units, ix, jx, .FALSE., ierr)
 #endif
 
     ierr = nf_close(ncid)

--- a/src/Routing/module_lsm_forcing.F
+++ b/src/Routing/module_lsm_forcing.F
@@ -443,7 +443,7 @@ Contains
 
 
 
-  subroutine READFORC_HRLDAS(flnm,ix,jx,target_date,t,q,u,v,p,lw,sw,pcp,lai,lqf,fpar)
+  subroutine READFORC_HRLDAS(flnm,ix,jx,target_date,t,q,u,v,p,lw,sw,pcp,lai,snowbl,fpar)
     implicit none
 
     character(len=*),                   intent(in)  :: flnm
@@ -460,8 +460,8 @@ Contains
     real,             dimension(ix,jx), intent(out) :: pcp
     real,             dimension(ix,jx), intent(inout) :: lai
     real,             dimension(ix,jx), intent(inout) :: fpar
-    real,             dimension(ix,jx), intent(inout) :: lqf
-
+    real,             dimension(ix,jx), intent(inout) :: snowbl
+    real,             dimension(:,:),   allocatable   :: liqfrac
     character(len=256) :: units
     integer :: ierr
     integer :: ncid
@@ -486,7 +486,17 @@ Contains
       if(maxval(fpar) .gt. 10 .and. maxval(fpar) .lt. 10000)  fpar = fpar * 1.E-2
     endif
     call get_2d_netcdf("LAI",     ncid, lai,   units, ix, jx, .FALSE., ierr)
-    call get_2d_netcdf("LQFRAC",  ncid, lqf,   units, ix, jx, .FALSE., ierr)
+    call get_2d_netcdf("SNOW",    ncid, snowbl,units, ix, jx, .FALSE., ierr)
+    if (ierr /= 0) then
+       allocate(liqfrac(ix,jx))
+       call get_2d_netcdf("LQFRAC", ncid, liqfrac, units, ix, jx, .FALSE., ierr)
+       if (ierr == 0) then
+          snowbl = (1.0 - liqfrac) * pcp
+       else
+          snowbl = 0.0 ! since is liqfrac is not present it is equal to 1.0
+       end if
+       deallocate(liqfrac)
+    end if
 
     ierr = nf_close(ncid)
 
@@ -903,7 +913,7 @@ Contains
        indir,olddate,hgrid, &
        ix,jx,forc_typ,snow_assim,  &
        T2,q2x,u,v,pres,xlong,short,prcp1,&
-       lai,lqf,fpar,snodep,dt,k,prcp_old)
+       lai,snowbl,fpar,snodep,dt,k,prcp_old)
 ! This subrouting is going to read different forcing.
    implicit none
    ! in variable
@@ -916,7 +926,7 @@ Contains
    ! tmp variable
    character(len=256) :: inflnm, inflnm2, product
    integer  :: i,j,mmflag,ierr_flg
-   real,dimension(ix,jx):: lai,lqf,fpar
+   real,dimension(ix,jx):: lai,snowbl,fpar
    character(len=4) nwxst_t
    logical :: fexist
 
@@ -939,7 +949,7 @@ Contains
         endif
 
       CALL READFORC_HRLDAS(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
-          PRES,XLONG,SHORT,PRCP1,LAI,LQF,FPAR)
+          PRES,XLONG,SHORT,PRCP1,LAI,snowbl,FPAR)
    end if
 
 
@@ -958,7 +968,7 @@ Contains
            call hydro_stop("In read_hydro_forcing_seq() - no forcing data found")
         endif
       CALL READFORC_HRLDAS(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
-          PRES,XLONG,SHORT,PRCP1,LAI,LQF,FPAR)
+          PRES,XLONG,SHORT,PRCP1,LAI,snowbl,FPAR)
    end if
 
 
@@ -1144,7 +1154,7 @@ Contains
 #endif
 
            CALL READFORC_HRLDAS(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
-                PRES,XLONG,SHORT,PRCP1,LAI,LQF,FPAR)
+                PRES,XLONG,SHORT,PRCP1,LAI,snowbl,FPAR)
            PRCP_old = PRCP1  ! This assigns new precip to last precip as a fallback for missing data...
         endif
 
@@ -1721,7 +1731,7 @@ Contains
        indir,olddate,hgrid, &
        ix,jx,forc_typ,snow_assim,  &
        T2,q2x,u,v,pres,xlong,short,prcp1,&
-       lai,lqf,fpar,snodep,dt,k,prcp_old)
+       lai,snowbl,fpar,snodep,dt,k,prcp_old)
 ! This subrouting is going to read different forcing.
 
 
@@ -1731,13 +1741,13 @@ Contains
    character(len=256) :: filename
    integer :: ix,jx,forc_typ,k,snow_assim  ! k is time loop
    real,dimension(ix,jx):: T2,q2x,u,v,pres,xlong,short,prcp1,&
-          prcpnew,lai,lqf,fpar,snodep,prcp_old
+          prcpnew,lai,snowbl,fpar,snodep,prcp_old
    real ::  dt
    ! tmp variable
    character(len=256) :: inflnm, product
    integer  :: i,j,mmflag
    real,dimension(global_nx,global_ny):: g_T2,g_Q2X,g_U,g_V,g_XLONG, &
-             g_SHORT,g_PRCP1,g_PRES,g_lai,g_lqf,g_snodep,g_prcp_old, g_fpar
+             g_SHORT,g_PRCP1,g_PRES,g_lai,g_snowbl,g_snodep,g_prcp_old, g_fpar
    integer flag
 
 
@@ -1753,7 +1763,7 @@ Contains
      call write_io_real(prcp_old,g_PRCP_old)
 
      call write_io_real(lai,g_lai)
-     call write_io_real(lqf,g_lqf)
+     call write_io_real(snowbl,g_snowbl)
      call write_io_real(fpar,g_fpar)
      call write_io_real(snodep,g_snodep)
 
@@ -1764,7 +1774,7 @@ Contains
         indir,olddate,hgrid,&
         global_nx,global_ny,forc_typ,snow_assim,  &
         g_T2,g_q2x,g_u,g_v,g_pres,g_xlong,g_short,g_prcp1,&
-        g_lai,g_lqf,g_fpar,g_snodep,dt,k,g_prcp_old)
+        g_lai,g_snowbl,g_fpar,g_snodep,dt,k,g_prcp_old)
 #ifdef HYDRO_D
      write(6,*) "finish read forcing,olddate ",olddate
 #endif
@@ -2255,7 +2265,7 @@ subroutine read_hydro_forcing_mpp1( &
      indir,olddate,hgrid, &
      ix,jx,forc_typ,snow_assim,  &
      T2,q2x,u,v,pres,xlong,short,prcp1,&
-     lai,lqf,fpar,snodep,dt,k,prcp_old)
+     lai,snowbl,fpar,snodep,dt,k,prcp_old)
 ! This subrouting is going to read different forcing.
 implicit none
 ! in variable
@@ -2268,7 +2278,7 @@ real ::  dt, wrf_dt
 ! tmp variable
 character(len=256) :: inflnm, inflnm2, product
 integer  :: i,j,mmflag,ierr_flg
-real,dimension(ix,jx):: lai,lqf,fpar
+real,dimension(ix,jx):: lai,snowbl,fpar
 character(len=4) nwxst_t
 logical :: fexist
 
@@ -2302,7 +2312,7 @@ if(FORC_TYP.eq.1) then
    print*, "read forcing data at ", OLDDATE,  trim(inflnm)
 #endif
    call READFORC_HRLDAS_mpp(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
-        PRES,XLONG,SHORT,PRCP1,LAI,LQF,FPAR)
+        PRES,XLONG,SHORT,PRCP1,LAI,snowbl,FPAR)
 
    where(PRCP1 .lt. 0) PRCP1= 0  ! set minimum to be 0
    where(PRCP1 .gt. 0.138889) PRCP1= 0.138889 ! set maximum to be 500 mm/h
@@ -2328,7 +2338,7 @@ if(FORC_TYP.eq.2) then
       call hydro_stop("In read_hydro_forcing_mpp1() - no forcing data found")
    endif
    call READFORC_HRLDAS_mpp(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
-        PRES,XLONG,SHORT,PRCP1,LAI,LQF,FPAR)
+        PRES,XLONG,SHORT,PRCP1,LAI,snowbl,FPAR)
 
    where(PRCP1 .lt. 0) PRCP1= 0  ! set minimum to be 0
    where(PRCP1 .gt. 0.138889) PRCP1= 0.138889 ! set maximum to be 500 mm/h
@@ -2542,7 +2552,7 @@ if(FORC_TYP.eq.6) then
 #endif
 
       call READFORC_HRLDAS_mpp(inflnm,IX,JX,OLDDATE,T2,Q2X,U,V,   &
-           PRES,XLONG,SHORT,PRCP1,LAI,LQF,FPAR)
+           PRES,XLONG,SHORT,PRCP1,LAI,snowbl,FPAR)
       PRCP_old = PRCP1  ! This assigns new precip to last precip as a fallback for missing data...
    endif
 
@@ -2731,7 +2741,7 @@ end subroutine read_hydro_forcing_mpp1
 
 
 
-  subroutine READFORC_HRLDAS_mpp(flnm,ix,jx,target_date, t,q,u,v,p,lw,sw,pcp,lai,lqf,fpar)
+  subroutine READFORC_HRLDAS_mpp(flnm,ix,jx,target_date, t,q,u,v,p,lw,sw,pcp,lai,snowbl,fpar)
     implicit none
 
     character(len=*),                   intent(in)  :: flnm
@@ -2747,7 +2757,7 @@ end subroutine read_hydro_forcing_mpp1
     real,             dimension(ix,jx), intent(out) :: sw
     real,             dimension(ix,jx), intent(out) :: pcp
     real,             dimension(ix,jx), intent(inout) :: lai
-    real,             dimension(ix,jx), intent(inout) :: lqf
+    real,             dimension(ix,jx), intent(inout) :: snowbl
     real,             dimension(ix,jx), intent(inout) :: fpar
 
     character(len=256) :: units
@@ -2757,6 +2767,7 @@ end subroutine read_hydro_forcing_mpp1
     ! Open the NetCDF file.
 #ifdef MPP_LAND
     real, allocatable, dimension(:,:):: buf2
+    real, allocatable, dimension(:,:) :: liqfrac
 
     if(my_id .eq. io_id) then
         allocate(buf2(global_nx,global_ny))
@@ -2800,9 +2811,22 @@ end subroutine read_hydro_forcing_mpp1
     if(my_id .eq. io_id ) call get_2d_netcdf("LAI",     ncid, buf2,   units, global_nx, global_ny, .FALSE., ierr)
     call mpp_land_bcast_int1(ierr)
     if(ierr == 0) call decompose_data_real (buf2,lai)
-    if(my_id .eq. io_id ) call get_2d_netcdf("LQFRAC", ncid,buf2, units, global_nx, global_ny, .FALSE., ierr)
+    if(my_id .eq. io_id ) call get_2d_netcdf("SNOW", ncid, buf2, units, global_nx, global_ny, .FALSE., ierr)
     call mpp_land_bcast_int1(ierr)
-    if(ierr == 0) call decompose_data_real (buf2,lqf)
+    if (ierr == 0) then
+       call decompose_data_real (buf2,snowbl)
+    else
+       if(my_id .eq. io_id ) call get_2d_netcdf("LQFRAC", ncid, buf2, units, global_nx, global_ny, .FALSE., ierr)
+       call mpp_land_bcast_int1(ierr)
+       if(ierr == 0) then
+          allocate(liqfrac(ix,jx))
+          call decompose_data_real (buf2,liqfrac)
+          snowbl = (1.0 - liqfrac) * pcp
+          deallocate(liqfrac)
+       else
+          snowbl = 0.0 ! since if liqfrac is not present it defaults to 1.0
+       end if
+    end if
 
     deallocate(buf2)
 #else
@@ -2825,7 +2849,18 @@ end subroutine read_hydro_forcing_mpp1
       if(maxval(fpar) .gt. 10 .and. maxval(fpar) .lt. 10000)  fpar = fpar * 1.E-2
     endif
     call get_2d_netcdf("LAI",     ncid, lai,   units, ix, jx, .FALSE., ierr)
-    call get_2d_netcdf("LQFRAC",  ncid, lqf,   units, ix, jx, .FALSE., ierr)
+    call get_2d_netcdf("SNOW",    ncid, snowbl,units, ix, jx, .FALSE., ierr)
+    if (ierr /= 0) then
+       allocate(liqfrac(ix,jx))
+       call get_2d_netcdf("LQFRAC", ncid, liqfrac, units, ix, jx, .FALSE., ierr)
+       if (ierr == 0) then
+          snowbl = (1.0 - liqfrac) * pcp
+       else
+          snowbl = 0.0 ! since if liqfrac is not present it is set to 1.0
+       end if
+       deallocate(liqfrac)
+    end if
+
 #endif
 
     ierr = nf_close(ncid)

--- a/src/Routing/module_lsm_forcing.F
+++ b/src/Routing/module_lsm_forcing.F
@@ -25,9 +25,9 @@ module module_lsm_forcing
 #endif
     use module_HYDRO_io, only: get_2d_netcdf, get_soilcat_netcdf, get2d_int
     use module_hydro_stop, only:HYDRO_stop
+    use netcdf
 
 implicit none
-#include <netcdf.inc>
     integer :: i_forcing
 character(len=19) out_date
 
@@ -62,8 +62,8 @@ Contains
     pcpc = 0
 
     ! Open the NetCDF file.
-    ierr = nf_open(flnm, NF_NOWRITE, ncid)
-    if (ierr /= 0) then
+    ierr = nf90_open(flnm, NF90_NOWRITE, ncid)
+    if (ierr /= NF90_NOERR) then
        write(*,'("READFORC_WRF Problem opening netcdf file: ''", A, "''")') trim(flnm)
        call hydro_stop("In READFORC_WRF() - Problem opening netcdf file")
     endif
@@ -83,7 +83,7 @@ Contains
     endif
     call get_2d_netcdf_ruc("LAI", ncid, lai,  ix, jx,tlevel, .true., ierr)
 
-    ierr = nf_close(ncid)
+    ierr = nf90_close(ncid)
 
 !DJG  Add the convective and non-convective rain components (note: conv. comp=0
 !for cloud resolving runs...)
@@ -103,63 +103,63 @@ Contains
     integer :: iret, ncid, dimid
 
     ! Open the NetCDF file.
-    iret = nf_open(geo_static_flnm, NF_NOWRITE, ncid)
+    iret = nf90_open(geo_static_flnm, NF90_NOWRITE, ncid)
     if (iret /= 0) then
        write(*,'("Problem opening geo_static file: ''", A, "''")') &
             trim(geo_static_flnm)
        call hydro_stop("In read_hrldas_hdrinfo() - Problem opening geo_static file")
     endif
 
-    iret = nf_inq_dimid(ncid, "west_east", dimid)
+    iret = nf90_inq_dimid(ncid, "west_east", dimid)
 
     if (iret /= 0) then
-!       print*, "nf_inq_dimid:  west_east"
-       call hydro_stop("In read_hrldas_hdrinfo() - nf_inq_dimid:  west_east problem")
+!       print*, "nf90_inq_dimid:  west_east"
+       call hydro_stop("In read_hrldas_hdrinfo() - nf90_inq_dimid:  west_east problem")
     endif
 
-    iret = nf_inq_dimlen(ncid, dimid, ix)
+    iret = nf90_inquire_dimension(ncid, dimid, len=ix)
     if (iret /= 0) then
-!       print*, "nf_inq_dimlen:  west_east"
-       call hydro_stop("In read_hrldas_hdrinfo() - nf_inq_dimlen:  west_east problem")
+!       print*, "nf90_inq_dimlen:  west_east"
+       call hydro_stop("In read_hrldas_hdrinfo() - nf90_inq_dimlen:  west_east problem")
     endif
 
-    iret = nf_inq_dimid(ncid, "south_north", dimid)
+    iret = nf90_inq_dimid(ncid, "south_north", dimid)
     if (iret /= 0) then
-!       print*, "nf_inq_dimid:  south_north"
-       call hydro_stop("In read_hrldas_hdrinfo() - nf_inq_dimid:  south_north problem")
+!       print*, "nf90_inq_dimid:  south_north"
+       call hydro_stop("In read_hrldas_hdrinfo() - nf90_inq_dimid:  south_north problem")
     endif
 
-    iret = nf_inq_dimlen(ncid, dimid, jx)
+    iret = nf90_inquire_dimension(ncid, dimid, len=jx)
     if (iret /= 0) then
- !      print*, "nf_inq_dimlen:  south_north"
-       call hydro_stop("In read_hrldas_hdrinfo() - nf_inq_dimlen:  south_north problem")
+ !      print*, "nf90_inq_dimlen:  south_north"
+       call hydro_stop("In read_hrldas_hdrinfo() - nf90_inq_dimlen:  south_north problem")
     endif
 
-    iret = nf_inq_dimid(ncid, "land_cat", dimid)
+    iret = nf90_inq_dimid(ncid, "land_cat", dimid)
     if (iret /= 0) then
- !      print*, "nf_inq_dimid:  land_cat"
-       call hydro_stop("In read_hrldas_hdrinfo() - nf_inq_dimid:  land_cat problem")
+ !      print*, "nf90_inq_dimid:  land_cat"
+       call hydro_stop("In read_hrldas_hdrinfo() - nf90_inq_dimid:  land_cat problem")
     endif
 
-    iret = nf_inq_dimlen(ncid, dimid, land_cat)
+    iret = nf90_inquire_dimension(ncid, dimid, len=land_cat)
     if (iret /= 0) then
-       print*, "nf_inq_dimlen:  land_cat"
-       call hydro_stop("In read_hrldas_hdrinfo() - nf_inq_dimlen:  land_cat problem")
+       print*, "nf90_inq_dimlen:  land_cat"
+       call hydro_stop("In read_hrldas_hdrinfo() - nf90_inq_dimlen:  land_cat problem")
     endif
 
-    iret = nf_inq_dimid(ncid, "soil_cat", dimid)
+    iret = nf90_inq_dimid(ncid, "soil_cat", dimid)
     if (iret /= 0) then
- !      print*, "nf_inq_dimid:  soil_cat"
-       call hydro_stop("In read_hrldas_hdrinfo() - nf_inq_dimid:  soil_cat problem")
+ !      print*, "nf90_inq_dimid:  soil_cat"
+       call hydro_stop("In read_hrldas_hdrinfo() - nf90_inq_dimid:  soil_cat problem")
     endif
 
-    iret = nf_inq_dimlen(ncid, dimid, soil_cat)
+    iret = nf90_inquire_dimension(ncid, dimid, len=soil_cat)
     if (iret /= 0) then
- !      print*, "nf_inq_dimlen:  soil_cat"
-       call hydro_stop("In read_hrldas_hdrinfo() - nf_inq_dimlen:  soil_cat problem")
+ !      print*, "nf90_inq_dimlen:  soil_cat"
+       call hydro_stop("In read_hrldas_hdrinfo() - nf90_inq_dimlen:  soil_cat problem")
     endif
 
-    iret = nf_close(ncid)
+    iret = nf90_close(ncid)
 
   end subroutine read_hrldas_hdrinfo
 
@@ -183,18 +183,18 @@ Contains
     integer :: islake, iswater, isoilwater
 
     ! Open the NetCDF file.
-    ierr = nf_open(geo_static_flnm, NF_NOWRITE, ncid)
+    ierr = nf90_open(geo_static_flnm, NF90_NOWRITE, ncid)
 
-    if (ierr /= 0) then
+    if (ierr /= NF90_NOERR) then
        write(*,'("Problem opening geo_static file: ''", A, "''")') trim(geo_static_flnm)
        call hydro_stop("In readland_hrldas() - Problem opening geo_static file")
     endif
 
     flag = -99
-    ierr = nf_inq_varid(ncid,"XLAT", varid)
+    ierr = nf90_inq_varid(ncid,"XLAT", varid)
     flag = 1
     if(ierr .ne. 0) then
-        ierr = nf_inq_varid(ncid,"XLAT_M", varid)
+        ierr = nf90_inq_varid(ncid,"XLAT_M", varid)
         if(ierr .ne. 0) then
 !            write(6,*) "XLAT not found from wrfstatic file. "
             call hydro_stop("In readland_hrldas() - XLAT not found from wrfstatic file")
@@ -257,26 +257,26 @@ Contains
 
     endif
 
-    ierr = NF_GET_ATT_INT(ncid, NF_GLOBAL, 'ISWATER', iswater)
-    if (ierr /= 0) then
+    ierr = nf90_get_att(ncid, NF90_GLOBAL, 'ISWATER', iswater)
+    if (ierr /= NF90_NOERR) then
        call hydro_stop("In readland_hrldas() - Attribute ISWATER unable to be read from geo_static_flnm")
     endif
 
-    ierr = NF_GET_ATT_INT(ncid, NF_GLOBAL, 'ISOILWATER', isoilwater)
-    if (ierr /= 0) then
+    ierr = nf90_get_att(ncid, NF90_GLOBAL, 'ISOILWATER', isoilwater)
+    if (ierr /= NF90_NOERR) then
        call hydro_stop("In readland_hrldas() - Attribute ISOILWATER unable to be read from geo_static_flnm")
     endif
 
-    ierr = NF_GET_ATT_INT(ncid, NF_GLOBAL, 'ISLAKE', islake)
-    if (ierr /= 0) then
+    ierr = nf90_get_att(ncid, NF90_GLOBAL, 'ISLAKE', islake)
+    if (ierr /= NF90_NOERR) then
        call hydro_stop("In readland_hrldas() - Attribute ISLAKE unable to be read from geo_static_flnm")
     endif
 
     ! Close the NetCDF file
-    ierr = nf_close(ncid)
-    if (ierr /= 0) then
-       print*, "MODULE_NOAHLSM_HRLDAS_INPUT:  READLAND_HRLDAS:  NF_CLOSE"
-       call hydro_stop("In readland_hrldas() - NF_CLOSE problem")
+    ierr = nf90_close(ncid)
+    if (ierr /= NF90_NOERR) then
+       print*, "MODULE_NOAHLSM_HRLDAS_INPUT:  READLAND_HRLDAS:  NF90_CLOSE"
+       call hydro_stop("In readland_hrldas() - NF90_CLOSE problem")
     endif
 
  write(6, *) "readland_hrldas: ISLAKE ISWATER ISOILWATER", islake, iswater, isoilwater
@@ -309,18 +309,18 @@ Contains
           count(1) = ix
           count(2) = jx
           start(4) = tlevel
-      ierr = nf_inq_varid(ncid,  var_name,  varid)
+      ierr = nf90_inq_varid(ncid,  var_name,  varid)
 
-      if (ierr /= 0) then
+      if (ierr /= NF90_NOERR) then
         if (fatal_IF_ERROR) then
-           print*, "MODULE_NOAHLSM_HRLDAS_INPUT: get_2d_netcdf_ruc:nf_inq_varid ", trim(var_name)
-           call hydro_stop("In get_2d_netcdf_ruc() - nf_inq_varid problem")
+           print*, "MODULE_NOAHLSM_HRLDAS_INPUT: get_2d_netcdf_ruc:nf90_inq_varid ", trim(var_name)
+           call hydro_stop("In get_2d_netcdf_ruc() - nf90_inq_varid problem")
         else
           return
         endif
       endif
 
-      ierr = nf_get_vara_real(ncid, varid, start,count,var)
+      ierr = nf90_get_var(ncid, varid, var, start, count)
 
 
       return
@@ -341,18 +341,18 @@ Contains
           count(1) = ix
           count(2) = jx
           start(4) = tlevel
-      iret = nf_inq_varid(ncid,  var_name,  varid)
+      iret = nf90_inq_varid(ncid,  var_name,  varid)
 
       if (iret /= 0) then
         if (fatal_IF_ERROR) then
-           print*, "MODULE_NOAHLSM_HRLDAS_INPUT: get_2d_netcdf_cows:nf_inq_varid"
-           call hydro_stop("In get_2d_netcdf_cows() - nf_inq_varid problem")
+           print*, "MODULE_NOAHLSM_HRLDAS_INPUT: get_2d_netcdf_cows:nf90_inq_varid"
+           call hydro_stop("In get_2d_netcdf_cows() - nf90_inq_varid problem")
         else
           ierr = iret
           return
         endif
       endif
-      iret = nf_get_vara_real(ncid, varid, start,count,var)
+      iret = nf90_get_var(ncid, varid, var, start,count)
 
       return
       end subroutine get_2d_netcdf_cows
@@ -387,8 +387,8 @@ Contains
     logical :: found_canwat, found_skintemp, found_weasd, found_stemp, found_smois
 
     ! Open the NetCDF file.
-    ierr = nf_open(netcdf_flnm, NF_NOWRITE, ncid)
-    if (ierr /= 0) then
+    ierr = nf90_open(netcdf_flnm, NF90_NOWRITE, ncid)
+    if (ierr /= NF90_NOERR) then
        write(*,'("READINIT Problem opening netcdf file: ''", A, "''")') &
             trim(netcdf_flnm)
        call hydro_stop("In readinit_hrldas()- Problem opening netcdf file")
@@ -437,7 +437,7 @@ Contains
 
     sh2o = smc
 
-    ierr = nf_close(ncid)
+    ierr = nf90_close(ncid)
   end subroutine readinit_hrldas
 
 
@@ -480,8 +480,8 @@ Contains
     integer :: ncid
 
     ! Open the NetCDF file.
-    ierr = nf_open(trim(flnm), NF_NOWRITE, ncid)
-    if (ierr /= 0) then
+    ierr = nf90_open(trim(flnm), NF90_NOWRITE, ncid)
+    if (ierr /= NF90_NOERR) then
        write(*,'("READFORC Problem opening netcdf file: ''", A, "''")') trim(flnm)
        call hydro_stop("In READFORC_HRLDAS() - Problem opening netcdf file")
     endif
@@ -501,7 +501,7 @@ Contains
 
     call get_2d_netcdf("LAI",     ncid, lai,   units, ix, jx, .FALSE., ierr)
     call get_2d_netcdf(trim(forcing_name_SN),    ncid, snowbl,units, ix, jx, .FALSE., ierr)
-    if (ierr /= 0) then
+    if (ierr /= NF90_NOERR) then
        allocate(liqfrac(ix,jx))
        call get_2d_netcdf(trim(forcing_name_LF), ncid, liqfrac, units, ix, jx, .FALSE., ierr)
        if (ierr == 0) then
@@ -512,7 +512,7 @@ Contains
        deallocate(liqfrac)
     end if
 
-    ierr = nf_close(ncid)
+    ierr = nf90_close(ncid)
 
   end subroutine READFORC_HRLDAS
 
@@ -577,7 +577,7 @@ Contains
 
 
 !open NetCDF file...
-        ierr_flg = nf_open(flnm, NF_NOWRITE, ncid)
+        ierr_flg = nf90_open(flnm, NF90_NOWRITE, ncid)
         if (ierr_flg /= 0) then
 #ifdef HYDRO_D
           write(*,'("READFORC_MDV Problem opening netcdf file: ''",A,"''")') &
@@ -586,13 +586,13 @@ Contains
            return
         end if
 
-        ierr = nf_inq_varid(ncid,  "precip",  varid)
-        if(ierr /= 0) ierr_flg = ierr
-        if (ierr /= 0) then
-          ierr = nf_inq_varid(ncid,  "precip_rate",  varid)   !recheck variable name...
-          if (ierr /= 0) then
-            ierr = nf_inq_varid(ncid,  "RAINRATE",  varid)   !recheck variable name...
-            if (ierr /= 0) then
+        ierr = nf90_inq_varid(ncid,  "precip",  varid)
+        if(ierr /= NF90_NOERR) ierr_flg = ierr
+        if (ierr /= NF90_NOERR) then
+          ierr = nf90_inq_varid(ncid,  "precip_rate",  varid)   !recheck variable name...
+          if (ierr /= NF90_NOERR) then
+            ierr = nf90_inq_varid(ncid,  "RAINRATE",  varid)   !recheck variable name...
+            if (ierr /= NF90_NOERR) then
 #ifdef HYDRO_D
               write(*,'("READFORC_MDV Problem reading precip netcdf file: ''", A,"''")') &
                  trim(flnm)
@@ -602,10 +602,10 @@ Contains
           ierr_flg = ierr
           mmflag = 1
         end if
-        ierr = nf_get_var_real(ncid, varid, pcp)
-        ierr = nf_close(ncid)
+        ierr = nf90_get_var(ncid, varid, pcp)
+        ierr = nf90_close(ncid)
 
-        if (ierr /= 0) then
+        if (ierr /= NF90_NOERR) then
 #ifdef HYDRO_D
           write(*,'("READFORC_MDV Problem reading netcdf file: ''", A,"''")') trim(flnm)
 #endif
@@ -638,18 +638,18 @@ Contains
 
 !open NetCDF file...
       if (k.eq.1.) then
-        ierr = nf_open(flnm, NF_NOWRITE, ncid)
-        if (ierr /= 0) then
+        ierr = nf90_open(flnm, NF90_NOWRITE, ncid)
+        if (ierr /= NF90_NOERR) then
           write(*,'("READFORC_NAMPCP1 Problem opening netcdf file: ''",A, "''")') &
               trim(flnm)
           call hydro_stop("In READFORC_NAMPCP() - Problem opening netcdf file")
         end if
 
-        ierr = nf_inq_varid(ncid,  trim(product),  varid)
-        ierr = nf_get_var_real(ncid, varid, buf)
-        ierr = nf_close(ncid)
+        ierr = nf90_inq_varid(ncid,  trim(product),  varid)
+        ierr = nf90_get_var(ncid, varid, buf)
+        ierr = nf90_close(ncid)
 
-        if (ierr /= 0) then
+        if (ierr /= NF90_NOERR) then
           write(*,'("READFORC_NAMPCP2 Problem reading netcdf file: ''", A,"''")') &
              trim(flnm)
           call hydro_stop("In READFORC_NAMPCP() - Problem reading netcdf file")
@@ -696,8 +696,8 @@ Contains
     integer :: ncid
 
     ! Open the NetCDF file.
-    ierr = nf_open(flnm, NF_NOWRITE, ncid)
-    if (ierr /= 0) then
+    ierr = nf90_open(flnm, NF90_NOWRITE, ncid)
+    if (ierr /= NF90_NOERR) then
        write(*,'("READFORC_COWS Problem opening netcdf file: ''", A, "''")') trim(flnm)
        call hydro_stop("In READFORC_COWS() - Problem opening netcdf file")
     endif
@@ -711,7 +711,7 @@ Contains
     call get_2d_netcdf_cows("RAIN",    ncid, pcp,   ix, jx,tlevel, .TRUE., ierr)
 !yw   call get_2d_netcdf_cows("V2D",     ncid, v,     ix, jx,tlevel, .TRUE., ierr)
 
-    ierr = nf_close(ncid)
+    ierr = nf90_close(ncid)
 
   end subroutine READFORC_COWS
 
@@ -736,8 +736,8 @@ Contains
     tlevel = 1
 
     ! Open the NetCDF file.
-    ierr = nf_open(flnm, NF_NOWRITE, ncid)
-    if (ierr /= 0) then
+    ierr = nf90_open(flnm, NF90_NOWRITE, ncid)
+    if (ierr /= NF90_NOERR) then
        write(*,'("READFORC_RUC Problem opening netcdf file: ''", A, "''")') trim(flnm)
        call hydro_stop("In READFORC_RUC() - Problem opening netcdf file")
     endif
@@ -752,7 +752,7 @@ Contains
     call get_2d_netcdf_ruc("RAINC",  ncid, pcpc,  ix, jx,tlevel, .true., ierr)
     call get_2d_netcdf_ruc("RAINNC", ncid, pcp,   ix, jx,tlevel, .true., ierr)
 
-    ierr = nf_close(ncid)
+    ierr = nf90_close(ncid)
 
 
 !DJG  Add the convective and non-convective rain components (note: conv. comp=0
@@ -783,14 +783,14 @@ Contains
 
     ! Open the NetCDF file.
 
-    ierr = nf_open(flnm, NF_NOWRITE, ncid)
-    if (ierr /= 0) then
+    ierr = nf90_open(flnm, NF90_NOWRITE, ncid)
+    if (ierr /= NF90_NOERR) then
        write(*,'("READSNOW Problem opening netcdf file: ''", A, "''")') trim(flnm)
        call hydro_stop("In READSNOW_FORC() - Problem opening netcdf file")
     endif
 
     call get_2d_netcdf("WEASD",  ncid, tmp,   units, ix, jx, .FALSE., ierr)
-    if (ierr /= 0) then
+    if (ierr /= NF90_NOERR) then
          call get_2d_netcdf("SNOW",  ncid, tmp,   units, ix, jx, .FALSE., ierr)
          if (ierr == 0) then
             units = "mm"
@@ -807,12 +807,12 @@ Contains
          endif
     endif
 
-    if (ierr /= 0) then
+    if (ierr /= NF90_NOERR) then
        print *, "!!!!! NO WEASD present in input file...initialize to 0."
     endif
 
     call get_2d_netcdf("SNODEP",     ncid, tmp,   units, ix, jx, .FALSE., ierr)
-    if (ierr /= 0) then
+    if (ierr /= NF90_NOERR) then
        ! Quick assumption regarding snow depth.
        call get_2d_netcdf("SNOWH",     ncid, tmp,   units, ix, jx, .FALSE., ierr)
        if(ierr .eq. 0) then
@@ -823,7 +823,7 @@ Contains
        snodep = tmp
     endif
 
-    if (ierr /= 0) then
+    if (ierr /= NF90_NOERR) then
        ! Quick assumption regarding snow depth.
 !yw       snodep = weasd * 10.
        where(snodep .lt. weasd) snodep = weasd*10  !set lower bound to correct bi-lin interp err...
@@ -832,7 +832,7 @@ Contains
 !DJG check for erroneous neg WEASD or SNOWD due to offline interpolation...
        where(snodep .lt. 0) snodep = 0
        where(weasd .lt. 0) weasd = 0
-    ierr = nf_close(ncid)
+    ierr = nf90_close(ncid)
 
   end subroutine READSNOW_FORC
 
@@ -843,7 +843,7 @@ Contains
           real,dimension(ix,jx,nsoil):: smc,stc,sh2ox
           character(len=*), intent(in) :: inflnm
           character(len=256)::   units
-          iret = nf_open(trim(inflnm), NF_NOWRITE, ncid)
+          iret = nf90_open(trim(inflnm), NF90_NOWRITE, ncid)
           if(iret .ne. 0 )then
               write(6,*) "Error: failed to open file :",trim(inflnm)
              call hydro_stop("In get2d_hrldas() - failed to open file")
@@ -881,7 +881,7 @@ Contains
     call get2d_hrldas_real("SOIL_W_7",    ncid, SH2OX(:,:,7),  ix, jx)
     call get2d_hrldas_real("SOIL_W_8",    ncid, SH2OX(:,:,8),  ix, jx)
 
-          iret = nf_close(ncid)
+          iret = nf90_close(ncid)
          return
       end subroutine get2d_hrldas
 
@@ -890,8 +890,8 @@ Contains
           integer ::iret,varid,ncid,ix,jx
           real out_buff(ix,jx)
           character(len=*), intent(in) :: var_name
-          iret = nf_inq_varid(ncid,trim(var_name),  varid)
-          iret = nf_get_var_real(ncid, varid, out_buff)
+          iret = nf90_inq_varid(ncid,trim(var_name),  varid)
+          iret = nf90_get_var(ncid, varid, out_buff)
          return
       end subroutine get2d_hrldas_real
 
@@ -901,14 +901,14 @@ Contains
         character(len=*),  intent(in)  :: flnm
         character(len=256) :: units
 
-        ierr = nf_open(flnm, NF_NOWRITE, ncid)
+        ierr = nf90_open(flnm, NF90_NOWRITE, ncid)
 
         if(ierr .ne. 0) then
             call hydro_stop("In read_stage4() - failed to open stage4 file.")
         endif
 
         call get_2d_netcdf("RAINRATE",ncid, buf,   units, ix, jx, .TRUE., ierr)
-        ierr = nf_close(ncid)
+        ierr = nf90_close(ncid)
         do j = 1, jx
         do i = 1, ix
             if(buf(i,j) .lt. 0) then
@@ -2858,10 +2858,10 @@ end subroutine read_hydro_forcing_mpp1
         allocate(buf2(1,1))
     endif
     if(my_id .eq. io_id) then
-        ierr = nf_open(trim(flnm), NF_NOWRITE, ncid)
+        ierr = nf90_open(trim(flnm), NF90_NOWRITE, ncid)
     endif
     call mpp_land_bcast_int1(ierr)
-    if (ierr /= 0) then
+    if (ierr /= NF90_NOERR) then
        write(*,'("READFORC Problem opening netcdf file: ''", A, "''")') trim(flnm)
        call hydro_stop("In READFORC_HRLDAS_mpp() - Problem opening netcdf file")
     endif
@@ -2913,8 +2913,8 @@ end subroutine read_hydro_forcing_mpp1
 
     deallocate(buf2)
 #else
-    ierr = nf_open(trim(flnm), NF_NOWRITE, ncid)
-    if (ierr /= 0) then
+    ierr = nf90_open(trim(flnm), NF90_NOWRITE, ncid)
+    if (ierr /= NF90_NOERR) then
        write(*,'("READFORC Problem opening netcdf file: ''", A, "''")') trim(flnm)
        call hydro_stop("READFORC_HRLDAS")
     endif
@@ -2934,7 +2934,7 @@ end subroutine read_hydro_forcing_mpp1
 
     call get_2d_netcdf("LAI",     ncid, lai,   units, ix, jx, .FALSE., ierr)
     call get_2d_netcdf(trim(forcing_name_SN),    ncid, snowbl,units, ix, jx, .FALSE., ierr)
-    if (ierr /= 0) then
+    if (ierr /= NF90_NOERR) then
        allocate(liqfrac(ix,jx))
        call get_2d_netcdf(trim(forcing_name_LF), ncid, liqfrac, units, ix, jx, .FALSE., ierr)
        if (ierr == 0) then
@@ -2947,7 +2947,7 @@ end subroutine read_hydro_forcing_mpp1
 
 #endif
 
-    ierr = nf_close(ncid)
+    ierr = nf90_close(ncid)
   end subroutine READFORC_HRLDAS_mpp
 
   subroutine READFORC_WRF_mpp(flnm,ix,jx,target_date,t,q,u,v,p,lw,sw,pcp,lai,fpar)
@@ -2980,9 +2980,9 @@ end subroutine read_hydro_forcing_mpp1
 
     ! Open the NetCDF file.
 
-    if(my_id .eq. io_id) ierr = nf_open(flnm, NF_NOWRITE, ncid)
+    if(my_id .eq. io_id) ierr = nf90_open(flnm, NF90_NOWRITE, ncid)
     call mpp_land_bcast_int1(ierr)
-    if (ierr /= 0) then
+    if (ierr /= NF90_NOERR) then
        write(*,'("READFORC_WRF Problem opening netcdf file: ''", A, "''")') trim(flnm)
        call hydro_stop("In READFORC_WRF_mpp() - Problem opening netcdf file")
     endif
@@ -3019,8 +3019,8 @@ end subroutine read_hydro_forcing_mpp1
 #else
 
     ! Open the NetCDF file.
-    ierr = nf_open(flnm, NF_NOWRITE, ncid)
-    if (ierr /= 0) then
+    ierr = nf90_open(flnm, NF90_NOWRITE, ncid)
+    if (ierr /= NF90_NOERR) then
        write(*,'("READFORC_WRF Problem opening netcdf file: ''", A, "''")') trim(flnm)
        call hydro_stop("In READFORC_WRF_mpp() - Problem opening netcdf file")
     endif
@@ -3043,7 +3043,7 @@ end subroutine read_hydro_forcing_mpp1
 
 
     pcp=pcp+pcpc   ! assumes pcpc=0 for resolved convection...
-    ierr = nf_close(ncid)
+    ierr = nf90_close(ncid)
 
 
   end subroutine READFORC_WRF_mpp
@@ -3078,7 +3078,7 @@ end subroutine read_hydro_forcing_mpp1
 #ifdef MPP_LAND
       if(my_id .eq. io_id) then
 #endif
-        ierr_flg = nf_open(flnm, NF_NOWRITE, ncid)
+        ierr_flg = nf90_open(flnm, NF90_NOWRITE, ncid)
 #ifdef MPP_LAND
       endif
       call mpp_land_bcast_int1(ierr_flg)
@@ -3095,31 +3095,31 @@ end subroutine read_hydro_forcing_mpp1
 #ifdef MPP_LAND
       if(my_id .eq. io_id) then
 #endif
-        ierr = nf_inq_varid(ncid,  "precip",  varid)
+        ierr = nf90_inq_varid(ncid,  "precip",  varid)
 #ifdef MPP_LAND
       endif
       call mpp_land_bcast_int1(ierr)
 #endif
-        if(ierr /= 0) ierr_flg = ierr
-        if (ierr /= 0) then
+        if(ierr /= NF90_NOERR) ierr_flg = ierr
+        if (ierr /= NF90_NOERR) then
 #ifdef MPP_LAND
       if(my_id .eq. io_id) then
 #endif
-          ierr = nf_inq_varid(ncid,  "precip_rate",  varid)   !recheck variable name...
+          ierr = nf90_inq_varid(ncid,  "precip_rate",  varid)   !recheck variable name...
 #ifdef MPP_LAND
       endif
       call mpp_land_bcast_int1(ierr)
 #endif
-          if (ierr /= 0) then
+          if (ierr /= NF90_NOERR) then
 #ifdef MPP_LAND
           if(my_id .eq. io_id) then
 #endif
-             ierr = nf_inq_varid(ncid,  "RAINRATE",  varid)   !recheck variable name...
+             ierr = nf90_inq_varid(ncid,  "RAINRATE",  varid)   !recheck variable name...
 #ifdef MPP_LAND
           endif
           call mpp_land_bcast_int1(ierr)
 #endif
-            if (ierr /= 0) then
+            if (ierr /= NF90_NOERR) then
               write(*,'("READFORC_MDV Problem reading precip netcdf file: ''", A,"''")') &
                  trim(flnm)
 #ifdef MPP_LAND
@@ -3133,18 +3133,18 @@ end subroutine read_hydro_forcing_mpp1
         end if
 #ifdef MPP_LAND
       if(my_id .eq. io_id) then
-          ierr = nf_get_var_real(ncid, varid, buf2)
+          ierr = nf90_get_var(ncid, varid, buf2)
       endif
       call mpp_land_bcast_int1(ierr)
       if(ierr ==0) call decompose_data_real (buf2,pcp)
       deallocate(buf2)
 #else
-        ierr = nf_get_var_real(ncid, varid, pcp)
+        ierr = nf90_get_var(ncid, varid, pcp)
 #endif
-        if (ierr /= 0) then
+        if (ierr /= NF90_NOERR) then
            write(*,'("READFORC_MDV Problem reading netcdf file: ''", A,"''")') trim(flnm)
         end if
-        ierr = nf_close(ncid)
+        ierr = nf90_close(ncid)
 
   end subroutine READFORC_MDV_mpp
 
@@ -3174,12 +3174,12 @@ end subroutine read_hydro_forcing_mpp1
 #ifdef MPP_LAND
       if(my_id .eq. io_id) then
 #endif
-    ierr = nf_open(flnm, NF_NOWRITE, ncid)
+    ierr = nf90_open(flnm, NF90_NOWRITE, ncid)
 #ifdef MPP_LAND
       endif
       call mpp_land_bcast_int1(ierr)
 #endif
-    if (ierr /= 0) then
+    if (ierr /= NF90_NOERR) then
        write(*,'("READSNOW Problem opening netcdf file: ''", A, "''")') trim(flnm)
        call hydro_stop("In READSNOW_FORC_mpp() - Problem opening netcdf file")
     endif
@@ -3193,7 +3193,7 @@ end subroutine read_hydro_forcing_mpp1
 #else
     call get_2d_netcdf("WEASD",  ncid, tmp,   units, ix, jx, .FALSE., ierr)
 #endif
-    if (ierr /= 0) then
+    if (ierr /= NF90_NOERR) then
          call get_2d_netcdf("SNOW",  ncid, tmp,   units, ix, jx, .FALSE., ierr)
          if (ierr == 0) then
             units = "mm"
@@ -3212,7 +3212,7 @@ end subroutine read_hydro_forcing_mpp1
          endif
     endif
 
-    if (ierr /= 0) then
+    if (ierr /= NF90_NOERR) then
        print *, "!!!!! NO WEASD present in input file...initialize to 0."
     endif
 #ifdef MPP_LAND
@@ -3224,7 +3224,7 @@ end subroutine read_hydro_forcing_mpp1
 #else
     call get_2d_netcdf("SNODEP",     ncid, tmp,   units, ix, jx, .FALSE., ierr)
 #endif
-    if (ierr /= 0) then
+    if (ierr /= NF90_NOERR) then
        ! Quick assumption regarding snow depth.
 
 #ifdef MPP_LAND
@@ -3246,7 +3246,7 @@ end subroutine read_hydro_forcing_mpp1
        snodep = tmp
     endif
 
-    if (ierr /= 0) then
+    if (ierr /= NF90_NOERR) then
        ! Quick assumption regarding snow depth.
 !yw       snodep = weasd * 10.
        where(snodep .lt. weasd) snodep = weasd*10  !set lower bound to correct bi-lin interp err...
@@ -3255,7 +3255,7 @@ end subroutine read_hydro_forcing_mpp1
 !DJG check for erroneous neg WEASD or SNOWD due to offline interpolation...
        where(snodep .lt. 0) snodep = 0
        where(weasd .lt. 0) weasd = 0
-    ierr = nf_close(ncid)
+    ierr = nf90_close(ncid)
 
   end subroutine READSNOW_FORC_mpp
 
@@ -3315,7 +3315,7 @@ end subroutine read_hydro_forcing_mpp1
 !       read file1
 #ifdef MPP_LAND
         if(my_id .eq. io_id) then
-           ierr = nf_open(trim(inflnm), NF_NOWRITE, ncid)
+           ierr = nf90_open(trim(inflnm), NF90_NOWRITE, ncid)
            call get_2d_netcdf("SFCRNOFF",    ncid, gArr, units,  global_nx, global_ny, .TRUE., ierr)
         endif
         call decompose_data_real (gArr,infxsrt)
@@ -3324,18 +3324,18 @@ end subroutine read_hydro_forcing_mpp1
         endif
         call decompose_data_real (gArr,soldrain)
         if(my_id .eq. io_id) then
-            ierr = nf_close(ncid)
+            ierr = nf90_close(ncid)
         endif
 #else
-        ierr = nf_open(trim(inflnm), NF_NOWRITE, ncid)
+        ierr = nf90_open(trim(inflnm), NF90_NOWRITE, ncid)
         call get_2d_netcdf("SFCRNOFF",    ncid, infxsrt, units,  ix, jx, .TRUE., ierr)
         call get_2d_netcdf("UGDRNOFF",    ncid, soldrain, units,  ix, jx, .TRUE., ierr)
-        ierr = nf_close(ncid)
+        ierr = nf90_close(ncid)
 #endif
 !       read file2
 #ifdef MPP_LAND
        if(my_id .eq. io_id) then
-           ierr = nf_open(trim(inflnm2), NF_NOWRITE, ncid)
+           ierr = nf90_open(trim(inflnm2), NF90_NOWRITE, ncid)
            call get_2d_netcdf("SFCRNOFF",    ncid, gArr, units,  global_nx, global_ny, .TRUE., ierr)
         endif
         call decompose_data_real (gArr,infxsrt2)
@@ -3344,13 +3344,13 @@ end subroutine read_hydro_forcing_mpp1
         endif
         call decompose_data_real (gArr,soldrain2)
         if(my_id .eq. io_id) then
-           ierr = nf_close(ncid)
+           ierr = nf90_close(ncid)
         endif
 #else
-        ierr = nf_open(trim(inflnm2), NF_NOWRITE, ncid)
+        ierr = nf90_open(trim(inflnm2), NF90_NOWRITE, ncid)
         call get_2d_netcdf("SFCRNOFF",    ncid, infxsrt2, units,  ix, jx, .TRUE., ierr)
         call get_2d_netcdf("UGDRNOFF",    ncid, soldrain2, units,  ix, jx, .TRUE., ierr)
-        ierr = nf_close(ncid)
+        ierr = nf90_close(ncid)
 #endif
 
         infxsrt = infxsrt2 - infxsrt
@@ -3410,15 +3410,15 @@ end subroutine read_hydro_forcing_mpp1
             call hydro_stop( "LDASOUT input Error")
         endif
 !       read file1
-        ierr = nf_open(trim(inflnm), NF_NOWRITE, ncid)
+        ierr = nf90_open(trim(inflnm), NF90_NOWRITE, ncid)
         call get_2d_netcdf("SFCRNOFF",    ncid, infxsrt, units,  ix, jx, .TRUE., ierr)
         call get_2d_netcdf("UGDRNOFF",    ncid, soldrain, units,  ix, jx, .TRUE., ierr)
-        ierr = nf_close(ncid)
+        ierr = nf90_close(ncid)
 !       read file2
-        ierr = nf_open(trim(inflnm2), NF_NOWRITE, ncid)
+        ierr = nf90_open(trim(inflnm2), NF90_NOWRITE, ncid)
         call get_2d_netcdf("SFCRNOFF",    ncid, infxsrt2, units,  ix, jx, .TRUE., ierr)
         call get_2d_netcdf("UGDRNOFF",    ncid, soldrain2, units,  ix, jx, .TRUE., ierr)
-        ierr = nf_close(ncid)
+        ierr = nf90_close(ncid)
 
         infxsrt = infxsrt2 - infxsrt
         soldrain = soldrain2 - soldrain

--- a/src/template/NoahMP/namelist.hrldas
+++ b/src/template/NoahMP/namelist.hrldas
@@ -64,6 +64,18 @@ rst_bi_in = 0      !0: use netcdf input restart file
 rst_bi_out = 0     !0: use netcdf output restart file
                    !1: use parallel io for outputting multiple restart files (1 per core)
 
+! Forcing input variable names
+forcing_name_T = "T2D"
+forcing_name_Q = "Q2D"
+forcing_name_U = "U2D"
+forcing_name_V = "V2D"
+forcing_name_P = "PSFC"
+forcing_name_LW = "LWDOWN"
+forcing_name_SW = "SWDOWN"
+forcing_name_PR = "RAINRATE"
+forcing_name_SN = ""
+forcing_name_LF = "LQFRAC"
+
 /
 
 &WRF_HYDRO_OFFLINE


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: liquid water fraction, lqf, forcing variable names

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: 

- Liquid water fraction: if liquid water fraction is present set `snowbl = (1.0 - liqfrac) * pcp`, otherwise set snow to 0.
- Forcing variable names in namelist: forcing variable names `T, Q, U, V, P, LW, SW` can be passed to the model in the `namelist.hrldas`. In the namelist they take the form `forcing_name_T`. If the variables are not in the namelist they default to the normal hardcoded values that have been traditionally used.
- `module_lsm_forcing.F` transitioned to Fortran 90 interfaces

TESTS CONDUCTED: Ran Amir's liquid water fraction testcase, tested new forcing variable in `namelist.hrldas`, ran Croton testcase

### Checklist
 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
