### PR TITLE
enhancement: Dropping .exe extension from wrf_hydro binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,8 @@ if (WRF_HYDRO_NUOPC STREQUAL "1" )
 endif()
 
 option(BUILD_CROCUS "Build Crocus" ON)
+option(WRF_HYDRO_CREATE_EXE_SYMLINK "Create symlink wrfhydro.exe -> wrfhydro" ON)
+message("WRF_HYDRO_CREATE_EXE_SYMLINK = " ${WRF_HYDRO_CREATE_EXE_SYMLINK} )
 
 message("=============================================================")
 

--- a/docs/userguide/appendices.rest
+++ b/docs/userguide/appendices.rest
@@ -127,9 +127,9 @@ details on the domain and time period of the simulation are provided in the
       | *(from your project directory)*
       | :code:`cp wrf_hydro_nwm_public*/build/Run/\*.TBL example_case/Gridded`
 
-   Copy the :file:`wrf_hydro.exe` file:
+   Copy the :file:`wrf_hydro` file:
 
-      :code:`cp wrf_hydro_nwm_public*/build/Run/wrf_hydro.exe example_case/Gridded`
+      :code:`cp wrf_hydro_nwm_public*/build/Run/wrf_hydro example_case/Gridded`
 
    .. note:: There are other configuration subfolders with the names such as :file:`Gridded`, :file:`nwm`, and
       :file:`Reach`. These folders contain prepared files for other configurations of WRF-Hydro. They are found
@@ -167,7 +167,7 @@ details on the domain and time period of the simulation are provided in the
                   ├──SOILPARM.TBL
                   ├──hydro.namelist
                   ├──namelist.hydrodas
-                  ├──wrf_hydro.exe
+                  ├──wrf_hydro
 
 3. Now we will run the simulation. Note that there are many options
    and filepaths that need to be set in the two namelist files
@@ -183,7 +183,7 @@ details on the domain and time period of the simulation are provided in the
 
    .. code-block:: bash
 
-      mpirun -np 2 ./wrf_hydro.exe
+      mpirun -np 2 ./wrf_hydro
 
 4. If your simulation ran successfully, there should now be a large
    number of output files. Descriptions of the output files and their contents
@@ -602,7 +602,7 @@ the wrfinput* and wrfbdy* files as initial and boundary conditions and the
 model physics and other options selected in the namelist.input and
 hydro.namelist files.
 
-1. Execute wrf.exe using the proper syntax for your system (example below) and
+1. Execute wrf using the proper syntax for your system (example below) and
    pipe the output to a log file.
 
 .. code-block:: console
@@ -637,7 +637,7 @@ the WRF-Hydro workflow to work with Noah:
 -  **LSM initialization:** The simple wrfinput.nc initialization file
    created by the create_Wrfinput.R script does not currently include
    all of the fields required by the Noah LSM. Therefore, Noah users
-   should use the WRF real.exe utility to create a wrfinput_d0x file.
+   should use the WRF real utility to create a wrfinput_d0x file.
    Refer to the WRF documentation and user guides for information on how
    to do this.
 

--- a/docs/userguide/model-code-config.rest
+++ b/docs/userguide/model-code-config.rest
@@ -46,7 +46,7 @@ for coupling other modeling systems into WRF-Hydro.
 
     *Example:* For coupled WRF/WRF-Hydro runs the WRF-Hydro components are
     compiled as a single library function call with the WRF system. As such,
-    a single executable is created upon compilation (:program:`wrf.exe`). As
+    a single executable is created upon compilation (:program:`wrf`). As
     illustrated in :ref:`Figure 2.1 <figure2.1>`, WRF-hydro is called directly
     from WRF in the WRF surface driver module (:file:`phys/module_surface_driver.F90`).
     The code that manages the communication is the :file:`WRF_drv_Hydro.F90`

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,15 +94,15 @@ if (HYDRO_LSM MATCHES "NoahMP")
         add_dependencies(hydro_noahmp_cpl hydro_mpp )
         add_dependencies(hydro_noahmp_cpl hydro_driver )
 
