### PR TITLE
bugfix: run four CI jobs max and Python version bump

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -17,6 +17,7 @@ jobs:
   Model_Testing:
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
         configuration: [nwm_ana, nwm_long_range, gridded, reach, reach_lakes]
     runs-on: ubuntu-latest
@@ -32,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Checkout candidate (pull request / push)
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: CI, Github Actions

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: Since adding a fifth testcase configuration to the Github Actions CI, one job sometimes fails. Seems to be because the Github Runner has four processes and one of the five jobs will overwrite information of another one. The failing job passes when manually rerun.
- Changing the CI to run four jobs at a time max. This is a small hack but seems worth the time saved
- Bumping python version to 3.11 to match Derecho's default environment.

TESTS CONDUCTED: Github CI is the test

<!--
ITEMS THAT MIGHT BE USEFUL TO CONSIDER
 - Closes issue #xxxx
 - Tests added (unit tests and/or regression/integration tests)
 - Backwards compatible
 - Documentation included
 - Short description in the Development section of `NEWS.md`
--->
