### PR TITLE
Properly handle unexpected NaNs in diversion observations

### DIFF
--- a/src/Routing/Diversions/module_diversions.F90
+++ b/src/Routing/Diversions/module_diversions.F90
@@ -138,7 +138,8 @@ contains
                 if (diversions(i)%type_div /= 3) then
                     print free, "!!! UNSUPPORTED DIVERSION TYPE (", diversions(i)%type_div, "), skipping"
                 else
-                    diversion_quantity_in = diversions(i)%persisted_flow_dest
+                    if (.not. ieee_is_nan(diversions(i)%persisted_flow_dest)) &
+                        diversion_quantity_in = diversions(i)%persisted_flow_dest
                 end if
             end if
         end do

--- a/src/Routing/module_channel_routing.F90
+++ b/src/Routing/module_channel_routing.F90
@@ -1646,6 +1646,7 @@ end subroutine drive_CHANNEL
                                          nudge_apply_upstream_muskingumCunge
 #endif
       use module_channel_diversions, only: calculate_diversion
+      use ieee_arithmetic, only: ieee_is_nan
 
        implicit none
 
@@ -2031,8 +2032,17 @@ do nt = 1, nsteps
 #endif
             Qup = div_dst
             Quc = div_dst
-            tmpQLINK(k,1) = div_dst
             tmpQLINK(k,2) = div_dst
+
+            ! reset any NaNs that got through
+            if (ieee_is_nan(div_dst)) then
+               ! fallback to zero if div_dst is NaN
+               if (ieee_is_nan(QLINK(k,1))) QLINK(k,1) = 0.0
+               if (ieee_is_nan(QLINK(k,2))) QLINK(k,2) = 0.0
+            else
+               if (ieee_is_nan(QLINK(k,1))) QLINK(k,1) = tmpQLINK(k,2)
+               if (ieee_is_nan(QLINK(k,2))) QLINK(k,2) = tmpQLINK(k,2)
+            end if
          end if
 
 #ifdef WRF_HYDRO_NUDGING


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: diversions

SOURCE: NSF NCAR

DESCRIPTION OF ISSUE:  NaNs in DA/diversion timeslice gage observations could be unintentionally and unexpectedly applied to streamflow values, creating invalid output and restart files. These NaNs would persist even when valid data was later used due to NaN math (NaN + any value = NaN).

DESCRIPTION OF CHANGES: Ignore NaNs in timeslice files and look for older, valid values. Remove NaNs that appear when using restart files.

TESTS: NCAR internal