### PR TITLE
Support int64 for station_id, time, and lake_id

### DIFF
--- a/src/Routing/module_HYDRO_io.F90
+++ b/src/Routing/module_HYDRO_io.F90
@@ -5103,7 +5103,7 @@ end subroutine mpp_output_chrt
 !#endif
 
       !- station location definition,  LAKEIDM
-      iret = nf90_def_var(ncid, "lake_id", NF90_INT, (/stationdim/), varid)
+      iret = nf90_def_var(ncid, "lake_id", NF90_INT64, (/stationdim/), varid)
       iret = nf90_put_att(ncid, varid, 'long_name', 'Lake COMMON ID')
 
 !#ifndef HYDRO_REALTIME
@@ -9805,7 +9805,7 @@ if (io_config_outputs .le. 0) then
 !        iret = nf90_put_att(ncid, varid, '_FillValue', -1)
 endif
 
-        iret = nf90_def_var(ncid, "time", NF90_INT, (/timedim/), varid)
+        iret = nf90_def_var(ncid, "time", NF90_INT64, (/timedim/), varid)
         iret = nf90_put_att(ncid, varid, 'units', sec_valid_date)
         iret = nf90_put_att(ncid, varid, 'long_name', 'valid output time')
 
@@ -9860,7 +9860,7 @@ endif
 
      !-- station  id
      ! define character-position dimension for strings of max length 11
-        iret = nf90_def_var(ncid, "station_id", NF90_INT, (/stationdim/), varid)
+        iret = nf90_def_var(ncid, "station_id", NF90_INT64, (/stationdim/), varid)
         iret = nf90_put_att(ncid, varid, 'long_name', 'Station id')
 
        !! JLM: Write/define a global attribute of the file as the LSM timestep. Enforce


### PR DESCRIPTION
Updates output files to support int64 for station_id and time. This is to align with the equivalent change that was made years back on what I believe must be the official NWM output side of things (which used "feature_id" instead of "station_id"). For example, all of the official NWM outputs for the Alaska domain correctly use int64 for the feature_id variable with no data loss.

TYPE: bug fix

KEYWORDS: dtype, netcdf, output, int64

SOURCE: Shawn Crawley (NOAA Affiliate via Lynker)

DESCRIPTION OF CHANGES: The dtype of a few output NetCDF variables was changed from int to int64.

ISSUE: My input RouteLink.nc file supports INT64 in the "link", "from", and "to" columns. The CHRTOUT_DOMAIN output NetCDF files had the associated links - stored as "station_id" - recast to int32, and thus were converted to 10-digits that no longer matched the input.

TESTS CONDUCTED: I just manually made the changes herein, recompiled, reran my simulation and checked that the results were as hoped.

There may be other spots that a similar update is needed. I only did so for the few that were unique to my situation.