### PR TITLE
text: Adding readthedocs documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 #  WRF-Hydro® <img src=".github/images/wrf_hydro_symbol_logo_2017_09.png" width=100 align="left" />
 
 [![Build Status](https://github.com/NCAR/wrf_hydro_nwm_public/actions/workflows/test-pr.yml/badge.svg?branch=main)](https://github.com/NCAR/wrf_hydro_nwm_public/actions/workflows/test-pr.yml)
+[![Doc Build Status](https://readthedocs.org/projects/wrf-hydro/badge/?version=latest&style=flat)](https://wrf-hydro.readthedocs.io)
 [![Release](https://img.shields.io/github/release/NCAR/wrf_hydro_nwm_public.svg)](https://github.com/NCAR/wrf_hydro_nwm_public/releases/latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3625237.svg)](https://doi.org/10.5281/zenodo.3625237)
 
@@ -10,8 +11,7 @@ This is the code repository for [WRF-Hydro®](https://ral.ucar.edu/projects/wrf_
 WRF-Hydro is a community modeling system and framework for hydrologic modeling and model coupling.  In 2016 a configuration of WRF-Hydro was implemented as the [National Water Model](http://water.noaa.gov/about/nwm) (NWM) for the continental United States.
 
 ## Documentation
-Documentation and in-depth build instructions can be found on our [project website](https://ral.ucar.edu/projects/wrf_hydro/technical-description-user-guide).
-Quick [build instructions](docs/BUILD.rst) for CMake are also available.
+Documentation is available at [wrf-hydro.readthedocs.io](https://wrf-hydro.readthedocs.io) with further guides available at our [project website](https://ral.ucar.edu/projects/wrf_hydro/technical-description-user-guide). For getting started see the [dependencies](https://wrf-hydro.readthedocs.io/en/latest/model-code-config.html#requirements) and [build instructions](https://wrf-hydro.readthedocs.io/en/latest/model-code-config.html#cmake-build) in the documentation.
 
 ## Resources and Support
 For news and updates regarding the WRF-Hydro project please subscribe to our [email list](https://ral.ucar.edu/projects/wrf_hydro/subscribe).


### PR DESCRIPTION
TYPE: text only

KEYWORDS: README, readthedocs

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: Adding the new readthedocs documentation link to the README and a readthedocs build badge.


<!--
ITEMS THAT MIGHT BE USEFUL TO CONSIDER
 - Closes issue #xxxx
 - Tests added (unit tests and/or regression/integration tests)
 - Backwards compatible
 - Documentation included
 - Short description in the Development section of `NEWS.md`
--->
