### PR TITLE
Restore Reach-based Lakes from v5.1.x

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ main, v5.2.x ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, v5.2.x ]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        configuration: [nwm_ana, nwm_long_range, gridded, reach]
+        configuration: [nwm_ana, nwm_long_range, gridded, reach, reach_lakes]
     runs-on: ubuntu-latest
 
     env:

--- a/src/HYDRO_drv/module_HYDRO_drv.F90
+++ b/src/HYDRO_drv/module_HYDRO_drv.F90
@@ -957,24 +957,27 @@ contains
                     RT_DOMAIN(did)%HLINK, RT_DOMAIN(did)%ELRT,RT_DOMAIN(did)%CHANLEN,&
                     RT_DOMAIN(did)%MannN,RT_DOMAIN(did)%So, RT_DOMAIN(did)%ChSSlp, &
                     RT_DOMAIN(did)%Bw,RT_DOMAIN(did)%Tw,RT_DOMAIN(did)%Tw_CC, RT_DOMAIN(did)%n_CC, &
-                    RT_DOMAIN(did)%ChannK,&
+                    RT_DOMAIN(did)%ChannK, &
                     RT_DOMAIN(did)%RESHT, &
+                    RT_DOMAIN(did)%HRZAREA, RT_DOMAIN(did)%LAKEMAXH, &
+                    RT_DOMAIN(did)%WEIRH, RT_DOMAIN(did)%WEIRC, RT_DOMAIN(did)%WEIRL, &
+                    RT_DOMAIN(did)%ORIFICEC, RT_DOMAIN(did)%ORIFICEA, RT_DOMAIN(did)%ORIFICEE, &
                     RT_DOMAIN(did)%ZELEV, RT_DOMAIN(did)%CVOL, &
                     RT_DOMAIN(did)%NLAKES, RT_DOMAIN(did)%QLAKEI, RT_DOMAIN(did)%QLAKEO,&
                     RT_DOMAIN(did)%LAKENODE, rt_domain(did)%overland%properties%distance_to_neighbor, &
                     RT_DOMAIN(did)%QINFLOWBASE, RT_DOMAIN(did)%CHANXI, &
                     RT_DOMAIN(did)%CHANYJ, nlst(did)%channel_option, &
                     RT_DOMAIN(did)%RETDEP_CHAN, RT_DOMAIN(did)%NLINKSL, RT_DOMAIN(did)%LINKID, &
-                    RT_DOMAIN(did)%node_area  &
+                    RT_DOMAIN(did)%node_area, RT_DOMAIN(did)%LAKEIDX  &
 #ifdef MPP_LAND
                     ,RT_DOMAIN(did)%lake_index,RT_DOMAIN(did)%link_location,&
                     RT_DOMAIN(did)%mpp_nlinks,RT_DOMAIN(did)%nlinks_index, &
-                    RT_DOMAIN(did)%yw_mpp_nlinks  &
-                    , RT_DOMAIN(did)%LNLINKSL &
-                    , rt_domain(did)%gtoNode,rt_domain(did)%toNodeInd,rt_domain(did)%nToInd  &
+                    RT_DOMAIN(did)%yw_mpp_nlinks,  &
+                    RT_DOMAIN(did)%LNLINKSL, RT_DOMAIN(did)%LLINKID, &
+                    rt_domain(did)%gtoNode, rt_domain(did)%toNodeInd,rt_domain(did)%nToInd  &
 #endif
-                    , rt_domain(did)%CH_LNKRT_SL   &
-                    ,nlst(did)%GwBaseSwCRT, gw2d(did)%ho, gw2d(did)%qgw_chanrt, &
+                    , rt_domain(did)%CH_LNKRT_SL,   &
+                    nlst(did)%GwBaseSwCRT, gw2d(did)%ho, gw2d(did)%qgw_chanrt, &
                     nlst(did)%gwChanCondSw, nlst(did)%gwChanCondConstIn, &
                     nlst(did)%gwChanCondConstOut, rt_domain(did)%velocity, rt_domain(did)%qloss &
                     )

--- a/src/Routing/module_RT.F90
+++ b/src/Routing/module_RT.F90
@@ -559,7 +559,7 @@ subroutine getChanDim(did)
       rt_domain(did)%GNLINKSL = 1
       rt_domain(did)%NLINKSL = 1
    endif
