### PR TITLE
bugfix: jsonpickle and py dependabot warnings 

### DIFF
--- a/tests/local/requirements.txt
+++ b/tests/local/requirements.txt
@@ -13,7 +13,6 @@ f90nml==1.2
 gdown==5.1.0
 idna==3.7
 importlib-metadata==4.13.0
-jsonpickle==1.2
 locket==0.2.0
 more-itertools==7.2.0
 netCDF4==1.6.0
@@ -22,8 +21,7 @@ pandas==1.3.5
 partd==1.0.0
 pathlib==1.0.1
 pluggy==0.12.0
-py==1.11.0
-pytest==5.4.1
+pytest==7.4.4
 pytest-html==3.0.0
 pytest-metadata==1.8.0
 python-dateutil==2.8.0

--- a/tests/local/utils/nwm_testing.yml
+++ b/tests/local/utils/nwm_testing.yml
@@ -56,13 +56,12 @@ dependencies:
     - DateTime==4.3
     - deepdiff==6.2.3
     - f90nml==1.2
-    - jsonpickle==1.2
     - more-itertools==7.2.0
     - pandas==1.3.5
     - pathlib==1.0.1
     - pluggy==0.12.0
     - py==1.11.0
-    - pytest==3.8.0
+    - pytest==7.4.4
     - pytest-datadir-ng==1.1.0
     - pytest-html==1.19.0
     - pytest-metadata==1.7.0


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: Python Packages, Security, Dependabot Alerts

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES: Removing Python packages with security risks, bumping `Pytest` version. The Python package `jsonpickle` is not used and the `py` dependency for `Pytest` was removed in version 7.2.0.

Dependabot Alerts: 
- Fixes [#5](https://github.com/NCAR/wrf_hydro_nwm_public/security/dependabot/5)
- Fixes [#20](https://github.com/NCAR/wrf_hydro_nwm_public/security/dependabot/20)

### Checklist

 - [X] Closes Dependabots Alert 5 and 20
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
