### PR TITLE
Removing re-definition of snow parameters ssi, snowretfac, and rsurfsnow

### DIFF
--- a/src/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
+++ b/src/Land_models/NoahMP/phys/module_sf_noahmpdrv.F
@@ -1673,8 +1673,6 @@ SUBROUTINE TRANSFER_MP_PARAMETERS(VEGTYPE,SOILTYPE,SLOPETYPE,SOILCOLOR,CROPTYPE,
    parameters%TIMEAN     =      TIMEAN_TABLE
    parameters%FSATMX     =      FSATMX_TABLE
    parameters%Z0SNO      =       Z0SNO_TABLE
-   parameters%SSI        =         SSI_TABLE
-   parameters%SNOW_RET_FAC =  SNOW_RET_FAC_TABLE
    parameters%SWEMX      =       SWEMX_TABLE
    parameters%GRAIN_GROWTH = GRAIN_GROWTH_TABLE
    parameters%EXTRA_GROWTH = EXTRA_GROWTH_TABLE
@@ -1686,7 +1684,6 @@ SUBROUTINE TRANSFER_MP_PARAMETERS(VEGTYPE,SOILTYPE,SLOPETYPE,SOILCOLOR,CROPTYPE,
    parameters%BATS_NIR_AGE = BATS_NIR_AGE_TABLE
    parameters%BATS_VIS_DIR = BATS_VIS_DIR_TABLE
    parameters%BATS_NIR_DIR = BATS_NIR_DIR_TABLE
-   parameters%RSURF_SNOW =  RSURF_SNOW_TABLE
    parameters%SWE_LIMIT  =  SWE_LIMIT_TABLE
 
 ! ----------------------------------------------------------------------


### PR DESCRIPTION
Certain 2D snow parameters from soil_properties.nc were being re-defined with 1D parameter from MPTABLE.TBL when SPATIAL_SOIL is active.

TYPE: bug fix

KEYWORDS: SPATIAL_SOIL, snow parameter, soil_properties, BATS

SOURCE: Kevin Sampson, Airborne Snow Observatories, Inc.

DESCRIPTION OF CHANGES: 
	Parameter perturbation experiments conducted with snow parameters yielded results that suggested that the current version of WRF-Hydro (v5.4.0 and 5.3.0-alpha3 tested) have no sensitivity to perturbations of ssi, snowretfac, and rsurfsnow in the soil_properties file. However, perturbations of these same parameters in the global MPTABLE.TBL file showed sensitivity to perturbation. Discussion with developers resulted in identifying the issue, with credit to @aubreyd for the eventual solution.

ISSUE: The GitHub Issue that this PR addresses. For issue number 123, it would be `Fixes #123`

TESTS CONDUCTED: Tested the impact of the change by performing parameter perturbation experiments before and after the change, 
which indicate that the change was effective in exposing the 2D snow parameters. No regression, integration, or unit tests were run before submitting.