### PR TITLE
bugfix: wrf cmake ifx updates

### DIFF
--- a/src/CPL/WRF_cpl/CMakeLists.txt
+++ b/src/CPL/WRF_cpl/CMakeLists.txt
@@ -14,6 +14,8 @@ add_dependencies(hydro_wrf_cpl
         MPI::MPI_Fortran
 )
 
+target_link_libraries(hydro_wrf_cpl PRIVATE hydro_driver)
+
 target_include_directories(hydro_wrf_cpl
         PRIVATE
         $<TARGET_PROPERTY:${PROJECT_NAME}_Core,Fortran_MODULE_DIRECTORY>

--- a/src/Data_Rec/CMakeLists.txt
+++ b/src/Data_Rec/CMakeLists.txt
@@ -5,3 +5,4 @@ add_library(hydro_data_rec STATIC
         module_RT_data.F90
         module_namelist.F90
 )
+target_link_libraries(hydro_data_rec PRIVATE hydro_mpp)

--- a/src/Debug_Utilities/CMakeLists.txt
+++ b/src/Debug_Utilities/CMakeLists.txt
@@ -2,3 +2,4 @@
 add_library(hydro_debug_utils STATIC
         debug_dump_variable.F90
 )
+target_link_libraries(hydro_debug_utils PRIVATE hydro_mpp)

--- a/src/HYDRO_drv/CMakeLists.txt
+++ b/src/HYDRO_drv/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(hydro_driver PUBLIC
         hydro_data_rec
         hydro_routing
         hydro_debug_utils
+        netCDF::netcdff
 )
 
 if(WRF_HYDRO_NUDGING STREQUAL "1")

--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -4,5 +4,7 @@ add_library(hydro_netcdf_layer STATIC
 )
 
 target_link_libraries(hydro_netcdf_layer
+        PUBLIC
         MPI::MPI_Fortran
+        netCDF::netcdff
 )

--- a/src/MPP/CMakeLists.txt
+++ b/src/MPP/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(hydro_mpp STATIC
         hashtable.F90
 )
 
-target_link_libraries(hydro_mpp MPI::MPI_Fortran)
+target_link_libraries(hydro_mpp PUBLIC MPI::MPI_Fortran)
 target_include_directories(hydro_mpp PUBLIC
         ${MPI_Fortran_MODULE_DIR}
 )

--- a/src/Routing/CMakeLists.txt
+++ b/src/Routing/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(hydro_routing STATIC
 )
 
 target_link_libraries(hydro_routing
+       PRIVATE
        MPI::MPI_Fortran
        hydro_mpp
        hydro_utils

--- a/src/cmake-modules/FindNetCDF.cmake
+++ b/src/cmake-modules/FindNetCDF.cmake
@@ -88,4 +88,26 @@ set (NETCDF_LIBRARIES ${NetCDF_libs} CACHE INTERNAL "All NetCDF libraries requir
 include (FindPackageHandleStandardArgs)
 find_package_handle_standard_args (NetCDF DEFAULT_MSG NETCDF_LIBRARIES NETCDF_INCLUDES NetCDF_has_interfaces)
 
+if (NETCDF_FOUND AND NOT TARGET netCDF::netcdf)
+  add_library(netCDF::netcdf UNKNOWN IMPORTED)
+  set_target_properties(
+    netCDF::netcdf
+    PROPERTIES
+    IMPORTED_LOCATION "${NETCDF_LIBRARIES_C}"
+    IMPORTED_LINK_INTERFACE_LANGUAGES C
+    INTERFACE_INCLUDE_DIRECTORIES "${NETCDF_INCLUDES}"
+    )
+endif()
+if (NETCDF_FOUND AND NOT TARGET netCDF::netcdff)
+  add_library(netCDF::netcdff UNKNOWN IMPORTED)
+  set_target_properties(
+    netCDF::netcdff
+    PROPERTIES
+    IMPORTED_LOCATION "${NETCDF_LIBRARIES_F90}"
+    IMPORTED_LINK_INTERFACE_LANGUAGES Fortran
+    INTERFACE_INCLUDE_DIRECTORIES "${NETCDF_MODULES}"
+    )
+  target_link_libraries(netCDF::netcdff INTERFACE netCDF::netcdf)
+endif()
+
 mark_as_advanced (NETCDF_LIBRARIES NETCDF_INCLUDES)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -18,5 +18,6 @@ add_library(hydro_utils STATIC
         module_version.F90
         module_hydro_stop.F90
 )
+target_link_libraries(hydro_utils PRIVATE MPI::MPI_Fortran)
 
 add_subdirectory(fortglob)


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: WRF, CMake, MPI/NetCDF Libraries

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: 
- `357db05` commit brings changes from https://github.com/wrf-model/WRF/pull/2178 PR. This changes how the MPI and NetCDF libraries link because the WRF build wasn't working with `ifx` on some local machines.
- `8ce9f05` commit adds `netcdf::netcdf netcdf::netcdff` targets to WRF-Hydro so the previous changes will work with the stand-alone model.

TESTS CONDUCTED: 
- WRF-Hydro builds and runs Croton with MPI. Tested with `GNU 12.4.0, Intel 2024.2.1, Intel 2025.0.3`
- WRF builds with WRF-Hydro's `src` directory. Tested with `GNU 12.4.0, Intel 2024.2.1, Intel 2025.0.3`


<!--
ITEMS THAT MIGHT BE USEFUL TO CONSIDER
 - Closes issue #xxxx
 - Tests added (unit tests and/or regression/integration tests)
 - Backwards compatible
 - Documentation included
 - Short description in the Development section of `NEWS.md`
--->