-        add_executable(wrfhydro.exe
+        add_executable(wrfhydro
                 Land_models/NoahMP/IO_code/main_hrldas_driver.F
                 Land_models/NoahMP/IO_code/module_hrldas_netcdf_io.F
                 Land_models/NoahMP/IO_code/module_NoahMP_hrldas_driver.F
         )
 
-        target_include_directories(wrfhydro.exe BEFORE PUBLIC ${PROJECT_BINARY_DIR}/mods)
+        target_include_directories(wrfhydro BEFORE PUBLIC ${PROJECT_BINARY_DIR}/mods)
 
-        target_link_libraries(wrfhydro.exe
+        target_link_libraries(wrfhydro
                 hydro_utils
                 hydro_mpp
                 hydro_debug_utils
@@ -127,17 +127,17 @@ if (HYDRO_LSM MATCHES "NoahMP")
         )
 
         if (WRF_HYDRO_NUDGING STREQUAL "1")
-                target_link_libraries(wrfhydro.exe hydro_nudging)
-                target_link_libraries(wrfhydro.exe hydro_routing_diversions)
-                add_dependencies(wrfhydro.exe hydro_nudging)
-                add_dependencies(wrfhydro.exe hydro_routing_diversions)
+                target_link_libraries(wrfhydro hydro_nudging)
+                target_link_libraries(wrfhydro hydro_routing_diversions)
+                add_dependencies(wrfhydro hydro_nudging)
+                add_dependencies(wrfhydro hydro_routing_diversions)
         endif()
 
         # bash commands to copy namelists to the Run directory
         set(BASH_CP_HRLDAS_NML "if [[ ! -f ${CMAKE_BINARY_DIR}/Run/namelist.hrldas ]]\; then cp ${PROJECT_SOURCE_DIR}/src/template/NoahMP/namelist.hrldas ${CMAKE_BINARY_DIR}/Run \; fi\;")
         set(BASH_CP_HYDRO_NML "if [[ ! -f ${CMAKE_BINARY_DIR}/Run/hydro.namelist ]]\; then cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/hydro.namelist ${CMAKE_BINARY_DIR}/Run \; fi\;")
 
-        add_custom_command(TARGET wrfhydro.exe POST_BUILD
+        add_custom_command(TARGET wrfhydro POST_BUILD
                 COMMAND mkdir -p ${CMAKE_BINARY_DIR}/Run
                 COMMAND cp ${PROJECT_SOURCE_DIR}/tests/ctests/run_dir_makefile.mk ${CMAKE_BINARY_DIR}/Run/Makefile
                 # copy tables
@@ -148,12 +148,17 @@ if (HYDRO_LSM MATCHES "NoahMP")
                 COMMAND bash -c "${BASH_CP_HRLDAS_NML}"
                 COMMAND bash -c "${BASH_CP_HYDRO_NML}"
                 # copy and setup executables
-                COMMAND rm -f ${CMAKE_BINARY_DIR}/Run/wrf_hydro.exe
-                COMMAND rm -f ${CMAKE_BINARY_DIR}/Run/wrf_hydro_NoahMP.exe
-                COMMAND cp ${PROJECT_BINARY_DIR}/src/wrfhydro.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro_NoahMP.exe
-                COMMAND ln -s wrf_hydro_NoahMP.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro.exe
-                COMMAND rm ${PROJECT_BINARY_DIR}/src/wrfhydro.exe
+                COMMAND rm -f ${CMAKE_BINARY_DIR}/Run/wrf_hydro
+                COMMAND rm -f ${CMAKE_BINARY_DIR}/Run/wrf_hydro_NoahMP
+                COMMAND cp ${PROJECT_BINARY_DIR}/src/wrfhydro ${CMAKE_BINARY_DIR}/Run/wrf_hydro
+                COMMAND ln -sf ${CMAKE_BINARY_DIR}/Run/wrf_hydro ${CMAKE_BINARY_DIR}/Run/wrf_hydro_NoahMP
+                COMMAND rm ${PROJECT_BINARY_DIR}/src/wrfhydro
         )
+        if(WRF_HYDRO_CREATE_EXE_SYMLINK)
+                add_custom_command(TARGET wrfhydro POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_BINARY_DIR}/Run/wrf_hydro ${CMAKE_BINARY_DIR}/Run/wrf_hydro.exe
+                )
+        endif()
 
 elseif (HYDRO_LSM MATCHES "Noah")
         message("-- Building Noah LSM")
@@ -164,14 +169,14 @@ elseif (HYDRO_LSM MATCHES "Noah")
         add_dependencies(hydro_noah_cpl hydro_mpp )
         add_dependencies(hydro_noah_cpl hydro_driver )
 
-        add_executable(wrfhydro.exe
+        add_executable(wrfhydro
                 Land_models/Noah/IO_code/module_hrldas_netcdf_io.F
                 Land_models/Noah/IO_code/Noah_hrldas_driver.F
         )
 
-        target_include_directories(wrfhydro.exe BEFORE PUBLIC ${PROJECT_BINARY_DIR}/mods)
+        target_include_directories(wrfhydro BEFORE PUBLIC ${PROJECT_BINARY_DIR}/mods)
 
-        target_link_libraries(wrfhydro.exe
+        target_link_libraries(wrfhydro
                 hydro_utils
                 hydro_mpp
                 hydro_debug_utils
@@ -196,21 +201,22 @@ elseif (HYDRO_LSM MATCHES "Noah")
         )
 
         if (WRF_HYDRO_NUDGING STREQUAL "1")
-                target_link_libraries(wrfhydro.exe hydro_nudging)
-                add_dependencies(wrfhydro.exe hydro_nudging)
+                target_link_libraries(wrfhydro hydro_nudging)
+                add_dependencies(wrfhydro hydro_nudging)
         endif()
 
-        add_custom_command(TARGET wrfhydro.exe POST_BUILD
+        add_custom_command(TARGET wrfhydro POST_BUILD
                 COMMAND mkdir -p ${CMAKE_BINARY_DIR}/Run
                 COMMAND rm -f ${CMAKE_BINARY_DIR}/Run/*
-                COMMAND cp ${PROJECT_BINARY_DIR}/src/wrfhydro.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro_Noah.exe
+                COMMAND cp ${PROJECT_BINARY_DIR}/src/wrfhydro ${CMAKE_BINARY_DIR}/Run/wrf_hydro_Noah
                 COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/Noah/* ${CMAKE_BINARY_DIR}/Run
                 COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/CHANPARM.TBL ${CMAKE_BINARY_DIR}/Run
                 COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/hydro.namelist ${CMAKE_BINARY_DIR}/Run
                 COMMAND cp ${PROJECT_SOURCE_DIR}/src/template/HYDRO/HYDRO.TBL ${CMAKE_BINARY_DIR}/Run
                 COMMAND cp ${PROJECT_SOURCE_DIR}/src/Land_models/Noah/Run/*.TBL ${CMAKE_BINARY_DIR}/Run
-                COMMAND ln -s wrf_hydro_Noah.exe ${CMAKE_BINARY_DIR}/Run/wrf_hydro.exe
-                COMMAND rm ${PROJECT_BINARY_DIR}/src/wrfhydro.exe
+                COMMAND ln -sf ${CMAKE_BINARY_DIR}/Run/wrf_hydro_Noah ${CMAKE_BINARY_DIR}/Run/wrf_hydro
+                COMMAND ln -sf ${CMAKE_BINARY_DIR}/Run/wrf_hydro_Noah ${CMAKE_BINARY_DIR}/Run/wrf_hydro.exe
+                COMMAND rm ${PROJECT_BINARY_DIR}/src/wrfhydro
         )
 
 elseif(${PROJECT_NAME} STREQUAL "WRF")

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 # Makefile
 #
-CMD = Run/wrf_hydro.exe
+CMD = Run/wrf_hydro
 .PHONY: $(CMD)
 
 all: $(CMD)
@@ -9,7 +9,7 @@ $(CMD):
 	@if [ ! -d "Run" ]; then \
 		(mkdir Run);\
 	fi
-	(rm -f Run/wrf_hydro.exe   )
+	(rm -f Run/wrf_hydro   )
 	(make -f Makefile.comm BASIC)
 	@if [ -d "LandModel_cpl" ]; then \
 	(cd LandModel_cpl; make) \
@@ -31,8 +31,8 @@ debug::
 debug:: $(CMD)
 
 install:
-	-rm -f ./Run/wrf_hydro.exe
-	mv LandModel/run/hrldas.exe  ./Run/wrf_hydro.exe
+	-rm -f ./Run/wrf_hydro
+	mv LandModel/run/hrldas.exe  ./Run/wrf_hydro
 test:
 	@echo "No libraries or utilities are built, skip testing."
 clean:
@@ -46,4 +46,4 @@ clean:
 	@if [ "$(WRF_HYDRO_RAPID)" = "1" ]; then \
 	(cd Rapid_routing; make -f makefile.cpl clean); \
 	fi
-	(rm -f */*.mod */*.o lib/*.a Run/wrf_hydro.exe)
+	(rm -f */*.mod */*.o lib/*.a Run/wrf_hydro)

--- a/src/README.build.md
+++ b/src/README.build.md
@@ -47,7 +47,7 @@ $ make -j 4
 
 This should result in the creation of a 'Run' directory populated with the
 appropriate template parameter tables and namelists for the land surface model
-selected as well as a model executable that is then symlinked to wrf_hydro.exe.
+selected as well as a model executable that is then symlinked to `wrf_hydro`.
 
 Note that, as mentioned above, passing the environment variable file as an
 argument to the compile script is optional. However, if this is not passed the

--- a/src/arc/Makefile.Noah
+++ b/src/arc/Makefile.Noah
@@ -1,5 +1,5 @@
-# Makefile 
-CMD = Run/wrf_hydro.exe
+# Makefile
+CMD = Run/wrf_hydro
 
 all: $(CMD)
 
@@ -7,7 +7,7 @@ $(CMD):
 	@if [ ! -d "Run" ]; then \
 		(mkdir Run);\
 	fi
-	(rm -f Run/wrf_hydro.exe   )
+	(rm -f Run/wrf_hydro   )
 	(make -f Makefile.comm BASIC)
 	@if [ -d "LandModel_cpl" ]; then \
 	(cd LandModel_cpl; make) \
@@ -23,16 +23,16 @@ $(CMD):
 	(cd LandModel; make ) \
 	fi
 
-debug:: 
-	@echo 'F90FLAGS := $$(DEBUGFLAGS) $$(F90FLAGS)' >> ./macros 
+debug::
+	@echo 'F90FLAGS := $$(DEBUGFLAGS) $$(F90FLAGS)' >> ./macros
 	@echo 'F90FLAGS := $$(DEBUGFLAGS) $$(F90FLAGS)' >> ./LandModel/user_build_options
 debug:: $(CMD)
 
 install:
-	-rm -f ./Run/wrf_hydro.exe; \
-	mv ./Run/Noah_hrldas_beta ./Run/wrf_hydro.exe
+	-rm -f ./Run/wrf_hydro; \
+	mv ./Run/Noah_hrldas_beta ./Run/wrf_hydro
 test:
-	@echo "No libraries or utilities are built, skip testing." 
+	@echo "No libraries or utilities are built, skip testing."
 clean:
 	@if [ -d "LandModel_cpl" ]; then \
 	(cd LandModel_cpl; make clean) \
@@ -44,4 +44,4 @@ clean:
 	if [ $(WRF_HYDRO_RAPID) -eq 1 ]; then \
 		(cd Rapid_routing; make -f makefile.cpl clean); \
 	fi
-	(rm -f */*.mod */*.o lib/*.a Run/wrf_hydro.exe)
+	(rm -f */*.mod */*.o lib/*.a Run/wrf_hydro)

--- a/src/arc/Makefile.NoahMP
+++ b/src/arc/Makefile.NoahMP
@@ -1,6 +1,6 @@
 # Makefile
 #
-CMD = Run/wrf_hydro.exe
+CMD = Run/wrf_hydro
 .PHONY: $(CMD)
 
 all: $(CMD)
@@ -9,7 +9,7 @@ $(CMD):
 	@if [ ! -d "Run" ]; then \
 		(mkdir Run);\
 	fi
-	(rm -f Run/wrf_hydro.exe   )
+	(rm -f Run/wrf_hydro   )
 	(make -f Makefile.comm BASIC)
 	@if [ -d "LandModel_cpl" ]; then \
 	(cd LandModel_cpl; make) \
@@ -31,8 +31,8 @@ debug::
 debug:: $(CMD)
 
 install:
-	-rm -f ./Run/wrf_hydro.exe
-	mv LandModel/run/hrldas.exe  ./Run/wrf_hydro.exe
+	-rm -f ./Run/wrf_hydro
+	mv LandModel/run/hrldas.exe  ./Run/wrf_hydro
 test:
 	@echo "No libraries or utilities are built, skip testing."
 clean:
@@ -46,4 +46,4 @@ clean:
 	if [ $(WRF_HYDRO_RAPID) -eq 1 ]; then \
 		(cd Rapid_routing; make -f makefile.cpl clean); \
 	fi
-	(rm -f */*.mod */*.o lib/*.a Run/wrf_hydro.exe)
+	(rm -f */*.mod */*.o lib/*.a Run/wrf_hydro)

--- a/src/compile_offline_Noah.sh
+++ b/src/compile_offline_Noah.sh
@@ -39,7 +39,7 @@ cp arc/Makefile.Noah Makefile
 ln -sf CPL/Noah_cpl LandModel_cpl
 ln -sf Land_models/Noah LandModel
 cat macros LandModel/user_build_options.bak  > LandModel/user_build_options
-make clean ; rm -f Run/wrf_hydro_Noah.exe ; rm -f Run/*TBL ; rm -f Run/*namelist*
+make clean ; rm -f Run/wrf_hydro_Noah ; rm -f Run/*TBL ; rm -f Run/*namelist*
 
 cat macros LandModel/user_build_options.bak > LandModel/user_build_options
 
@@ -58,7 +58,7 @@ else
 fi
 
 cd Run
-mv wrf_hydro.exe wrf_hydro_Noah.exe ; ln -sf wrf_hydro_Noah.exe wrf_hydro.exe
+mv wrf_hydro wrf_hydro_Noah ; ln -sf wrf_hydro_Noah wrf_hydro ; ln -sf wrf_hydro_Noah wrf_hydro
 cp ../Land_models/Noah/Run/GENPARM.TBL .
 cp ../Land_models/Noah/Run/SOILPARM.TBL .
 cp ../Land_models/Noah/Run/VEGPARM.TBL .

--- a/src/compile_offline_NoahMP.sh
+++ b/src/compile_offline_NoahMP.sh
@@ -48,7 +48,7 @@ cd ../..
 ln -sf Land_models/NoahMP LandModel
 cat macros LandModel/hydro/user_build_options.bak  > LandModel/user_build_options
 ln -sf CPL/NoahMP_cpl LandModel_cpl
-make clean; rm -f Run/wrf_hydro_NoahMP.exe ; rm -f Run/*TBL ; rm -f Run/*namelist*
+make clean; rm -f Run/wrf_hydro_NoahMP ; rm -f Run/*TBL ; rm -f Run/*namelist*
 
 #for debugging and testing
 #make debug; make install; make test
@@ -66,7 +66,7 @@ else
 fi
 
 cd Run
-mv  wrf_hydro.exe wrf_hydro_NoahMP.exe; ln -sf wrf_hydro_NoahMP.exe wrf_hydro.exe
+mv  wrf_hydro wrf_hydro_NoahMP; ln -sf wrf_hydro_NoahMP wrf_hydro
 
 if [ "$NWM_META" != "1" ]; then
     # If it is not an nwm version, copy the stock namelists and tables.

--- a/tests/README.md
+++ b/tests/README.md
@@ -118,7 +118,7 @@ optional arguments:
                         best guess. The first/zeroth variable is set to the
                         total number of cores (ncores). The wrf_hydro_py
                         convention is that the exe is always named
-                        wrf_hydro.exe.
+                        wrf_hydro.
   --ncores NCORES       Number of cores to use for testing
   --scheduler           Scheduler to use for testing, options are PBSDerecho
                         or do not specify for no scheduler

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,12 +111,12 @@ def pytest_addoption(parser):
 
     parser.addoption(
         '--exe_cmd',
-        default='mpirun -np {0} ./wrf_hydro.exe',
+        default='mpirun -np {0} ./wrf_hydro',
         required=False,
         action='store',
         help='The MPI-dependent model execution command. Default is best guess. '
         'The first/zeroth variable is set to the total number of cores. The '
-        'wrf_hydro_py convention is that the exe is always named wrf_hydro.exe.'
+        'wrf_hydro_py convention is that the exe is always named wrf_hydro.'
     )
 
     parser.addoption(

--- a/tests/ctests/run_cmake_testcase.sh
+++ b/tests/ctests/run_cmake_testcase.sh
@@ -11,9 +11,9 @@ run_dir=${binary_dir}/Run
 output_dir=output_${testcase_type}
 
 if [ "$np" -eq "1" ]; then
-    run_cmd="./wrf_hydro.exe"
+    run_cmd="./wrf_hydro"
 else
-    run_cmd="mpiexec -np ${np} ./wrf_hydro.exe"
+    run_cmd="mpiexec -np ${np} ./wrf_hydro"
 fi
 
 # run testcase

--- a/tests/ctests/run_dir_makefile.mk
+++ b/tests/ctests/run_dir_makefile.mk
@@ -5,7 +5,7 @@ build:
 	make -C ..
 
 run:
-	./wrf_hydro.exe
+	./wrf_hydro
 
 # download and extract Croton, NY test case to Run directory
 # testcase options: {Gridded, Gridded_no_lakes, NWM, Reach, ReachLakes}

--- a/tests/ctests/setup_cmake_testcase.sh
+++ b/tests/ctests/setup_cmake_testcase.sh
@@ -2,7 +2,7 @@
 
 # Bash script is meant to be used by CMake. It downloads and extracts the
 # Croton, NY testcase to the CMake build Run directory. It then setups up the
-# files so ctest can run wrf_hydro.exe
+# files so ctest can run wrf_hydro
 
 # setup directory variables in script
 # match the input case to valid testcase_dir

--- a/tests/local/derecho/model_test.sh
+++ b/tests/local/derecho/model_test.sh
@@ -10,29 +10,29 @@ the_help="\
 Model Testing
 
 Required
-    -c: 
-        Candidate directory path. The code to test. 
+    -c:
+        Candidate directory path. The code to test.
     -r:
         Reference directory path. The code to test against.
 
 Options:
-    --reference_update: 
+    --reference_update:
        default=true
-       In the reference repo, fetch upstream (NCAR) and checkout branch matching 
+       In the reference repo, fetch upstream (NCAR) and checkout branch matching
        that of the candidate?
-    --compiler: 
-        [default=ifort, gfort, <You can try whatever is available in modules>] 
+    --compiler:
+        [default=ifort, gfort, <You can try whatever is available in modules>]
         Currently:  ifort -> intel/17.0.1   and  gnu -> gnu/7.1.0
         We should try to keep this update along with what is here:
         https://github.com/NCAR/wrf_hydro_nwm_public/wiki/Compiler-requirements-by-version
-    --mpi: 
+    --mpi:
         [default=impi, <You can try whatever is available in modules.>]
     --exe_cmd:
-        [default=\"mpirun -np \\\$ncores ./wrf_hydro.exe\", <Whatever you need for your mpi.>]
+        [default=\"mpirun -np \\\$ncores ./wrf_hydro\", <Whatever you need for your mpi.>]
         See examples for MPT in the shared queue (other MPI distros apparently dont need this).
-    --config: 
+    --config:
         [default=nwm_ana, nwm_long_range, <Whatever is available in the .json files for the domain.>]
-    ---ncores: 
+    ---ncores:
         default=360
     --nnodes:
         default=ceiling ncores 36
@@ -44,7 +44,7 @@ Options:
         default=01:00:00
     --domain_dir:
         The domain must be properly constructed with domain-side json namelist patch files and a
-        .version file. 
+        .version file.
     --use_existing_test_dir
         default is not included. Lets testing proceede with existing output in place.
     --xrcmp_n_cores
@@ -53,7 +53,7 @@ Options:
 
 
 
-Usage Examples: 
+Usage Examples:
 # A CONUS test of nwm_ana
 ./model_test.sh -c /path/to/candidate_dir -r /path/to/reference_dir
 
@@ -76,7 +76,7 @@ Usage Examples:
     -c ~/WRF_Hydro/wrf_hydro_nwm_public \\
     -r ~/WRF_Hydro/.wrf_hydro_nwm_public_REFERENCE \\
     --compiler=ifort --mpi=mpt \\
-    --exe_cmd=\"mpiexec_mpt $'\\\$(hostname)' -np \\\$ncores ./wrf_hydro.exe\" \\
+    --exe_cmd=\"mpiexec_mpt $'\\\$(hostname)' -np \\\$ncores ./wrf_hydro\" \\
     --config='nwm_ana' \\
     --ncores=6 --queue=share \\
     --domain_dir path/to/croton_NY
@@ -85,7 +85,7 @@ Usage Examples:
 ## Default options
 compiler=ifort
 mpi=impi
-exe_cmd="mpirun -np \$ncores ./wrf_hydro.exe"
+exe_cmd="mpirun -np \$ncores ./wrf_hydro"
 config=nwm_ana
 ncores=360
 nnodes=to_calculate
@@ -198,7 +198,7 @@ if [[ $reference_update == 'true' ]]; then
     else
         cd $reference_dir || exit 9
         git fetch upstream || exit 9
-    fi             
+    fi
     git checkout origin/$branch_name  || exit 9
     cd - 2> /dev/null cd 1> /dev/null
 fi

--- a/tests/local/run_tests.py
+++ b/tests/local/run_tests.py
@@ -181,11 +181,11 @@ def main():
 
     parser.add_argument(
         '--exe_cmd',
-        default="'mpirun -np {0} ./wrf_hydro.exe'",
+        default="'mpirun -np {0} ./wrf_hydro'",
         required=False,
         help='The MPI-dependent model execution command. Default is best guess. '
         'The first/zeroth variable is set to the total number of cores (ncores). The '
-        'wrf_hydro_py convention is that the exe is always named wrf_hydro.exe.'
+        'wrf_hydro_py convention is that the exe is always named wrf_hydro.'
     )
 
     parser.add_argument(

--- a/tests/test_supp_2_nwm_output.py
+++ b/tests/test_supp_2_nwm_output.py
@@ -37,7 +37,7 @@ def test_run_reference_nwm_output_sim(
     reference_nwm_output_sim_copy.model = copy.deepcopy(reference_sim.model)
 
     # Job
-    exe_command = 'mpirun -np {0} ./wrf_hydro.exe'.format(str(ncores))
+    exe_command = 'mpirun -np {0} ./wrf_hydro'.format(str(ncores))
     job = wrfhydropy.Job(
         job_id='run_reference',
         exe_cmd=exe_command,
@@ -96,7 +96,7 @@ def test_run_candidate_nwm_output_sim(
     candidate_nwm_output_sim_copy.model = copy.deepcopy(candidate_sim.model)
 
     # Job
-    exe_command = 'mpirun -np {0} ./wrf_hydro.exe'.format(str(ncores))
+    exe_command = 'mpirun -np {0} ./wrf_hydro'.format(str(ncores))
     job = wrfhydropy.Job(
         job_id='run_candidate',
         exe_cmd=exe_command,
@@ -162,4 +162,3 @@ def test_regression_metadata_nwm_output(output_dir):
         print_diffs(meta_data_diffs)
     assert has_metadata_diffs is False, \
         'NWM output metadata and attributes of candidate run do not match those of the reference run.'
-


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: build system, documentation, training

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: It seem an appropriate time to drop the `.exe` from the `wrf_hydro.exe` executable for the following reasons. 
- The `.exe` indicates an executable on Windows systems and WRF-Hydro targets Linux systems
- WRF has dropped the `.exe` extension
- Current work is being done to update the training material.
- `WRF_HYDRO_CREATE_EXE_SYMLINK` CMake option added to allow the user to turn on creation of `.exe` symlink. Defaults to `ON` for now

TESTS CONDUCTED: built and ran Croton

<!--
ITEMS THAT MIGHT BE USEFUL TO CONSIDER
 - Closes issue #xxxx
 - Tests added (unit tests and/or regression/integration tests)
 - Backwards compatible
 - Documentation included
 - Short description in the Development section of `NEWS.md`
--->
