### PR TITLE
Revert TYPEL(k) check

### DIFF
--- a/src/Routing/module_channel_routing.F90
+++ b/src/Routing/module_channel_routing.F90
@@ -876,7 +876,7 @@ END SUBROUTINE SUBMUSKINGCUNGE
 !        endif
 
           do k = 1, NLINKSL
-            if(TYPEL(k) .ne. 2) then
+            if(TYPEL(k) .ne. 1) then
                QLINK(k,2) = tmpQLINK(k,2)
             endif
             QLINK(k,1) = QLINK(k,2)    !assing link flow of current to be previous for next time step


### PR DESCRIPTION
Revert TYPEL(k) check from == 2 as in drive_channel_RSL back to the == 1 as needed for traditional routing.

TYPE: bugfix

KEYWORDS: reach routing

SOURCE: NCAR

DESCRIPTION OF CHANGES:

Change `if(TYPEL(k) .ne. 2) then ...` back to `if(TYPEL(k) .ne. 1) then ...`. This had been copied from `drive_channel_RSL()` and doesn't work correctly in traditional channel routing.