### PR TITLE
Github Actions Warnings Fix: upload-artifact version bump and copy fix

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -203,14 +203,14 @@ jobs:
           cp -r $GITHUB_WORKSPACE/candidate/build/Run/output_${{ matrix.configuration }}/* $GITHUB_WORKSPACE/test_report/
 
       - name: Attach diff plots to PR
-        if: ${{ always() }}
+        if: ${{ failure() }}
         run: |
           cd $GITHUB_WORKSPACE/candidate/tests/local/utils
           bash attach_all_plots.bash $(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH") ${{ matrix.configuration }}
 
       - name: Archive test results to GitHub
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports
           path: |


### PR DESCRIPTION
TYPE: warning fix

KEYWORDS: Github Actions, NodeJS Warnings, Version Bump

SOURCE: Soren Rasmussen 

DESCRIPTION OF CHANGES: PR to fix [the warnings](https://github.com/NCAR/wrf_hydro_nwm_public/actions/runs/9671012731) that are produced when running Github Actions. To fix these warnings, upload-artifact version is upgraded and difference plots are copied only on failure, which means they would be generated and available to copy


TESTS CONDUCTED: check this PR's CI tests for their [warning report](https://github.com/NCAR/wrf_hydro_nwm_public/actions/runs/9683544996?pr=757)

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [ ] Closes issue #xxxx
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [X] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Documentation included
 - [ ] Short description in the Development section of `NEWS.md`
