### PR TITLE
Allow turning lakes off (`lake_option = 0`) for Gridded

### DIFF
--- a/src/Routing/module_RT.F90
+++ b/src/Routing/module_RT.F90
@@ -567,7 +567,7 @@ subroutine getChanDim(did)
 
    return
 
-endif
+  endif
 
 
 allocate(CH_NETLNK(ixrt,jxrt))
@@ -588,6 +588,11 @@ if (nlst(did)%CHANRTSWCRT.eq.1 .or. nlst(did)%CHANRTSWCRT .eq. 2) then  !IF/then
 #ifndef MPP_LAND
    call get_NLINKSL(rt_domain(did)%NLINKSL, nlst(did)%channel_option, nlst(did)%route_link_f)
 #endif
+
+if (nlst(did)%lake_option == 0) then
+   write(6,*) "Lakes have been disabled -- NLAKES will be set to zero."
+   rt_domain(did)%nlakes = 0
+end if
 
 #ifdef HYDRO_D
    write(6,*) "before rt_allocate after READ_ROUTEDIM"


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: lakes, gridded

SOURCE: NCAR

DESCRIPTION OF CHANGES: 
  
* fixes an issue where `lake_option=0` caused an erroneous error message about a missing `route_lake_f` file by resetting the lake count to 0 after the grid is scanned for channels and lakes