### PR TITLE
docs: instruction tweaks and trunk/NDHMS reference cleanup

### DIFF
--- a/docs/userguide/appendices.rest
+++ b/docs/userguide/appendices.rest
@@ -280,7 +280,16 @@ project directory.
 2. Create a top-level directory that will hold all subdirectories and files
    used for this walkthrough. Hereafter referred to as the ‘project
    directory’.
-3. Git clone WRF-Hydro, WRF, and WPS into project directory created in step 2
+3. Git clone WRF-Hydro, WRF, and WPS into project directory created in step 2.
+   Here are examples of possible commands to use, modify as needed:
+
+.. code-block:: console
+
+  git clone https://github.com/NCAR/wrf_hydro_nwm_public.git
+  git clone --recurse-submodule --branch v4.6.1 https://github.com/wrf-model/WRF.git
+  git clone --branch v4.6.0 https://github.com/wrf-model/WPS.git
+  wget https://github.com/NCAR/wrf_hydro_nwm_public/releases/download/v5.3.0/croton_NY_training_example_v5.3.tar.gz
+
 4. Copy the uncompressed WPS geographic data into the WPS directory.
 5. Copy the uncompressed coupled example case into the project directory.
 6. Your project directory structure will look like the following:
@@ -311,8 +320,6 @@ This section will walk you through compiling the coupled WRF | WRF-Hydro
 modeling system and the WRF Preprocessing System (WPS) utilities
 
 **Compiling the coupled WRF | WRF-Hydro modeling system**
-
-0. Compile WRF-Hydro first
 
 1. Navigate to the WRF source code directory at WRF*
 
@@ -392,7 +399,7 @@ Make sure that paths are set as in Step #5b from above
 
 .. code-block:: console
 
-  ./configure
+  ./configure_new
 
 For Derecho select option 43: Cray XC CLE/Linux x86_64, Intel Classic compilers   (dmpar).
 
@@ -400,7 +407,7 @@ For Derecho select option 43: Cray XC CLE/Linux x86_64, Intel Classic compilers 
 
 .. code-block:: console
 
-  ./compile >& compile.log
+  ./compile_new >& compile.log
 
 check the compile log for errors.
 

--- a/docs/userguide/appendices.rest
+++ b/docs/userguide/appendices.rest
@@ -111,12 +111,13 @@ Running a WRF-Hydro Simulation
 
 In this section we will use our compiled WRF-Hydro model and an
 example test case to run a WRF-Hydro simulation. This walkthrough is
-using the Croton, NY example test case. Details on the domain and
-time period of the simulation are provided in the
+using the Croton, NY example test case. After extracting the Croton tarball
+details on the domain and time period of the simulation are provided in the
 :file:`example_case/Readme.txt` file.
 
 1. First we need to copy the TBL and executable files in the
-   :file:`wrf_hydro_nwm_public*/trunk/NDHMS/Run` directory to the directory
+   :file:`wrf_hydro_nwm_public*/src/build/Run`
+   directory to the directory
    containing the domain and forcing files. For the WRF-Hydro Gridded
    configuration, these files are located in the directory
    :file:`example_case/Gridded`.
@@ -124,14 +125,15 @@ time period of the simulation are provided in the
    Copy the :file:`*.TBL` files to the example configuration directory:
 
       | *(from your project directory)*
-      | :code:`cp wrf_hydro_nwm_public*/trunk/NDHMS/Run/\*.TBL example_case/Gridded`
+      | :code:`cp wrf_hydro_nwm_public*/build/Run/\*.TBL example_case/Gridded`
 
    Copy the :file:`wrf_hydro.exe` file:
 
-      :code:`cp wrf_hydro_nwm_public*/trunk/NDHMS/Run/wrf_hydro.exe example_case/Gridded`
+      :code:`cp wrf_hydro_nwm_public*/build/Run/wrf_hydro.exe example_case/Gridded`
 
    .. note:: There are other configuration subfolders with the names such as :file:`Gridded`, :file:`nwm`, and
-      :file:`Reach`. These folders contain prepared files for other configurations of WRF-Hydro. Information
+      :file:`Reach`. These folders contain prepared files for other configurations of WRF-Hydro. They are found
+      under the :file:`src/template/` directory. Information
       regarding physics options and routing configurations can be found in the main body of the *WRF-Hydro*
       v\ |version_short| *Technical Description*. Also, note that there is only one :file:`FORCING/` directory.
       The same forcing data can be used for all configurations.
@@ -288,7 +290,7 @@ project directory.
   git clone https://github.com/NCAR/wrf_hydro_nwm_public.git
   git clone --recurse-submodule --branch v4.6.1 https://github.com/wrf-model/WRF.git
   git clone --branch v4.6.0 https://github.com/wrf-model/WPS.git
-  wget https://github.com/NCAR/wrf_hydro_nwm_public/releases/download/v5.3.0/croton_NY_training_example_v5.3.tar.gz
+  wget https://github.com/NCAR/wrf_hydro_nwm_public/releases/download/v5.4.0/croton_NY_training_example_v5.4.tar.gz
 
 4. Copy the uncompressed WPS geographic data into the WPS directory.
 5. Copy the uncompressed coupled example case into the project directory.

--- a/docs/userguide/model-code-config.rest
+++ b/docs/userguide/model-code-config.rest
@@ -130,9 +130,10 @@ required even if running over a single core.
 ------------------------
 
 The top-level directory structure of the code is provided below as
-nested under :file:`trunk/NDHMS` and subdirectory structures are described
-thereafter. The tables below provide brief descriptions of the file
-contents of each directory where the model code resides.
+nested under the :file:`wrf_hydro_nwm_public` root directory and the
+subdirectory structures are described thereafter. The tables below provide
+brief descriptions of the file contents of each directory where the model code
+resides.
 
 .. default-role:: file
 
@@ -157,9 +158,9 @@ contents of each directory where the model code resides.
    | `docs/`                 | Pointer to location of full documentation (i.e.  |
    |                         | this document).                                  |
    +-------------------------+--------------------------------------------------+
-   | `tests`                 | Scripts and data used to test the model          |
+   | `tests/`                | Scripts and data used to test the model          |
    +-------------------------+--------------------------------------------------+
-   | `src`                   | WRF-Hydro Model source code                      |
+   | `src/`                  | WRF-Hydro Model source code                      |
    +-------------------------+--------------------------------------------------+
    | :underline:`Source code directories under \`src/\`:`                       |
    +-------------------------+--------------------------------------------------+


### PR DESCRIPTION
TYPE: text only

KEYWORDS: documentation, cleanup

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: 
- Removed references to `trunk/NDHMS`
- Small tweaks to build instructions for WPS and WRF-Hydro

TESTS CONDUCTED: built documentation locally and it was warning free.

<!--
ITEMS THAT MIGHT BE USEFUL TO CONSIDER
 - Closes issue #xxxx
 - Tests added (unit tests and/or regression/integration tests)
 - Backwards compatible
 - Documentation included
 - Short description in the Development section of `NEWS.md`
--->
