### PR TITLE
Fix gcc compiler errors in NUOPC cap

### DIFF
--- a/src/CPL/NUOPC_cpl/WRFHydro_NUOPC_Cap.F90
+++ b/src/CPL/NUOPC_cpl/WRFHydro_NUOPC_Cap.F90
@@ -364,23 +364,8 @@ module WRFHydro_NUOPC
     rc = ESMF_SUCCESS
 
     ! Query component for name, verbosity, and diagnostic values
-!    call NUOPC_CompGet(gcomp, name=name, verbosity=verbosity, &
-!      diagnostic=diagnostic, rc=rc)
-    call ESMF_GridCompGet(gcomp, name=cname, rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Diagnostic", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+    call NUOPC_CompGet(gcomp, name=cname, verbosity=verbosity, &
+      diagnostic=diagnostic, rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query Component for its internal State
@@ -775,23 +760,8 @@ module WRFHydro_NUOPC
     rc = ESMF_SUCCESS
 
     ! Query component for name, verbosity, and diagnostic values
-!    call NUOPC_CompGet(gcomp, name=name, verbosity=verbosity, &
-!      diagnostic=diagnostic, rc=rc)
-    call ESMF_GridCompGet(gcomp, name=cname, rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Diagnostic", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+    call NUOPC_CompGet(gcomp, name=cname, verbosity=verbosity, &
+      diagnostic=diagnostic, rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query Component for its internal State
@@ -867,23 +837,8 @@ module WRFHydro_NUOPC
     rc = ESMF_SUCCESS
 
     ! Query component for name, verbosity, and diagnostic values
-!    call NUOPC_CompGet(gcomp, name=name, verbosity=verbosity, &
-!      diagnostic=diagnostic, rc=rc)
-    call ESMF_GridCompGet(gcomp, name=cname, rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Diagnostic", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+    call NUOPC_CompGet(gcomp, name=cname, verbosity=verbosity, &
+      diagnostic=diagnostic, rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query Component for its internal State
@@ -977,23 +932,8 @@ module WRFHydro_NUOPC
     rc = ESMF_SUCCESS
 
     ! Query component for name, verbosity, and diagnostic values
-!    call NUOPC_CompGet(gcomp, name=name, verbosity=verbosity, &
-!      diagnostic=diagnostic, rc=rc)
-    call ESMF_GridCompGet(gcomp, name=cname, rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Diagnostic", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+    call NUOPC_CompGet(gcomp, name=cname, verbosity=verbosity, &
+      diagnostic=diagnostic, rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query Component for its internal State
@@ -1178,23 +1118,8 @@ module WRFHydro_NUOPC
     rc = ESMF_SUCCESS
 
     ! Query component for name, verbosity, and diagnostic values
-!    call NUOPC_CompGet(gcomp, name=name, verbosity=verbosity, &
-!      diagnostic=diagnostic, rc=rc)
-    call ESMF_GridCompGet(gcomp, name=cname, rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Diagnostic", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+    call NUOPC_CompGet(gcomp, name=cname, verbosity=verbosity, &
+      diagnostic=diagnostic, rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query Component for its internal State
@@ -1297,23 +1222,8 @@ subroutine CheckImport(gcomp, rc)
     rc = ESMF_SUCCESS
 
     ! Query component for name, verbosity, and diagnostic values
-!    call NUOPC_CompGet(gcomp, name=name, verbosity=verbosity, &
-!      diagnostic=diagnostic, rc=rc)
-    call ESMF_GridCompGet(gcomp, name=cname, rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Diagnostic", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+    call NUOPC_CompGet(gcomp, name=cname, verbosity=verbosity, &
+      diagnostic=diagnostic, rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query Component for its internal State
@@ -1365,23 +1275,8 @@ subroutine CheckImport(gcomp, rc)
     rc = ESMF_SUCCESS
 
     ! Query component for name, verbosity, and diagnostic values
-!    call NUOPC_CompGet(gcomp, name=name, verbosity=verbosity, &
-!      diagnostic=diagnostic, rc=rc)
-    call ESMF_GridCompGet(gcomp, name=cname, rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Diagnostic", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+    call NUOPC_CompGet(gcomp, name=cname, verbosity=verbosity, &
+      diagnostic=diagnostic, rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query component for its internal State
@@ -1570,23 +1465,8 @@ subroutine CheckImport(gcomp, rc)
     rc = ESMF_SUCCESS
 
     ! Query component for name, verbosity, and diagnostic values
-!    call NUOPC_CompGet(gcomp, name=name, verbosity=verbosity, &
-!      diagnostic=diagnostic, rc=rc)
-    call ESMF_GridCompGet(gcomp, name=cname, rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Diagnostic", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    diagnostic = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    call ESMF_AttributeGet(gcomp, name="Verbosity", value=value, &
-      defaultValue="0", convention="NUOPC", purpose="Instance", rc=rc)
-    if (ESMF_STDERRORCHECK(rc)) return  ! bail out
-    verbosity = ESMF_UtilString2Int(value, &
-      specialStringList=(/"min","max","bit16","maxplus"/), &
-      specialValueList=(/0,65535,65536,131071/), rc=rc)
+    call NUOPC_CompGet(gcomp, name=cname, verbosity=verbosity, &
+      diagnostic=diagnostic, rc=rc)
     if (ESMF_STDERRORCHECK(rc)) return  ! bail out
 
     ! query Component for its internal State

--- a/src/CPL/NUOPC_cpl/WRFHydro_NUOPC_Gluecode.F90
+++ b/src/CPL/NUOPC_cpl/WRFHydro_NUOPC_Gluecode.F90
@@ -147,11 +147,11 @@ contains
     call orchestrator%init()
 
     ! Set default namelist values
-    read (startTimeStr(1:4),"(I)")   nlst(did)%START_YEAR
-    read (startTimeStr(6:7),"(I)")   nlst(did)%START_MONTH
-    read (startTimeStr(9:10),"(I)")  nlst(did)%START_DAY
-    read (startTimeStr(12:13),"(I)") nlst(did)%START_HOUR
-    read (startTimeStr(15:16),"(I)") nlst(did)%START_MIN
+    read (startTimeStr(1:4),"(I4)")   nlst(did)%START_YEAR
+    read (startTimeStr(6:7),"(I2)")   nlst(did)%START_MONTH
+    read (startTimeStr(9:10),"(I2)")  nlst(did)%START_DAY
+    read (startTimeStr(12:13),"(I2)") nlst(did)%START_HOUR
+    read (startTimeStr(15:16),"(I2)") nlst(did)%START_MIN
     nlst(did)%startdate(1:19) = startTimeStr(1:19)
     nlst(did)%olddate(1:19)   = startTimeStr(1:19)
     nlst(did)%dt = dt
@@ -293,11 +293,11 @@ contains
 #endif
 
     ! Override the clock configuration in hyro.namelist
-    read (startTimeStr(1:4),"(I)")   nlst(did)%START_YEAR
-    read (startTimeStr(6:7),"(I)")   nlst(did)%START_MONTH
-    read (startTimeStr(9:10),"(I)")  nlst(did)%START_DAY
-    read (startTimeStr(12:13),"(I)") nlst(did)%START_HOUR
-    read (startTimeStr(15:16),"(I)") nlst(did)%START_MIN
+    read (startTimeStr(1:4),"(I4)")   nlst(did)%START_YEAR
+    read (startTimeStr(6:7),"(I2)")   nlst(did)%START_MONTH
+    read (startTimeStr(9:10),"(I2)")  nlst(did)%START_DAY
+    read (startTimeStr(12:13),"(I2)") nlst(did)%START_HOUR
+    read (startTimeStr(15:16),"(I2)") nlst(did)%START_MIN
     nlst(did)%startdate(1:19) = startTimeStr(1:19)
     nlst(did)%olddate(1:19)   = startTimeStr(1:19)
     nlst(did)%dt = dt


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: nuopc, gcc

SOURCE: Daniel Rosen - NCAR ESMF

DESCRIPTION OF CHANGES:

Fix the NUOPC cap code to support gnu compilers.
- string list must be the exact same length
- integer format specifier `(Iw)` must include width (e.g. `(I0)` or `(I4)`)

NOTES: NUOPC_CompGet changes have been supported since ESMF v8.0.0 (Oct 12, 2020). This change will not be backwards compatible with ESMF versions prior to 8.0.0.

ISSUE: (issue not opened)

TESTS CONDUCTED: Tested using NASA Land Coupler within a ubuntu container with gcc@13 and mpich@5

