### PR TITLE
Speedup of HEAD function used in gridded routing

### DIFF
--- a/src/Routing/module_channel_routing.F90
+++ b/src/Routing/module_channel_routing.F90
@@ -1334,12 +1334,12 @@ end subroutine drive_CHANNEL
 !=======find flow depth in channel with quadratic formula
     REAL FUNCTION HEAD(idx,AREA,Bw,z)
     ! Find the height of water in a channel (head) based on wetted area.
-    ! Channel shape is trapzeoidal. The zero of Af(h)-AREA=0 is
+    ! Channel shape is trapezoidal. The zero of Af(h)-AREA=0 is
     ! analytically solvable as Af(h) = z*h^2 + Bw*h, resulting in a quadratic
     ! equation of h, with A=z, B=Bw, and C=-AREA. Area is always positive, so C
     ! is always negative, and A=z is always positive, giving a real answer for both roots.
     ! Further, h is non-negative so only the addition root is needed,
-    ! d^2 = sqrt(Bw^2 + 4*z*AREA)>0 -> (-Bw - d^2)/z < 0.
+    ! d^1/2 = sqrt(Bw^2 + 4*z*AREA)>0 -> (-Bw - d^1/2)/z < 0.
      REAL :: Bw,z,AREA
      INTEGER :: idx
 


### PR DESCRIPTION
TYPE: Enhancement (speedup)

KEYWORDS: performance, gridded routing, profiling

SOURCE: Max Cooper, Aperture Space

DESCRIPTION OF CHANGES: Profiling of a gridded case showed 20% of time spent in the HEAD function. This function solves for water height in a trapezoidal channel by finding a height where fA(h)-AREA = 0. The existing implementation used root finding to determine h. However fA(h) = z*h^2 + Bw*h, giving a quadratic equation of h with A = z = 1/ChSSlp, B = Bw, and C=-AREA. As AREA is always positive, C is always negative, along with z, resulting in two real roots. As h,z is positive, only the + root is needed as sqrt(Bw^2 + 4*AREA*z) is always positive, resulting in (-Bw-sqrt(Bw^2 + 4*AREA*z))/z being negative.

The function HEAD in module_channel_routing.F90 was changed to be solved analytically, and the AREAf function removed. Comparison of Croton-gridded example case gives near equivalent output when compared before and after modification. Values that are different are in CHRTOUT_DOMAIN1, CHRTOUT_GRID1, CHANOBS_DOMAIN1, and LAKEOUT_DOMAIN1 files. Difference occurs for single indices within the file, typically the first index, and agree to >=4 decimals. The analytical result will be more accurate due to the convergence tolerance in the root finding algorithm.

Profiling 24 hr run of Croton showed being in this function ~14%  before modification, to effectively 0% after.

ISSUE:

TESTS CONDUCTED: Compared output pre/post modification on Croton gridded example with nccmp.