### PR TITLE
hotfix: don't run CI on forks

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   Model_Testing:
+    if: github.repository == 'NCAR/wrf_hydro_nwm_public'
     strategy:
       fail-fast: false
       max-parallel: 4


### PR DESCRIPTION
TYPE: hotfix

KEYWORDS: CI, Github Actions, Runner

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: Run CI only on upstream repo, not forks. This is to prevent charges to users

TESTS CONDUCTED: tested on [wrf_hydro_docker](https://github.com/scrasmussen/wrf_hydro_docker/)

<!--
ITEMS THAT MIGHT BE USEFUL TO CONSIDER
 - Closes issue #xxxx
 - Tests added (unit tests and/or regression/integration tests)
 - Backwards compatible
 - Documentation included
 - Short description in the Development section of `NEWS.md`
--->
