### PR TITLE
Add initial support for gage-assisted diversions in channel routing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 
 # set project name and version numbers
-project (WRF_Hydro LANGUAGES Fortran)
+project (WRF_Hydro LANGUAGES Fortran C)
 set (WRF_Hydro_VERSION_MAJOR 5)
 set (WRF_Hydro_VERSION_MINOR 3)
 set (WRF_Hydro_VERSION_PATCH 0)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory("Routing/Overland")
 add_subdirectory("Routing/Subsurface")
 #add_subdirectory("Routing/Groundwater")
 add_subdirectory("Routing/Reservoirs")
+add_subdirectory("Routing/Diversions")
 add_subdirectory("Data_Rec")
 add_subdirectory("Routing")
 add_subdirectory("HYDRO_drv")
@@ -103,7 +104,9 @@ if (HYDRO_LSM MATCHES "NoahMP")
 
     if (WRF_HYDRO_NUDGING STREQUAL "1")
         target_link_libraries(wrfhydro.exe hydro_nudging)
+        target_link_libraries(wrfhydro.exe hydro_routing_diversions)
         add_dependencies(wrfhydro.exe hydro_nudging)
+        add_dependencies(wrfhydro.exe hydro_routing_diversions)
     endif (WRF_HYDRO_NUDGING STREQUAL "1")
 
     # bash commands to copy namelists to the Run directory

--- a/src/Data_Rec/module_namelist.F
+++ b/src/Data_Rec/module_namelist.F
@@ -53,6 +53,7 @@ contains
           character(len=256) :: route_lake_f=""
           character(len=256) :: route_direction_f=""
           character(len=256) :: route_order_f=""
+          character(len=256) :: diversions_file=""
           logical            :: reservoir_persistence_usgs
           logical            :: reservoir_persistence_usace
           character(len=256) :: reservoir_parameter_file=""
@@ -125,8 +126,8 @@ contains
             RT_OPTION, CHANRTSWCRT, channel_option, &
                     SUBRTSWCRT,OVRTSWCRT,AGGFACTRT, dtrt_ter,dtrt_ch,dxrt,&
                     GwSpinCycles, GwPreCycles, GwSpinUp, GwPreDiag, GwPreDiagInterval, gwIhShift, &
-                    GWBASESWCRT, gwChanCondSw, gwChanCondConstIn, gwChanCondConstOut , &
-                    route_topo_f,route_chan_f,route_link_f, compound_channel, route_lake_f, &
+                    GWBASESWCRT, gwChanCondSw, gwChanCondConstIn, gwChanCondConstOut, &
+                    route_topo_f,route_chan_f,route_link_f, compound_channel, route_lake_f, diversions_file, &
                     reservoir_persistence_usgs, reservoir_persistence_usace, reservoir_parameter_file, reservoir_usgs_timeslice_path, &
                     reservoir_usace_timeslice_path, reservoir_observation_lookback_hours, reservoir_observation_update_time_interval_seconds, &
                     reservoir_rfc_forecasts,  reservoir_rfc_forecasts_time_series_path, reservoir_rfc_forecasts_lookback_hours, &
@@ -268,6 +269,7 @@ contains
   nlst%DEEPGWSPIN = DEEPGWSPIN
   nlst%SOLVEG_INITSWC = SOLVEG_INITSWC
   nlst%reservoir_obs_dir = "testDirectory"
+  nlst%diversions_file = diversions_file
   nlst%reservoir_persistence_usgs = reservoir_persistence_usgs
   nlst%reservoir_persistence_usace = reservoir_persistence_usace
   nlst%reservoir_parameter_file = reservoir_parameter_file

--- a/src/Data_Rec/module_namelist_inc.F
+++ b/src/Data_Rec/module_namelist_inc.F
@@ -42,6 +42,7 @@ module module_namelist_inc
           character(len=256) :: route_chan_f=""
           character(len=256) :: route_link_f=""
           character(len=256) :: route_lake_f=""
+          character(len=256) :: diversions_file=""
           logical            :: reservoir_persistence_usgs
           logical            :: reservoir_persistence_usace
           character(len=256) :: reservoir_parameter_file=""

--- a/src/HYDRO_drv/module_HYDRO_drv.F
+++ b/src/HYDRO_drv/module_HYDRO_drv.F
@@ -49,6 +49,8 @@ module module_HYDRO_drv
 #endif
    use module_hydro_stop, only: HYDRO_stop
    use module_UDMAP, only: get_basn_area_nhd