-   if(nlst(did)%UDMP_OPT .eq. 1) &
+   if(nlst(did)%UDMP_OPT .eq. 1 .or. nlst(did)%channel_option .eq. 1 .or. nlst(did)%channel_option .eq. 2) &
         call read_NSIMLAKES(rt_domain(did)%NLAKES,nlst(did)%route_lake_f)
 
    call rt_allocate(did,rt_domain(did)%ix,rt_domain(did)%jx,&
@@ -615,7 +615,7 @@ if (nlst(did)%CHANRTSWCRT.eq.1 .or. nlst(did)%CHANRTSWCRT .eq. 2) then  !IF/then
 
 endif
 
-if(nlst(did)%UDMP_OPT .eq. 1) then
+if(nlst(did)%UDMP_OPT .eq. 1 .or. nlst(did)%channel_option .eq. 1 .or. nlst(did)%channel_option .eq. 2) then
    call read_NSIMLAKES(rt_domain(did)%NLAKES,nlst(did)%route_lake_f)
 endif
 

--- a/src/Routing/module_channel_routing.F90
+++ b/src/Routing/module_channel_routing.F90
@@ -858,11 +858,11 @@ END SUBROUTINE SUBMUSKINGCUNGE
 !            endif !!! order(1) .ne. 1
          end do       !--k links
 
-   #ifdef MPP_LAND
+#ifdef MPP_LAND
          call updateLake_seq(RESHT,nlakes,tmpRESHT)
          call updateLake_seq(QLAKEO,nlakes,tmpQLAKEO)
          call updateLake_seq(QLAKEI,nlakes,tmpQLAKEI)
-   #endif
+#endif
 
 !yw check
 !        gQLINK = 0.0

--- a/src/Routing/module_channel_routing.F90
+++ b/src/Routing/module_channel_routing.F90
@@ -834,7 +834,7 @@ END SUBROUTINE SUBMUSKINGCUNGE
                 if(TYPEL(k) == 1) then   !--link is a reservoir
                     l_idx = lake_lookup(k)
                     if (l_idx >= 0) then     !-- -999 if not a reservoir in the lookup table (belt-and-suspenders check)
-                        call rt_domain(did)%reservoirs(lakeid)%ptr%run(Qup, Quc, 0.0, &
+                        call rt_domain(did)%reservoirs(l_idx)%ptr%run(Qup, Quc, 0.0, &
                               RESHT(l_idx), QLINK(k,2), DTRT_CH, rt_domain(did)%final_reservoir_type(l_idx), &
                               rt_domain(did)%reservoir_assimilated_value(l_idx), rt_domain(did)%reservoir_assimilated_source_file(l_idx))
 

--- a/src/Routing/module_channel_routing.F90
+++ b/src/Routing/module_channel_routing.F90
@@ -546,13 +546,13 @@ END SUBROUTINE SUBMUSKINGCUNGE
        LAKE_MSKRT, DT, DTCT, DTRT_CH,MUSK, MUSX, QLINK, &
        QLateral, &
        HLINK, ELRT, CHANLEN, MannN, So, ChSSlp, Bw, Tw, Tw_CC, n_CC,  &
-       ChannK, RESHT, &
+       ChannK, RESHT, HRZAREA, LAKEMAXH, WEIRH, WEIRC, WEIRL, ORIFICEC, ORIFICEA, ORIFICEE, &
        ZELEV, CVOL, NLAKES, QLAKEI, QLAKEO, LAKENODE, &
        dist, QINFLOWBASE, CHANXI, CHANYJ, channel_option, RETDEP_CHAN, &
-       NLINKSL, LINKID, node_area  &
+       NLINKSL, LINKID, node_area, lake_lookup  &
 #ifdef MPP_LAND
        , lake_index,link_location,mpp_nlinks,nlinks_index,yw_mpp_nlinks  &
-       , LNLINKSL  &
+       , LNLINKSL, LLINKID  &
        , gtoNode,toNodeInd,nToNodeInd &
 #endif
        , CH_LNKRT_SL &
@@ -619,6 +619,15 @@ END SUBROUTINE SUBMUSKINGCUNGE
 
 
         !-- lake params
+        REAL, INTENT(IN), DIMENSION(NLAKES)       :: HRZAREA  !-- horizontal area (km^2)
+        REAL, INTENT(IN), DIMENSION(NLAKES)       :: LAKEMAXH !-- maximum lake depth  (m^2)
+        REAL, INTENT(IN), DIMENSION(NLAKES)       :: WEIRH    !-- lake depth  (m^2)
+        REAL, INTENT(IN), DIMENSION(NLAKES)       :: WEIRC    !-- weir coefficient
+        REAL, INTENT(IN), DIMENSION(NLAKES)       :: WEIRL    !-- weir length (m)
+        REAL, INTENT(IN), DIMENSION(NLAKES)       :: ORIFICEC !-- orrifice coefficient
+        REAL, INTENT(IN), DIMENSION(NLAKES)       :: ORIFICEA !-- orrifice area (m^2)
+        REAL, INTENT(IN), DIMENSION(NLAKES)       :: ORIFICEE !-- orrifce elevation (m)
+
         REAL, INTENT(INOUT), DIMENSION(NLAKES)    :: RESHT    !-- reservoir height (m)
         REAL*8,  DIMENSION(NLAKES)    :: QLAKEI8   !-- lake inflow (cms)
         REAL, INTENT(INOUT), DIMENSION(NLAKES)    :: QLAKEI   !-- lake inflow (cms)
@@ -632,8 +641,10 @@ END SUBROUTINE SUBMUSKINGCUNGE
         REAL, DIMENSION(NLAKES)                   :: QLLAKE   !-- lateral inflow to lake in diffusion scheme
         REAL*8, DIMENSION(NLAKES)                   :: QLLAKE8   !-- lateral inflow to lake in diffusion scheme
 
+        integer, intent(in), dimension(:)     :: lake_lookup  !-- inverse lake index for k->lake mapping
+
 !-- Local Variables
-        INTEGER                     :: i,j,k,t,m,jj,kk,KRT,node
+        INTEGER                     :: i,j,k,t,m,jj,kk,KRT,node,l_idx, lakeid
         INTEGER                     :: DT_STEPS               !-- number of timestep in routing
         REAL                        :: Qup,Quc                !--Q upstream Previous, Q Upstream Current, downstream Previous
         REAL                        :: bo                     !--critical depth, bnd outflow just for testing
@@ -651,19 +662,29 @@ END SUBROUTINE SUBMUSKINGCUNGE
         integer(kind=int64) link_location(ixrt,jxrt)
         real     ywtmp(ixrt,jxrt)
         integer LNLINKSL
-        real*8,  dimension(LNLINKSL) :: LQLateral
-!        real*4,  dimension(LNLINKSL) :: LQLateral
+        integer(kind=int64), dimension(LNLINKSL) :: LLINKID
+        real(kind=8),  dimension(LNLINKSL) :: LQLateral
         integer, dimension(:) ::  toNodeInd
         integer(kind=int64), dimension(:,:) ::  gtoNode
         integer  :: nToNodeInd
         real, dimension(nToNodeInd,2) :: gQLINK
+        real, allocatable,dimension(:) :: tmpQLAKEO, tmpQLAKEI, tmpRESHT
 #else
-        real*8, dimension(NLINKS)                   :: LQLateral !--lateral flow
+        real(kind=8), dimension(NLINKS)                   :: LQLateral !--lateral flow
 #endif
         integer flag
 
         integer :: n, kk2, nt, nsteps  ! tmp
 
+#ifdef MPP_LAND
+       if(my_id == io_id) then
+#endif
+           allocate(tmpQLAKEO(NLAKES))
+           allocate(tmpQLAKEI(NLAKES))
+           allocate(tmpRESHT(NLAKES))
+#ifdef MPP_LAND
+        endif
+#endif
         QLAKEIP = 0
         QLAKEI8 = 0
         HLINKTMP = 0
@@ -771,6 +792,15 @@ END SUBROUTINE SUBMUSKINGCUNGE
 
       !---------- route other reaches, with upstream inflow
        tmpQlink = 0.0
+#ifdef MPP_LAND
+       if(my_id .eq. io_id) then
+#endif
+            tmpQLAKEO = QLAKEO
+            tmpQLAKEI = QLAKEI
+            tmpRESHT = RESHT
+#ifdef MPP_LAND
+       endif
+#endif
        do k = 1,NLINKSL
 !          if (ORDER(k) .gt. 1 ) then  !-- exclude first order stream
              Quc  = 0.0
@@ -801,28 +831,38 @@ END SUBROUTINE SUBMUSKINGCUNGE
                end do ! do m
 #endif
 
-                if(TYPEL(k) .eq. 1) then   !--link is a reservoir
+                if(TYPEL(k) == 1) then   !--link is a reservoir
+                    l_idx = lake_lookup(k)
+                    if (l_idx >= 0) then     !-- -999 if not a reservoir in the lookup table (belt-and-suspenders check)
+                        call rt_domain(did)%reservoirs(lakeid)%ptr%run(Qup, Quc, 0.0, &
+                              RESHT(l_idx), QLINK(k,2), DTRT_CH, rt_domain(did)%final_reservoir_type(l_idx), &
+                              rt_domain(did)%reservoir_assimilated_value(l_idx), rt_domain(did)%reservoir_assimilated_source_file(l_idx))
 
-                   ! CALL LEVELPOOL(1,QLINK(k,1), Qup, QLINK(k,1), QLINK(k,2), &
-                   !  QLateral(k), DT, RESHT(k), HRZAREA(k), LAKEMAXH(k), &
-                   !  WEIRC(k), WEIRL(k),ORIFICEE(k),  ORIFICEC(k), ORIFICEA(k))
-
-                   elseif (channel_option .eq. 1) then  !muskingum routing
+                        QLAKEO(l_idx)  = QLINK(k,2)     !save outflow to lake
+                        QLAKEI(l_idx)  = Quc            !save inflow to lake
+                    end if
+                elseif (channel_option .eq. 1) then  !muskingum routing
                        Km = MUSK(k)
                        X = MUSX(k)
-                       tmpQLINK(k,2) = MUSKING(k,Qup,(Quc+QLateral(k)),QLINK(k,1),DTRT_CH,Km,X) !upstream plust lateral inflow
+                       tmpQLINK(k,2) = MUSKING(k,Qup,(Quc+QLateral(k)),QLINK(k,1),DTRT_CH,Km,X) !upstream plus lateral inflow
                    elseif (channel_option .eq. 2) then ! muskingum cunge
 
                    call SUBMUSKINGCUNGE(tmpQLINK(k,2), velocity(k), qloss(k), LINKID(k),  &
                     Qup,Quc, QLINK(k,1), QLateral(k),   DTRT_CH, So(k), &
                     CHANLEN(k), MannN(k), ChSSlp(k), Bw(k), Tw(k),Tw_CC(k), n_CC(k),  HLINK(k), ChannK(k) )
 
-                   else
+                else
                     print *, "FATAL ERROR: no channel option selected"
                     call hydro_stop("In drive_CHANNEL() - no channel option selected")
                    endif
 !            endif !!! order(1) .ne. 1
          end do       !--k links
+
+   #ifdef MPP_LAND
+         call updateLake_seq(RESHT,nlakes,tmpRESHT)
+         call updateLake_seq(QLAKEO,nlakes,tmpQLAKEO)
+         call updateLake_seq(QLAKEI,nlakes,tmpQLAKEI)
+   #endif
 
 !yw check
 !        gQLINK = 0.0
@@ -836,7 +876,7 @@ END SUBROUTINE SUBMUSKINGCUNGE
 !        endif
 
           do k = 1, NLINKSL
-            if(TYPEL(k) .ne. 1) then
+            if(TYPEL(k) .ne. 2) then
                QLINK(k,2) = tmpQLINK(k,2)
             endif
             QLINK(k,1) = QLINK(k,2)    !assing link flow of current to be previous for next time step
@@ -1270,7 +1310,13 @@ gwOption:   if(gwBaseSwCRT == 3) then
 
         if (KT .eq. 1) KT = KT + 1
 
-
+#ifdef MPP_LAND
+       if (my_id == io_id) then
+           if(allocated(tmpRESHT))  deallocate(tmpRESHT)
+           if(allocated(tmpQLAKEO))  deallocate(tmpQLAKEO)
+           if(allocated(tmpQLAKEI))  deallocate(tmpQLAKEI)
+       endif
+#endif
 end subroutine drive_CHANNEL
 ! ----------------------------------------------------------------
 


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: reach, lakes, routing

SOURCE: NCAR

DESCRIPTION OF CHANGES:  support for lakes (reservoirs) in non-UDMP reach-based routing was added in version 5.1.1 but subsequently dropped from subsequent releases. This PR adds that functionality back in.

TESTS CONDUCTED: testing offline, will update in comments if necessary