### PR TITLE
bugfix: make clean new directories

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -43,7 +43,7 @@ clean:
 	@if [ -d "LandModel" ]; then \
 	(cd LandModel; make clean) \
 	fi
-	if [ $(WRF_HYDRO_RAPID) -eq 1 ]; then \
-		(cd Rapid_routing; make -f makefile.cpl clean); \
+	@if [ "$(WRF_HYDRO_RAPID)" = "1" ]; then \
+	(cd Rapid_routing; make -f makefile.cpl clean); \
 	fi
 	(rm -f */*.mod */*.o lib/*.a Run/wrf_hydro.exe)

--- a/src/arc/Makefile.mpp
+++ b/src/arc/Makefile.mpp
@@ -1,4 +1,4 @@
-# Makefile 
+# Makefile
 
 all:
 	(make -f Makefile.comm BASIC)
@@ -19,15 +19,17 @@ BASIC:
 	make -C HYDRO_drv
 
 clean:
-	(cd IO; make -f Makefile clean)
-	(cd OrchestratorLayer; make -f Makefile clean)
-	(cd utils     ; make -f Makefile clean)
+	make -C IO clean
+	make -C OrchestratorLayer clean
+	make -C utils clean
+	make -C utils/fortglob clean
+	make -C Routing/Diversions clean
 	make -C Routing/Overland clean
 	make -C Routing/Subsurface clean
 	make -C Routing/Reservoirs clean
-	(cd Data_Rec; make -f Makefile clean)
-	(cd HYDRO_drv; make -f Makefile clean)
-	(cd MPP; make -f Makefile clean)
+	make -C Data_Rec clean
+	make -C HYDRO_drv clean
+	make -C MPP clean
 	make -C Debug_Utilities/ clean
-	(cd Routing;    make -f Makefile clean)
+	make -C Routing clean
 	(rm -f lib/*.a */*.mod */*.o CPL/*/*.o CPL/*/*.mod)


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: build system, configure, clean

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES:
 - Include new directories in `make clean` when using the old configure method. 
 - Use same `make -C foo_fir clean` method for all directories. 
 - Fix "unary operator expected" message from `make clean`

TESTS CONDUCTED: Tested old configure method

<!--
ITEMS THAT MIGHT BE USEFUL TO CONSIDER
 - Closes issue #xxxx
 - Tests added (unit tests and/or regression/integration tests)
 - Backwards compatible
 - Documentation included
 - Short description in the Development section of `NEWS.md`
--->