+   use module_channel_diversions, only: init_diversions
+
    use netcdf
 
    implicit none
@@ -1599,6 +1601,11 @@ endif
 #ifdef WRF_HYDRO_NUDGING
 if(nlst(did)%CHANRTSWCRT .ne. 0) call init_stream_nudging
 #endif
+
+!#ifdef WRF_HYDRO_DIVERSIONS
+! TODO: should this check to make sure we have nudging on too? [RC]
+call init_diversions(nlst(did)%diversions_file, nlst(did)%timeSlicePath)
+!#endif
 
 
 !    if (trim(nlst_rt(did)%restart_file) == "") then

--- a/src/OrchestratorLayer/config.f90
+++ b/src/OrchestratorLayer/config.f90
@@ -123,6 +123,7 @@ module config_base
      character(len=256) :: route_chan_f=""
      character(len=256) :: route_link_f=""
      character(len=256) :: route_lake_f=""
+     character(len=256) :: diversions_file=""
      logical            :: reservoir_persistence_usgs
      logical            :: reservoir_persistence_usace
      character(len=256) :: reservoir_parameter_file=""
@@ -499,6 +500,7 @@ contains
     logical            :: compound_channel
     integer            :: channel_loss_option = 0
     character(len=256) :: route_lake_f=""
+    character(len=256) :: diversions_file=""
     logical            :: reservoir_persistence_usgs
     logical            :: reservoir_persistence_usace
     character(len=256) :: reservoir_parameter_file=""
@@ -573,7 +575,7 @@ contains
          SUBRTSWCRT,OVRTSWCRT,AGGFACTRT, dtrt_ter,dtrt_ch,dxrt,&
          GwSpinCycles, GwPreCycles, GwSpinUp, GwPreDiag, GwPreDiagInterval, gwIhShift, &
          GWBASESWCRT, gwChanCondSw, gwChanCondConstIn, gwChanCondConstOut , &
-         route_topo_f,route_chan_f,route_link_f, compound_channel, channel_loss_option, route_lake_f, &
+         route_topo_f,route_chan_f,route_link_f, compound_channel, channel_loss_option, route_lake_f, diversions_file,  &
          reservoir_persistence_usgs, reservoir_persistence_usace, reservoir_parameter_file, reservoir_usgs_timeslice_path, &
          reservoir_usace_timeslice_path, reservoir_observation_lookback_hours, reservoir_observation_update_time_interval_seconds, &
          reservoir_rfc_forecasts, reservoir_rfc_forecasts_time_series_path, reservoir_rfc_forecasts_lookback_hours, &
@@ -800,6 +802,8 @@ contains
     nlst(did)%route_chan_f = route_chan_f
     nlst(did)%route_link_f = route_link_f
     nlst(did)%route_lake_f = route_lake_f
+
+    nlst(did)%diversions_file = diversions_file
 
     nlst(did)%reservoir_persistence_usgs = reservoir_persistence_usgs
     nlst(did)%reservoir_persistence_usace = reservoir_persistence_usace

--- a/src/Routing/CMakeLists.txt
+++ b/src/Routing/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(hydro_routing STATIC
 	Noah_distr_routing_subsurface.F
 )
 
+add_dependencies(hydro_routing hydro_routing_diversions)
+
 target_link_libraries(hydro_routing PUBLIC hydro_mpp)
 target_link_libraries(hydro_routing PUBLIC hydro_utils)
 target_link_libraries(hydro_routing PUBLIC hydro_orchestrator)
@@ -31,4 +33,5 @@ target_link_libraries(hydro_routing PUBLIC hydro_routing_reservoirs_levelpool)
 target_link_libraries(hydro_routing PUBLIC hydro_routing_reservoirs_hybrid)
 target_link_libraries(hydro_routing PUBLIC hydro_data_rec)
 target_link_libraries(hydro_routing PUBLIC hydro_routing_reservoirs_rfc)
+target_link_libraries(hydro_routing PUBLIC hydro_routing_diversions)
 

--- a/src/Routing/Diversions/CMakeLists.txt
+++ b/src/Routing/Diversions/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(hydro_routing_diversions STATIC
+    module_diversions.F
+    module_diversions_timeslice.F
+)
+
+add_dependencies(hydro_routing_diversions hydro_orchestrator)
+add_dependencies(hydro_routing_diversions fortglob)
+
+target_link_libraries(hydro_routing_diversions PUBLIC hydro_orchestrator)
+target_link_libraries(hydro_routing_diversions PUBLIC fortglob)

