### PR TITLE
docs: add accessibility statement

### DIFF
--- a/docs/userguide/_templates/footer.html
+++ b/docs/userguide/_templates/footer.html
@@ -1,0 +1,8 @@
+{% extends "!footer.html" %}
+
+{% block extrafooter %}
+  {{ super() }}
+  <div>
+    <a href="https://www.ucar.edu/web-accessibility">Web Accessibility</a>
+  </div>
+{% endblock %}

--- a/docs/userguide/conf.py
+++ b/docs/userguide/conf.py
@@ -1,6 +1,6 @@
 project = 'WRF-Hydro Modeling System'
 author = 'WRF-Hydro Team'
-copyright = '2024, '+author
+copyright = '2026, '+author
 version = 'v5.4.0'
 release = '5.4.0'
 try:
@@ -11,7 +11,7 @@ try:
     # html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     html_theme = 'sphinx_rtd_theme'
     html_theme_options = {
-        'navigation_depth': -1
+        'navigation_depth': -1,
     }
 except:
     print("Warning: sphinx_rtd_theme not installed, using default theme")
@@ -24,7 +24,7 @@ numfig_secnum_depth = 2
 numfig = 0
 smartquotes = 0
 source_suffix = '.rest'
-templates_path = []
+templates_path = ["_templates"]
 language = 'en'
 highlight_language = "none"
 default_role = 'math'


### PR DESCRIPTION
TYPE: docs

KEYWORDS: readthedocs, accessibility

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: Adding accessibility statement per Sundog's [Mandate: Accessibility Statement link in all Website/App Footers](https://sundog.ucar.edu/page/8295) page

TESTS CONDUCTED: built and viewed docs locally. The following is displayed at the bottom of every page
<img width="350"  alt="image" src="https://github.com/user-attachments/assets/6fbd3e46-dd8a-41eb-aa3a-2c68b1c58359" />
