### PR TITLE
Add new Intel compilers to configure: ifx/openapi

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -85,7 +85,7 @@ if [[ -z $theArgument ]]; then
     echo "---------------------------------------------------"
     echo "     1        nvfort  nvidia parallel"
     echo "     2         gfort  gfortran parallel"
-    echo "     3         ifort  intel parallel"
+    echo "     3     ifx|ifort  intel parallel"
     echo "     4          cray  cray (ftn) parallel"
     echo "     5     ifort_omp  intel openmp"
     echo "     6 intel.cray_xc  intel parallel (cray_xc)"
@@ -114,9 +114,9 @@ if [[ "$theArgument" == "2" ]] || [[ "$theArgument" == "gfort" ]]; then
     echo "Configured: gfort"
 fi
 
-if [[ "$theArgument" == "3" ]] || [[ "$theArgument" == "ifort" ]]; then
+if [[ "$theArgument" == "3" ]] || [[ "$theArgument" =~ ^(ifort|ifx|intel)$ ]]; then
     cp arc/macros.mpp.ifort macros
-    echo "Configured: ifort"
+    echo "Configured: Intel"
     cp arc/Makefile.mpp Makefile.comm
 fi
 

--- a/src/wrf_hydro_config
+++ b/src/wrf_hydro_config
@@ -8,9 +8,9 @@ if($#ARGV ne 1) {
          $x = lc(shift(@ARGV));
          $paropt = lc(shift(@ARGV));
 
-         print("Configure option for Hydro : $x  $paropt \n");  
+         print("Configure option for Hydro : $x  $paropt \n");
           if($x =~ "pgi") {
-              if($paropt eq 'serial') { 
+              if($paropt eq 'serial') {
                  # system("./configure 1");
                  print "Error : option not defined in WRF-Hyro. \n";
                  exit(1);
@@ -24,15 +24,15 @@ if($#ARGV ne 1) {
               else {system("./configure 4");}
           }
           if($x =~ "gfortran") {
-              if($paropt eq 'serial') { 
+              if($paropt eq 'serial') {
                  # system("./configure 5");
                  print "Error : option not defined in WRF-Hyro. \n";
                  exit(1);
               }
               else {system("./configure 2"); exit(0);}
           }
-          if($x =~ "ifort") {
-              if($paropt eq 'serial') { 
+          if ($x =~ /(?:ifort|ifx|intel|oneapi)/i) {
+              if($paropt eq 'serial') {
                    #system("./configure 7");
                  print "Error : option not defined. \n";
                  exit(1);
@@ -41,4 +41,3 @@ if($#ARGV ne 1) {
           }
                  print "Error : option not defined. \n";
                  exit(1);
-


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: old configure, new Intel compilers

SOURCE: Soren Rasmussen, Will Hatheway

DESCRIPTION OF CHANGES: Added `ifx, oneapi` string matching to old configure to work with the new Intel compilers

ISSUE: #858

TESTS CONDUCTED: Need to test with coupled case, there were some issues but seem unrelated to these changes