### PR TITLE
Update CMakeLists.txt to support UFS integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,16 @@ enable_testing()
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/src/cmake-modules)
 
 # try to find the installed NETCDF library
-set(NETCDF_F90 "YES")
-set(NETCDF_F77 "YES")
-find_package(NetCDF REQUIRED)
-message("-- NetCDF Include Dir(s): ${NETCDF_INCLUDES_F77} ${NETCDF_INCLUDES_F90}")
+if (NOT TARGET netCDF::netcdff AND TARGET NetCDF::NetCDF_Fortran)
+   add_library(netCDF::netcdff ALIAS NetCDF::NetCDF_Fortran)
+endif()
+
+if (NOT TARGET netCDF::netcdff)
+   set(NETCDF_F90 "YES")
+   set(NETCDF_F77 "YES")
+   find_package(NetCDF REQUIRED)
+   message("-- NetCDF Include Dir(s): ${NETCDF_INCLUDES_F77} ${NETCDF_INCLUDES_F90}")
+endif()
 
 # set user controled enviorment variables
 set(HYDRO_LSM $ENV{HYDRO_LSM} CACHE STRING "Name of the Land Surface Model to Use")

--- a/src/CPL/NUOPC_cpl/CMakeLists.txt
+++ b/src/CPL/NUOPC_cpl/CMakeLists.txt
@@ -28,6 +28,8 @@ list(APPEND wrfhydro_nuopc_linklibs
   hydro_routing_subsurface
   hydro_data_rec
   hydro_routing
+  hydro_routing_diversions
+  fortglob
   hydro_routing_reservoirs_levelpool
   hydro_routing_reservoirs_hybrid
   hydro_routing_reservoirs_rfc


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: cmake, ufs

SOURCE: NCAR

DESCRIPTION OF CHANGES: 

 * add `hydro_routing_diversions` and `fort_glob` to `wrfhydro_nuopc_linklibs`
 * check if upstream CMake has defined `netCDF::NetCDF_Fortran` and use it instead of calling `find_package` again