### PR TITLE
Fixed Plotting for New CI

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -200,7 +200,7 @@ jobs:
         if: ${{ always() }}
         run: |
           mkdir -p $GITHUB_WORKSPACE/test_report
-          cp -r $GITHUB_WORKSPACE/candidate/build/Run/output_${{ matrix.configuration }}/* $GITHUB_WORKSPACE/test_report/
+          cp -r $GITHUB_WORKSPACE/candidate/build/Run/output_diff/diff_plots/* $GITHUB_WORKSPACE/test_report/
 
       - name: Attach diff plots to PR
         if: ${{ failure() }}
@@ -214,5 +214,4 @@ jobs:
         with:
           name: test-reports
           path: |
-            ${{ github.workspace }}/test_report/**.html
-            ${{ github.workspace }}/test_report/*/diff_plots
+            ${{ github.workspace }}/test_report/*

--- a/tests/local/utils/attach_all_plots.bash
+++ b/tests/local/utils/attach_all_plots.bash
@@ -3,10 +3,10 @@
 PR=$1
 CONFIG=$2
 cwd=`pwd`
-diffs=$GITHUB_WORKSPACE/test_report/$CONFIG/diff_plots
+diffs=$GITHUB_WORKSPACE/test_report/$CONFIG
 
 if [[ ! -d $diffs ]]; then
-    echo "No diff plots to attach!"
+    echo "No diff plots to attach at ${diffs}"
     exit 0
 fi
 
@@ -21,9 +21,8 @@ REPO=NCAR/wrf_hydro_nwm_public
 
 cd $diffs
 
-for d in `ls -1`
-do
-        if [[ -d $d && `ls -1 $d` ]]; then
-            python $cwd/attach_plots_to_pr.py -r $REPO -p $PR -d -t "$TOKEN" --title "$title" $d/* 
-        fi
-done
+# if $diffs directory is not empty, attach files in it
+if [[ `ls -1 ./` ]]
+then
+    python $cwd/attach_plots_to_pr.py -r $REPO -p $PR -d -t "$TOKEN" --title "$title" ./*
+fi


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: CI, Github Actions

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: This fixes paths for the new CI.  When there's a difference in output from PR changes, plots are generated and need to be copied into a directory that gets zipped as an artifact. Commit is copied from [testing/new-ci-plotting](https://github.com/scrasmussen/wrf_hydro_nwm_public/tree/testing/new-ci-plotting) branch. See "Tests Conducted" section.

TESTS CONDUCTED:
- Commit `5e9d1a4` from the [testing/new-ci-plotting](https://github.com/NCAR/wrf_hydro_nwm_public/compare/main...scrasmussen:wrf_hydro_nwm_public:testing/new-ci-plotting) branches changes constants so the output from the CI run is different
- Commit `1bd34d5` (which is the same as this PR's `5e309a3`) has the changes to paths so the correct directories and files are copied to the `test-report` artifact.
- See [test-reports](https://github.com/NCAR/wrf_hydro_nwm_public/actions/runs/9009544691) at bottom of CI run.

NOTES: Once this is merged [PR#747](https://github.com/NCAR/wrf_hydro_nwm_public/pull/747) can be closed.

TODO:
 - [ ] put plots in the comments

### Checklist
 - [ ] Closes issue #xxxx 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
