### PR TITLE
Fix CMake / LTO incompatibility and some NUOPC cap tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.24)
 cmake_policy(SET CMP0074 NEW) # use xxxx_ROOT env vars
 if (NOT CMAKE_BUILD_TYPE)
         set(CMAKE_BUILD_TYPE "Release")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set (National_Water_Model_VERSION_PATCH beta)
 
 # set cmake to work with MPI Fortran
 find_package(MPI REQUIRED)
-add_compile_options(${MPI_Fortran_COMPILE_FLAGS})
+add_compile_options(${MPI_Fortran_COMPILE_OPTIONS})
 include_directories(${MPI_Fortran_INCLUDE_PATH})
 link_directories(${MPI_Fortran_LIBRARIES})
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,23 +108,26 @@ if (HYDRO_LSM MATCHES "NoahMP")
 
         target_include_directories(wrfhydro BEFORE PUBLIC ${PROJECT_BINARY_DIR}/mods)
 
+        # WRF-Hydro's internal static libraries reach each other through
+        # several independent PUBLIC/PRIVATE target_link_libraries paths
+        # (e.g. hydro_driver, hydro_noahmp_cpl, and noahmp_util/noahmp_data
+        # all separately depend on hydro_mpp/hydro_routing/hydro_orchestrator).
+        # CMake's link-line generator resolves this kind of diamond dependency
+        # by repeating a static archive later in the command line wherever a
+        # later target still needs it. That repetition is harmless for
+        # classic linking, but GCC's LTO linker plugin claims each occurrence
+        # of a repeated archive as its own "prevailing" definition and fatally
+        # errors with "multiple prevailing defs" once the same archive
+        # appears twice.
+        #
+        # $<LINK_GROUP:RESCAN,...> (CMake >= 3.24) wraps the whole internal
+        # closure in a linker group (-Wl,--start-group/--end-group for
+        # GNU-like linkers) and tells CMake's link-line generator to treat it
+        # as a single already-resolved unit instead of duplicating members:
+        # ld itself re-scans the group as many times as needed to resolve
+        # cross-references, so every archive needs to be listed only once.
         target_link_libraries(wrfhydro
-                hydro_utils
-                hydro_mpp
-                hydro_debug_utils
-                hydro_routing_overland
-                hydro_routing_subsurface
-                hydro_data_rec
-                hydro_routing
-                hydro_routing_reservoirs_levelpool
-                hydro_routing_reservoirs_hybrid
-                hydro_routing_reservoirs_rfc
-                hydro_routing_reservoirs
-                hydro_driver
-                noahmp_util
-                noahmp_phys
-                noahmp_data
-                hydro_noahmp_cpl
+                "$<LINK_GROUP:RESCAN,hydro_utils,hydro_mpp,hydro_debug_utils,hydro_driver,hydro_noahmp_cpl,hydro_routing,hydro_routing_overland,hydro_routing_subsurface,hydro_routing_reservoirs,hydro_routing_reservoirs_levelpool,hydro_routing_reservoirs_hybrid,hydro_routing_reservoirs_rfc,hydro_routing_diversions,hydro_orchestrator,hydro_netcdf_layer,hydro_data_rec,noahmp_util,noahmp_phys,noahmp_data,snowcro,crocus_surfex>"
                 ${NETCDF_LIBRARIES}
                 # hydro_routing_groundwater
                 # hydro_routing_groundwater_bucket


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: CMake, LTO, NUOPC

SOURCE: NCAR

DESCRIPTION OF CHANGES: 

* changes to CMakeLists to support LTO (link-time optimization) for compilers/MPIs that default to it
* update CMakeLists with modern `${MPI_Fortran_COMPILE_OPTIONS})` (vs `_COMPILE_FLAGS`)
* pad out ESMF strings to full width in NUOPC cap
* add integer string widths to `read()` string parsing
 