### PR TITLE
bugfix: reach channel and high process count

### DIFF
--- a/src/Routing/module_NWM_io.F90
+++ b/src/Routing/module_NWM_io.F90
@@ -314,13 +314,17 @@ subroutine output_chrt_NWM(domainId)
       ! to missing as this causes the model to crash.
       allocate(strFlowLocal(RT_DOMAIN(domainId)%NLINKS))
       allocate(velocityLocal(RT_DOMAIN(domainId)%NLINKS))
-      strFlowLocal = RT_DOMAIN(domainId)%QLINK(:,1)
-      velocityLocal = RT_DOMAIN(domainId)%velocity
+      if (RT_DOMAIN(domainId)%NLINKS > 0) then
+         strFlowLocal = RT_DOMAIN(domainId)%QLINK(:,1)
+         velocityLocal = RT_DOMAIN(domainId)%velocity
+      endif
       ! TML: Add qloss allocation and compute variable, only for channel
       ! option #2, where qloss is active (muskingum-cunge).
       if(nlst(domainId)%channel_option == 2 .and. nlst(domainId)%channel_loss_option > 0) then
          allocate(qlossLocal(RT_DOMAIN(domainId)%NLINKS))
-         qlossLocal = RT_DOMAIN(domainId)%qloss !TML temp fix to test code
+         if (RT_DOMAIN(domainId)%NLINKS > 0) then
+            qlossLocal = RT_DOMAIN(domainId)%qloss !TML temp fix to test code
+         endif
       endif
 
       ! Loop through all the local links on this processor. For lake_type


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: reach routing, domain decomposition

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: 
- bugfix: if a core in a reach based run as 0 nlinks, defining certain variables might make it crash

ISSUE: #865

TESTS CONDUCTED: Croton reach testcase runs with `np=96`. Before the fix it was producing the following error

```
...
#1  0x58a471 in __module_nwm_io_MOD_output_chrt_nwm
        at src/Routing/module_NWM_io.F90:318
#2  0x5d186d in __module_hydro_drv_MOD_hydro_out
        at src/HYDRO_drv/module_HYDRO_drv.F90:346
#3  0x5cf43e in __module_hydro_drv_MOD_hydro_exe
        at src/HYDRO_drv/module_HYDRO_drv.F90:737
...
```
