### PR TITLE
Correctly handle lake_option=3 / no DA case

### DIFF
--- a/src/OrchestratorLayer/config.F90
+++ b/src/OrchestratorLayer/config.F90
@@ -761,9 +761,13 @@ contains
     nlst(did)%SOLVEG_INITSWC = SOLVEG_INITSWC
     nlst(did)%reservoir_obs_dir = "testDirectory"
 
-    if ((lake_option == 3) .and. (reservoir_persistence_usgs .or. reservoir_persistence_usace .or. reservoir_rfc_forecasts)) then
-      reservoir_type_specified = .TRUE.
-      lake_option = 1
+    if (lake_option == 3) then
+      if (reservoir_persistence_usgs .or. reservoir_persistence_usace .or. reservoir_rfc_forecasts) then
+         reservoir_type_specified = .TRUE.
+      else
+         print *, "WARNING: lake_option = 3 (Reservoir DA), but no specific DA option was enabled. Setting lake_option to 1."
+      end if
+      lake_option = 1      ! set to 1 either way
     end if
 
     if (lake_option == -99) then


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: reservoir,da

SOURCE: NCAR

DESCRIPTION OF CHANGES: 

If `lake_option` was set to 3 (Reservoir DA) but no Reservoir DA flags were set to `.true.` the internal lake_option was not set to [levelpool/off/passthrough] and a cryptic error resulted. This fix now prints an error message and reverts the value to Level Pool if no DA option is selected.