### PR TITLE
fix: reach lakes ci improvement

### DIFF
--- a/src/Routing/module_RT.F90
+++ b/src/Routing/module_RT.F90
@@ -213,7 +213,8 @@ CONTAINS
      !!rt_domain(did)%overland%streams_and_lakes%surface_water_to_lake= 0.0                                               ! moved to overland%streams_and_lakes
      allocate( rt_domain(did)%LAKE_INFLORT_TS(IXRT,JXRT) )
      allocate( rt_domain(did)%LAKE_INFLORT_DUM(IXRT,JXRT) )
-     rt_domain(did)%LAKE_INFLORT_DUM= 0.0
+     rt_domain(did)%LAKE_INFLORT_TS = 0.0
+     rt_domain(did)%LAKE_INFLORT_DUM = 0.0
      allocate( rt_domain(did)%LATVAL (ixrt,jxrt) )
      allocate( rt_domain(did)%LONVAL (ixrt,jxrt) )
      rt_domain(did)%LONVAL = 0.0

--- a/tests/local/utils/generate_diff_plots.py
+++ b/tests/local/utils/generate_diff_plots.py
@@ -255,7 +255,7 @@ def get_datasets(base_path, comp_path, filepattern, useDask=True):
 
             # merge files along the time axis
             try:
-                ds = xr.merge(a)
+                ds = xr.concat(a, dim=TIME, coords="minimal", compat="no_conflicts")
             except:
                 ds = None
 
@@ -601,4 +601,3 @@ if __name__ == "__main__":
     if run():
         exit(0)
     exit(-1)
-


### PR DESCRIPTION
TYPE: fix

KEYWORDS: ci, reach lakes

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: 
 - Initialize `LAKE_INFLORT_TS` to zero
 - Change to `generate_diff_plots.py` because default behavior of merge is changing

TESTS CONDUCTED: CI should pass other than `reach lakes`. This is a fix so one would expect the new answers to be different than the old ones.