### PR TITLE
Update version number for test case

### DIFF
--- a/tests/ctests/setup_cmake_testcase.sh
+++ b/tests/ctests/setup_cmake_testcase.sh
@@ -38,7 +38,7 @@ test_file_dir=${binary_dir}/tests
 run_dir=${binary_dir}/Run
 
 # download testcase if not present
-version=5.3
+version=5.4
 croton_tarball=croton_NY_training_example_v${version}.tar.gz
 if [ ! -f ${test_file_dir}/${croton_tarball} ]
 then


### PR DESCRIPTION
TYPE: update

KEYWORDS: testing

SOURCE: NCAR

DESCRIPTION OF CHANGES:  Update `version` in CTest setup to pull current (v5.4) test case tarball

NOTE: Tests are expected to fail