--- a/src/Routing/Diversions/module_diversions.F
+++ b/src/Routing/Diversions/module_diversions.F
@@ -1,0 +1,169 @@
+module module_channel_diversions
+    use netcdf
+    use iso_fortran_env, only: int8, int16, int64
+    use ieee_arithmetic, only: ieee_is_nan
+
+    use module_diversions_timeslice
+    use module_hydro_stop, only: hydro_stop
+
+    implicit none
+
+    type diversion_t
+        character(len=128) :: name
+        character(len=16)  :: da_src, da_dest
+
+        integer(kind=int8)  :: type_div, type_src, type_dest
+        integer(kind=int64) :: id_src, id_dest, src_index, dest_index
+        real :: capacity, fraction
+
+        integer(kind=int16) :: lookback
+        real :: persisted_flow_src, persisted_flow_dest
+    end type
+
+    logical :: diversions_active = .false.
+    integer :: ndivs = 0
+
+    type(diversion_t), allocatable :: diversions(:)
+
+    character(*), parameter :: free = '(*(g0,1x))'
+
+contains
+    subroutine init_diversions(diversions_file, timeslice_path)
+        character(*), intent(in) :: diversions_file
+        character(*), intent(in) :: timeslice_path
+
+        integer :: g, i, ierr = 0
+        character(len=20) :: istr
+        character(len=256) :: char_tmp
+
+        integer :: ncid, dimid
+        integer :: name_vid, type_div_vid, type_src_vid, type_dest_vid, da_src_vid, da_dest_vid
+        integer :: id_src_vid, id_dest_vid, capacity_vid, fraction_vid, lookback_vid
+
+        if (len_trim(diversions_file) > 0) then
+            print *, "Loading diversions data from " // trim(diversions_file)
+            ierr = nf90_open(trim(diversions_file), NF90_NOWRITE, ncid)
+            if (ierr /= 0) call hydro_stop("Could not open diversions file: " // trim(diversions_file))
+            ierr = nf90_inq_dimid(ncid, "diversion", dimid)
+            if (ierr /= 0) call hydro_stop("Error reading diversions file: " // trim(diversions_file))
+            ierr = nf90_inquire_dimension(ncid, dimid, len=ndivs)
+            if (ierr /= 0) call hydro_stop("Error reading diversions file: " // trim(diversions_file))
+
+            write (istr, *) ndivs
+            print *, "Diversions file has " // trim(adjustl(istr)) // " diversions"
+
+            ! get fields
+            ierr = 0
+            ierr = ierr + nf90_inq_varid(ncid, "Diversion_Name", name_vid)
+            ierr = ierr + nf90_inq_varid(ncid, "DivType", type_div_vid)
+            ierr = ierr + nf90_inq_varid(ncid, "FromType", type_src_vid)
+            ierr = ierr + nf90_inq_varid(ncid, "ToType", type_dest_vid)
+            ierr = ierr + nf90_inq_varid(ncid, "DA_Src", da_src_vid)
+            ierr = ierr + nf90_inq_varid(ncid, "DA_Dest", da_dest_vid)
+            ierr = ierr + nf90_inq_varid(ncid, "DivFrom", id_src_vid)
+            ierr = ierr + nf90_inq_varid(ncid, "DivTo", id_dest_vid)
+            ierr = ierr + nf90_inq_varid(ncid, "DivCap", capacity_vid)
+            ierr = ierr + nf90_inq_varid(ncid, "DivFrac", fraction_vid)
+            ierr = ierr + nf90_inq_varid(ncid, "Lookback", lookback_vid)
+
+            if (ierr /= 0) call hydro_stop("Error occurred accessing diversion file variables")
+
+            if (ndivs > 0) then
+                diversions_active = .true.
+
+                ! Read the timeslice data
+                ierr = init_timeslices(timeslice_path)
+                if (ierr /= 0) call hydro_stop("No timeslice files available when initializing diversions")
+
+                allocate(diversions(ndivs))
+                do i = 1, ndivs
+                    associate (div => diversions(i))
+                        div = diversion_t('', '', '', -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
+
+                        ierr = 0
+                        !ierr = ierr + nf_get_var1(ncid, name_vid, i, div%name)  !! can't read string with Fortran :-(
+
+                        ierr = ierr + nf90_get_var(ncid, da_src_vid, div%da_src, start=(/i/), count=(/15/))
+                        div%persisted_flow_src = get_flow_for_gage(div%da_src)
+                        ierr = ierr + nf90_get_var(ncid, da_dest_vid, div%da_dest, start=(/i/), count=(/15/))
+                        div%persisted_flow_dest = get_flow_for_gage(div%da_dest)
+
+                        ierr = ierr + nf90_get_var(ncid, type_div_vid, div%type_div, start=(/i/))
+                        ierr = ierr + nf90_get_var(ncid, type_src_vid, div%type_src, start=(/i/))
+                        ierr = ierr + nf90_get_var(ncid, type_dest_vid, div%type_dest, start=(/i/))
+                        ierr = ierr + nf90_get_var(ncid, id_src_vid, div%id_src, start=(/i/))
+                        ierr = ierr + nf90_get_var(ncid, id_dest_vid, div%id_dest, start=(/i/))
+                        ierr = ierr + nf90_get_var(ncid, capacity_vid, div%capacity, start=(/i/))
+                        ierr = ierr + nf90_get_var(ncid, fraction_vid, div%fraction, start=(/i/))
+                        ierr = ierr + nf90_get_var(ncid, lookback_vid, div%lookback, start=(/i/))
+
+                        if (ierr > 0) call hydro_stop("Error occurred reading diversion variables from diversion file")
+                    end associate
+                end do
+
+            end if
+        end if
+
+    end subroutine
+
+    subroutine calculate_diversion(src_link, dst_link, qlink_src, qlink_dst)
+        integer, intent(in) :: src_link
+        integer, intent(in) :: dst_link
+        real, intent(inout) :: qlink_src
+        real, intent(inout) :: qlink_dst
+
+        integer :: i
+
+        ! bail if we're inactive
+        if (.not. diversions_active) return
+
+        ! link to gage
+        ! look to see what type of diversion it is
+        ! call into sub-procedure to handle type=1, type=2, type=3, etc
+
+        do i = 1, ndivs
+            if (src_link == diversions(i)%id_src) then
+                if (diversions(i)%type_div /= 3) then
+                    print free, "!!! UNSUPPORTED DIVERSION TYPE (", diversions(i)%type_div, "), skipping"
+                else
+                    call gage_assisted_diversion(src_link, diversions(i), qlink_src)
+                end if
+            end if
+        end do
+
+    end subroutine
+
+    subroutine gage_assisted_diversion(src_link, diversion, qlink_src)
+        integer, intent(in) :: src_link
+        type(diversion_t), intent(in) :: diversion
+        real, intent(inout) :: qlink_src
+
+        real :: div_gage_flow, fraction
+
+        ! This is the so-called "Type 3" diversion. We take the observed flow from div_gage,
+        ! and subtract it from the upstream qlink_src, if it's a valid flow (not-NaN).
+        !
+        ! If it's not a valid flow, we try to use the Fraction property of the diversion,
+        ! and if -that's- not available, we just leave the flow untouched.
+
+        div_gage_flow = diversion%persisted_flow_dest
+        if (ieee_is_nan(div_gage_flow)) then
+            fraction = diversion%fraction
+            if (fraction == -1) then
+                print free, "WARNING: No fractional diversion value specified for diversion at gage '" // trim(adjustl(diversion%da_dest)) // "', skipping"
+                fraction = 0
+            else
+                print free, "INFO: No gage discharge available for diversion '" // trim(adjustl(diversion%da_dest)) // "', using fixed fractional diversion of", fraction
+            end if
+            div_gage_flow = qlink_src * fraction
+        end if
+
+#ifdef HYDRO_D
+        if (div_gage_flow /= 0) &
+            print free, "DEBUG: diverting", div_gage_flow, "of", qlink_src, "from link id =", src_link
+#endif
+        qlink_src = qlink_src - div_gage_flow
+
+    end subroutine
+
+end module

--- a/src/Routing/Diversions/module_diversions_timeslice.F
+++ b/src/Routing/Diversions/module_diversions_timeslice.F
@@ -1,0 +1,70 @@
+module module_diversions_timeslice
+    use fortglob, only: glob_t, globfiles
+    use module_hydro_stop, only: hydro_stop
+
+    use netcdf
+    use ieee_arithmetic, only: ieee_value, ieee_quiet_nan
+    implicit none
+
+    integer, parameter :: PATH_MAX = 4096
+    type(glob_t) :: timeslice_files
+
+    contains
+
+    integer function init_timeslices(timeslice_path) result(ierr)
+        character(*), intent(in) :: timeslice_path
+        character(len=PATH_MAX) :: tslice_glob
+
+        ierr = 0
+        tslice_glob = trim(adjustl(timeslice_path)) // '/' // "*.15min.usgsTimeSlice.ncdf"
+        timeslice_files = globfiles(tslice_glob)
+
+        if (timeslice_files%nfiles == 0) ierr = 1
+    end function
+
+    real function get_flow_for_gage(gage) result(flow)
+        character(len=15), intent(in) :: gage
+
+        integer :: i, ierr=0, ncid, dimid, varid, num_stns, found(1)
+        real    :: discharge(1)
+        character(len=15), allocatable :: gage_ids(:)
+
+        flow = ieee_value(flow, ieee_quiet_nan)
+
+        if (gage(1:4) == 'None') then
+            return
+        end if
+
+        ! start looking at files, going backward from most recent
+        do i = timeslice_files%nfiles, 1, -1
+            ierr = nf90_open(trim(timeslice_files%filenames(i)), NF90_NOWRITE, ncid)
+
+            ! look for gage
+            ierr = ierr + nf90_inq_dimid(ncid, 'stationIdInd', dimid)
+            ierr = ierr + nf90_inquire_dimension(ncid, dimid, len=num_stns)
+
+            allocate(gage_ids(num_stns))
+            ierr = ierr + nf90_inq_varid(ncid, 'stationId', varid)
+            ierr = ierr + nf90_get_var(ncid, varid, gage_ids)
+
+            if (ierr /= 0) call hydro_stop("Error occurred reading gage data from " // trim(timeslice_files%filenames(i)))
+
+            found = findloc(gage_ids, gage)
+            if (found(1) /= 0) then
+                ierr = ierr + nf90_inq_varid(ncid, 'discharge', varid)
+                ierr = ierr + nf90_get_var(ncid, varid, discharge, start=found, count=(/1/))
+                if (ierr /= 0) call hydro_stop("Error occurred reading gage data from " // trim(timeslice_files%filenames(i)))
+
+                flow = discharge(1)
+                deallocate(gage_ids)
+                return
+            end if
+
+            deallocate(gage_ids)
+            ierr = nf90_close(ncid)
+        end do
+
+        print *, "WARNING: Gage discharge not found in any timeslice file, falling back to fractional diversion"
+    end function
+
+end module

--- a/src/Routing/module_channel_routing.F
+++ b/src/Routing/module_channel_routing.F
@@ -528,11 +528,13 @@ use module_RT_data, only: rt_domain  !! JLM: this is only used in a c3 paramter 
       !TML:Added print statement to test qlos function;
       !comment out to prevent excessive file sizes when running model
       !print*, "qloss,dx,WP,WPk,depth,ChannK,qdc,ql,dt,D", qloss,dx,WP,WPk,depth,ChannK,qdc,ql,dt,D
-      if((qloss*dt)/D > ((ql*dt)/D - C4)) then
-           qloss = ql - C4*(D/dt)
-           if (qloss < 0) then
-              print*, 'WARNING CHANNEL LOSS IS NEGATIVE',qloss
-           endif
+      if (ChannK /= 0) then
+         if((qloss*dt)/D > ((ql*dt)/D - C4)) then
+            qloss = ql - C4*(D/dt)
+            if (qloss < 0) then
+               print*, 'WARNING CHANNEL LOSS IS NEGATIVE',qloss
+            endif
+         endif
       endif
 
 ! ----------------------------------------------------------------
@@ -1622,7 +1624,7 @@ end subroutine drive_CHANNEL
                                          nudgeWAdvance,                      &
                                          nudge_apply_upstream_muskingumCunge
 #endif
-
+      use module_channel_diversions, only: calculate_diversion
 
        implicit none
 
@@ -1986,6 +1988,7 @@ do nt = 1, nsteps
          call nudge_apply_upstream_muskingumCunge( Qup,  Quc,  nudge(k),  k )
 #endif
 
+         call calculate_diversion(LINKID(k), -1, Quc, tmpQLINK(k,2))
          call SUBMUSKINGCUNGE(&
               tmpQLINK(k,2), velocity(k), qloss(k), LINKID(k),     Qup,        Quc, QLINK(k,1), &
               QLateral(k),   DTRT_CH,     So(k), CHANLEN(k),                  &

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -17,3 +17,5 @@ add_library(hydro_utils STATIC
 	module_version.F
 	module_hydro_stop.F
 )
+
+add_subdirectory(fortglob)

--- a/src/utils/fortglob/CMakeLists.txt
+++ b/src/utils/fortglob/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(fortglob STATIC
+    libfortglob.c
+    fortglob.f90
+)

--- a/src/utils/fortglob/fortglob.f90
+++ b/src/utils/fortglob/fortglob.f90
@@ -1,0 +1,76 @@
+module fortglob
+    use iso_c_binding
+    implicit none
+
+    private
+    public :: glob_t, globfiles
+
+    integer, parameter :: PATH_MAX = 4096
+
+    type :: glob_t
+        integer :: nfiles
+        character(len=PATH_MAX), allocatable :: filenames(:)
+    end type
+
+    type, bind(c) :: globrec_c
+        integer (c_size_t) :: nfiles
+        type(c_ptr) :: filenames
+        type(c_ptr) :: globptr
+    end type globrec_c
+
+    interface
+        function globfiles_c(pattern) bind(c)
+            use iso_c_binding
+            character(kind=c_char), dimension(*), intent(in) :: pattern
+            type(c_ptr) :: globfiles_c
+        end function globfiles_c
+
+        subroutine freeglobrec(recptr) bind (c)
+            use iso_c_binding
+            type(c_ptr), intent(in) :: recptr
+        end subroutine
+
+        function strlen(s) bind(c)
+            use iso_c_binding
+            type(c_ptr), intent(in), value :: s
+            integer(c_size_t) :: strlen
+        end function strlen
+    end interface
+
+    contains
+
+    function globfiles(pattern)
+        use iso_c_binding
+
+        type(glob_t) :: globfiles
+        character(len=*), intent(in) :: pattern
+
+        integer :: i, j, slen
+        character(len=PATH_MAX) :: pattern_c
+        type(c_ptr) :: glob_c_ptr
+        type(globrec_c), pointer :: glob_f_ptr
+        type(c_ptr), pointer :: c_strs(:)
+        character(kind=c_char), pointer, dimension(:) :: temp_fstrp
+
+        pattern_c = pattern
+        slen = len_trim(pattern_c)
+        pattern_c(slen+1:slen+1) = c_null_char
+        glob_c_ptr = globfiles_c(pattern_c)
+        call c_f_pointer(glob_c_ptr, glob_f_ptr)
+        globfiles%nfiles = glob_f_ptr%nfiles
+
+        allocate(globfiles%filenames(globfiles%nfiles))
+
+        call c_f_pointer(glob_f_ptr%filenames, c_strs, [glob_f_ptr%nfiles])
+        do i = 1, globfiles%nfiles
+            slen = strlen(c_strs(i))
+            call c_f_pointer(c_strs(i), temp_fstrp, [slen])
+            globfiles%filenames(i) = ''
+            do j = 1, slen
+                globfiles%filenames(i)(j:j) = temp_fstrp(j)
+            end do
+        end do
+
+        call freeglobrec(glob_f_ptr%globptr)
+    end function
+end module

--- a/src/utils/fortglob/libfortglob.c
+++ b/src/utils/fortglob/libfortglob.c
@@ -1,0 +1,19 @@
+#include "libfortglob.h"
+
+globrec * globfiles_c(const char * pattern) {
+    globrec *record = malloc(sizeof(globrec));
+    glob_t *globbuf = malloc(sizeof(glob_t));
+
+    glob(pattern, 0, NULL, globbuf);
+    record->nfiles = globbuf->gl_pathc;
+    record->filenames = globbuf->gl_pathv;
+    record->__globptr = globbuf;
+
+    return record;
+}
+
+void freeglobrec(glob_t ** rec) {
+    glob_t *glob = *rec;
+    globfree(glob);
+    free(glob);
+}

--- a/src/utils/fortglob/libfortglob.h
+++ b/src/utils/fortglob/libfortglob.h
@@ -1,0 +1,13 @@
+#include <glob.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+
+typedef struct globrec {
+    size_t nfiles;
+    char ** filenames;
+    glob_t * __globptr;
+} globrec;
+
+globrec * globfiles_c(const char * pattern);
+void freeglobrec(glob_t **rec);


### PR DESCRIPTION
TYPE: ENHANCEMENT

KEYWORDS: diversions,channel routing

SOURCE: NCAR

DESCRIPTION OF CHANGES: 

Add initial support for channel diversions. This PR only covers the 'gage-assisted diversion' as used on the Mississippi at the Old River Control Structure. 

TESTS CONDUCTED: 

- Croton with artificial diversion - DONE
- CONUS with actual Old River Control Structure diversion - **IN PROGRESS**

NOTES: 

Diversions must be specified in a `diversions_file` added to the `hydro.namelist`. The format of this file will be documented later as part of the NWM v3.1 release.

