### PR TITLE
feature: adding nudging to CI and Croton test options

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        configuration: [nwm_ana, nwm_long_range, gridded, reach, reach_lakes]
+        configuration: [nwm_ana, nwm_long_range, nwm_nudging, gridded, reach, reach_lakes]
     runs-on: ubuntu-latest
 
     env:
@@ -94,15 +94,19 @@ jobs:
           python3 -m pip install matplotlib numpy xarray dask netCDF4 pygithub
 
       - name: Compile reference
+        env:
+          CMAKE_FLAGS: ${{ matrix.configuration == 'nwm_nudging' && '-DWRF_HYDRO_NUDGING=1' || '' }}
         run: |
           cd $GITHUB_WORKSPACE/reference
-          cmake -B build
+          cmake -B build ${CMAKE_FLAGS}
           make -C build -j
 
       - name: Compile candidate
+        env:
+          CMAKE_FLAGS: ${{ matrix.configuration == 'nwm_nudging' && '-DWRF_HYDRO_NUDGING=1' || '' }}
         run: |
           cd $GITHUB_WORKSPACE/candidate
-          cmake -B build
+          cmake -B build ${CMAKE_FLAGS}
           make -C build -j
 
       - name: Run reference model

--- a/tests/ctests/CMakeLists.txt
+++ b/tests/ctests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # add Makefile targets to setup test runs
 # Croton Test Options: {Gridded, Gridded_no_lakes, NWM, Reach, ReachLakes}
 set(croton_testcases "gridded" "gridded_no_lakes" "nwm" "nwm_ana"
-  "nwm_long_range" "reach" "reach_lakes")
+  "nwm_long_range" "nwm_nudging" "reach" "reach_lakes")
 
 # set default croton setup and run target
 set(croton_default_testcase "gridded")

--- a/tests/ctests/run_cmake_testcase.sh
+++ b/tests/ctests/run_cmake_testcase.sh
@@ -18,7 +18,9 @@ fi
 
 # run testcase
 cd $run_dir
+set -e -x
 ${run_cmd}
+set +e +x
 
 # collect output, and fail silently if files not outputted at this point
 mkdir -p ${output_dir}

--- a/tests/ctests/run_dir_makefile.mk
+++ b/tests/ctests/run_dir_makefile.mk
@@ -19,6 +19,8 @@ croton-nwm:
 	make -C .. $@
 croton-nwm_ana:
 	make -C .. $@
+croton-nwm_nudging:
+	make -C .. $@
 croton-nwm_long_range:
 	make -C .. $@
 croton-reach:
@@ -36,6 +38,8 @@ run-croton-nwm:
 	make -C .. $@
 run-croton-nwm_ana:
 	make -C .. $@
+run-croton-nwm_nudging:
+	make -C .. $@
 run-croton-nwm_long_range:
 	make -C .. $@
 run-croton-reach:
@@ -43,6 +47,8 @@ run-croton-reach:
 run-croton-reach_lakes:
 	make -C .. $@
 # run in parallel
+run-croton-parallel:
+	make -C .. $@
 run-croton-gridded-parallel:
 	make -C .. $@
 run-croton-gridded-no-lakes-parallel:
@@ -50,6 +56,8 @@ run-croton-gridded-no-lakes-parallel:
 run-croton-nwm-parallel:
 	make -C .. $@
 run-croton-nwm_ana-parallel:
+	make -C .. $@
+run-croton-nwm_nudging-parallel:
 	make -C .. $@
 run-croton-nwm_long_range-parallel:
 	make -C .. $@
@@ -64,3 +72,4 @@ clean:
 	rm -f *.RTOUT_DOMAIN1 RESTART.*_DOMAIN1 HYDRO_RST.*_DOMAIN1
 	rm -f *.CHRTOUT_GRID1
 	rm -f diag_hydro.*
+	rm -rf output_nwm_nudging/ nudgingLastObs.*

--- a/tests/ctests/setup_cmake_testcase.sh
+++ b/tests/ctests/setup_cmake_testcase.sh
@@ -16,7 +16,7 @@ case ${1} in
     nwm_ana)
         testcase_dir="NWM"
         ;;
-    nwm_ana)
+    nwm_nudging)
         testcase_dir="NWM"
         ;;
     nwm_long_range)
@@ -72,6 +72,9 @@ sed -i 's/^\( *RTOUT_DOMAIN *= *\).*$/\11/' hydro.namelist
 # if NWM test fix for ana and long_range runs
 case ${1} in
     nwm_ana)
+        sed -i 's/^\( *RUNOFF_OPTION *= *\).*$/\17/I' namelist.hrldas
+        ;;
+    nwm_nudging)
         sed -i 's/^\( *RUNOFF_OPTION *= *\).*$/\17/I' namelist.hrldas
         ;;
     nwm_longrange)


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: CI, Nudging, Croton

SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES:
 - Adding nudging to the Croton testcase options and github actions
 - This is in conjunction with the updates to the Croton tarball of [WRF-Hydro v5.4.0](https://github.com/NCAR/wrf_hydro_nwm_public/releases/tag/v5.4.0)

TESTS CONDUCTED: Manually tested the new options before submitting PR. The CI is failing because the reference `main` branch doesn't have the `run-croton-nwm_nudging` options yet.