### PR TITLE
bug fix: out of bounds array indexing error 

### DIFF
--- a/src/Routing/module_NWM_io.F90
+++ b/src/Routing/module_NWM_io.F90
@@ -3365,7 +3365,7 @@ subroutine output_chrtout_grd_NWM(domainId,iGrid)
       do iTmp2=1,fileMeta%nCrsCharAtts
          if(trim(fileMeta%crsCharAttNames(iTmp2)) .eq. 'esri_pe_string') then
             iret = nf90_put_att(ftn,indexVarId,trim(fileMeta%crsCharAttNames(iTmp2)),trim(fileMeta%crsCharAttVals(iTmp2)))
-            call nwmCheck(diagFlag,iret,'ERROR: Unable to place esri_pe_string attribute into '//trim(fileMeta%varNames(iTmp)))
+            call nwmCheck(diagFlag,iret,'ERROR: Unable to place esri_pe_string attribute into index variable')
          endif
       end do
       ! Define compression for meta-variables only if io_form_outputs is set to 1.


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: array bounds, indexing error, debugging

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: 
 - fixing out of bounds array indexing error
   - seems to be a copy-and-paste coding error. The variable `index` is the one being worked on, not `trim(fileMeta%varNames(iTmp))` whose `iTmp` indexing variable isn't even being set in that do loop
 - compiled with flags `-O0 -g -fbacktrace -fcheck=bounds -fsanitize=address -fno-omit-frame-pointer`
 - before fixing the bug, running led to the following error (note I slightly modified the following message for clarity)
```
$ mpiexec -np 4 ./wrf_hydro
...
 Opening
At line 3368 of file src/Routing/module_NWM_io.F90
Fortran runtime error: Index '9' of dimension 1 of array 'filemeta%varnames' above upper bound of 1

Error termination. Backtrace:
#0  0x2e8e749 in __module_nwm_io_MOD_output_chrtout_grd_nwm
        at src/Routing/module_NWM_io.F90:3368
#1  0x2c98bb0 in __module_hydro_drv_MOD_hydro_out
        at src/HYDRO_drv/module_HYDRO_drv.F90:422
#2  0x2c49001 in __module_hydro_drv_MOD_hydro_ini
        at src/HYDRO_drv/module_HYDRO_drv.F90:1622
...
```