### PR TITLE
hotfix: bump github action versions

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -31,14 +31,14 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Checkout candidate (pull request / push)
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: candidate
 
@@ -50,14 +50,14 @@ jobs:
 
       - name: Checkout reference (pull request)
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           path: reference
 
       - name: Checkout reference (push)
         if: ${{ github.event_name == 'push' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.before }}
           path: reference
@@ -209,7 +209,7 @@ jobs:
 
       - name: generic - Archive test results to GitHub
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports
           path: |
@@ -319,7 +319,7 @@ jobs:
 
       - name: n-cores - Archive test results to GitHub
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports
           path: |
@@ -432,7 +432,7 @@ jobs:
 
       - name: restart - Archive test results to GitHub
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports
           path: |


### PR DESCRIPTION
TYPE: hotfix

KEYWORDS: regression tests, github actions

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: 
 - Bump github action versions, some are deprecated and failing because they use node.js 20

ISSUE:  Actions starting to fail with this message

```
 Model_Testing (gridded)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20
 and may not work as expected: actions/checkout@v4, actions/setup-python@v5,
 actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by
 default starting June 2nd, 2026. Node.js 20 will be removed from the runner on
 September 16th, 2026. Please check if updated versions of these actions are
 available that support Node.js 24. To opt into Node.js 24 now, set the
 FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the
 runner or in your workflow file. Once Node.js 24 becomes the default, you can
 temporarily opt out by setting
 ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information
 see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

TESTS CONDUCTED: this PR should pass the RTs
